### PR TITLE
Improve error handling and centralize constants in mk_lib_rabbitmq

### DIFF
--- a/src/mk_lib_rabbitmq/src/mk_lib_rabbitmq.rs
+++ b/src/mk_lib_rabbitmq/src/mk_lib_rabbitmq.rs
@@ -1,14 +1,22 @@
 use amqprs::channel::Channel;
 use amqprs::{
+    BasicProperties,
     callbacks::{DefaultChannelCallback, DefaultConnectionCallback},
     channel::{
         BasicAckArguments, BasicConsumeArguments, BasicPublishArguments, ConsumerMessage,
         QueueBindArguments, QueueDeclareArguments,
     },
     connection::{Connection, OpenConnectionArguments},
-    BasicProperties,
 };
 use tokio::sync::mpsc::UnboundedReceiver;
+
+const RABBITMQ_HOST: &str = "mkstack-rabbitmq-production.rabbitmq-system";
+const RABBITMQ_PORT: u16 = 5672;
+const RABBITMQ_USER: &str = "guest";
+const RABBITMQ_PASSWORD: &str = "guest";
+const DEFAULT_EXCHANGE: &str = "amq.direct";
+const CONSUMER_TAG: &str = "mkrabbitconsume";
+const CONTENT_TYPE_JSON: &str = "application/json";
 
 pub async fn rabbitmq_ack(
     rabbit_channel: &Channel,
@@ -16,47 +24,42 @@ pub async fn rabbitmq_ack(
 ) -> Result<(), Box<dyn std::error::Error>> {
     rabbit_channel
         .basic_ack(BasicAckArguments::new(rabbit_msg_id, false))
-        .await
-        .unwrap();
+        .await?;
     Ok(())
 }
 
 pub async fn rabbitmq_connect(
     rabbit_queue: &str,
 ) -> Result<(Connection, Channel), Box<dyn std::error::Error>> {
-    // open a connection to RabbitMQ server
     let rabbit_connection = Connection::open(&OpenConnectionArguments::new(
-        "mkstack-rabbitmq-production.rabbitmq-system",
-        5672,
-        "guest",
-        "guest",
+        RABBITMQ_HOST,
+        RABBITMQ_PORT,
+        RABBITMQ_USER,
+        RABBITMQ_PASSWORD,
     ))
-    .await
-    .unwrap();
+    .await?;
     rabbit_connection
         .register_callback(DefaultConnectionCallback)
-        .await
-        .unwrap();
-    let rabbit_channel = rabbit_connection.open_channel(None).await.unwrap();
+        .await?;
+
+    let rabbit_channel = rabbit_connection.open_channel(None).await?;
     rabbit_channel
         .register_callback(DefaultChannelCallback)
-        .await
-        .unwrap();
+        .await?;
+
     let (queue_name, _, _) = rabbit_channel
         .queue_declare(QueueDeclareArguments::durable_client_named(rabbit_queue))
-        .await
-        .unwrap()
-        .unwrap();
-    let rounting_key = rabbit_queue;
-    let exchange_name = "amq.direct";
+        .await?
+        .ok_or("failed to declare queue")?;
+
     rabbit_channel
         .queue_bind(QueueBindArguments::new(
             &queue_name,
-            exchange_name,
-            rounting_key,
+            DEFAULT_EXCHANGE,
+            rabbit_queue,
         ))
-        .await
-        .unwrap();
+        .await?;
+
     Ok((rabbit_connection, rabbit_channel))
 }
 
@@ -64,10 +67,10 @@ pub async fn rabbitmq_consumer(
     rabbit_queue: &str,
     rabbit_channel: &Channel,
 ) -> Result<UnboundedReceiver<ConsumerMessage>, Box<dyn std::error::Error>> {
-    let rabbit_args = BasicConsumeArguments::new(rabbit_queue, "mkrabbitconsume")
+    let rabbit_args = BasicConsumeArguments::new(rabbit_queue, CONSUMER_TAG)
         .manual_ack(true)
         .finish();
-    let (_ctag, rabbit_rx) = rabbit_channel.basic_consume_rx(rabbit_args).await.unwrap();
+    let (_consumer_tag, rabbit_rx) = rabbit_channel.basic_consume_rx(rabbit_args).await?;
     Ok(rabbit_rx)
 }
 
@@ -76,18 +79,16 @@ pub async fn rabbitmq_publish(
     rabbit_queue: &str,
     rabbit_message: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let args = BasicPublishArguments::new("amq.direct", rabbit_queue);
+    let args = BasicPublishArguments::new(DEFAULT_EXCHANGE, rabbit_queue);
+    let properties = BasicProperties::default()
+        .with_content_type(CONTENT_TYPE_JSON)
+        .with_persistence(true)
+        .finish();
+
     rabbit_channel
-        .basic_publish(
-            BasicProperties::default()
-                .with_content_type("application/json")
-                .with_persistence(true)
-                .finish(),
-            rabbit_message.into_bytes(),
-            args,
-        )
-        .await
-        .unwrap();
+        .basic_publish(properties, rabbit_message.into_bytes(), args)
+        .await?;
+
     Ok(())
 }
 
@@ -95,7 +96,7 @@ pub async fn rabbitmq_close(
     rabbit_channel: Channel,
     rabbit_connection: Connection,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    rabbit_channel.close().await.unwrap();
-    rabbit_connection.close().await.unwrap();
+    rabbit_channel.close().await?;
+    rabbit_connection.close().await?;
     Ok(())
 }


### PR DESCRIPTION
### Motivation

- Prevent runtime panics from `unwrap()`/`expect()` in RabbitMQ hot paths and allow callers to handle failures gracefully. 
- Reduce repeated literals and make connection/publish configuration explicit and easy to adjust. 

### Description

- Replaced panic-prone `unwrap()` chains with `?` propagation across `rabbitmq_ack`, `rabbitmq_connect`, `rabbitmq_consumer`, `rabbitmq_publish`, and `rabbitmq_close` so errors bubble to callers. 
- Introduced module-level constants for host/port/credentials, default exchange, consumer tag, and content type (`RABBITMQ_HOST`, `RABBITMQ_PORT`, `RABBITMQ_USER`, `RABBITMQ_PASSWORD`, `DEFAULT_EXCHANGE`, `CONSUMER_TAG`, `CONTENT_TYPE_JSON`).
- Made queue declaration explicit by mapping the optional return with `.ok_or("failed to declare queue")` and used the constants when binding the queue and creating `BasicPublishArguments`/`BasicConsumeArguments`.
- Prebuilt `BasicProperties` for publishing to avoid repeated construction and clarified local naming for consumer tag and publish args while keeping public function signatures unchanged.

### Testing

- Ran `cargo fmt` in `src/mk_lib_rabbitmq` and it completed successfully. 
- Ran `cargo check` in `src/mk_lib_rabbitmq` but it failed due to the private registry returning HTTP 403 for `config.json`. 
- Ran `cargo clippy -- -D warnings` in `src/mk_lib_rabbitmq` but it failed for the same private registry HTTP 403 issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f53a31f7c8321bbd0db29351d1517)