### PR TITLE
Optimize mk_lib_common ffmpeg probe helper

### DIFF
--- a/src/mk_lib_common/src/mk_lib_common_ffmpeg.rs
+++ b/src/mk_lib_common/src/mk_lib_common_ffmpeg.rs
@@ -1,4 +1,6 @@
-use std::process::{Command, Stdio};
+use std::io::{Error, ErrorKind};
+use std::process::Stdio;
+use tokio::process::Command;
 
 pub async fn mk_common_ffmpeg_get_info(
     media_file: &str,
@@ -15,8 +17,17 @@ pub async fn mk_common_ffmpeg_get_info(
         ])
         .stdout(Stdio::piped())
         .output()
-        .unwrap();
-    let stdout: String = String::from_utf8(output.stdout).unwrap();
-    let json_output: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    Ok(json_output)
+        .await?;
+
+    if !output.status.success() {
+        return Err(Error::new(
+            ErrorKind::Other,
+            format!(
+                "ffprobe failed for '{media_file}' with status {}",
+                output.status
+            ),
+        ));
+    }
+
+    serde_json::from_slice(&output.stdout).map_err(|err| Error::new(ErrorKind::InvalidData, err))
 }


### PR DESCRIPTION
### Motivation
- Make `mk_common_ffmpeg_get_info` safe and non-blocking in async contexts and remove panics from production paths.

### Description
- Replaced `std::process::Command` with `tokio::process::Command` in `src/mk_lib_common/src/mk_lib_common_ffmpeg.rs` so the helper no longer blocks the Tokio runtime.
- Removed `unwrap()` uses and switched to `?` propagation and explicit `std::io::Error` mapping to avoid panic-prone paths.
- Added a check for non-zero `ffprobe` exit status and return a descriptive `Error` when `ffprobe` fails.
- Parsed ffprobe JSON directly from bytes using `serde_json::from_slice` to avoid an intermediate UTF-8 `String` allocation.

### Testing
- Ran `cargo fmt` in `src/mk_lib_common` and it completed successfully.
- Ran `cargo check` in `src/mk_lib_common` which failed due to a private registry request returning `403 Forbidden` when fetching `config.json` (external registry issue, not code error).
- Ran `cargo clippy -- -D warnings` in `src/mk_lib_common` which also failed for the same private registry `403 Forbidden` reason.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f4ae4b72483219ae64ca19283b29e)