### PR TITLE
Optimize mk_lib_hash file hashing to stream files in chunks

### DIFF
--- a/src/mk_lib_hash/src/hash_file_reader.rs
+++ b/src/mk_lib_hash/src/hash_file_reader.rs
@@ -1,0 +1,23 @@
+use std::io;
+use tokio::{fs::File, io::AsyncReadExt};
+
+const HASH_BUFFER_SIZE: usize = 64 * 1024;
+
+pub async fn read_file_chunks(
+    file_to_read: &str,
+    mut on_chunk: impl FnMut(&[u8]),
+) -> io::Result<()> {
+    let mut file = File::open(file_to_read).await?;
+    let mut buffer = [0_u8; HASH_BUFFER_SIZE];
+
+    loop {
+        let bytes_read = file.read(&mut buffer).await?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        on_chunk(&buffer[..bytes_read]);
+    }
+
+    Ok(())
+}

--- a/src/mk_lib_hash/src/lib.rs
+++ b/src/mk_lib_hash/src/lib.rs
@@ -5,3 +5,5 @@ pub mod mk_lib_hash_crc32;
 pub mod mk_lib_hash_ed2k;
 pub mod mk_lib_hash_md5;
 pub mod mk_lib_hash_sha1;
+
+mod hash_file_reader;

--- a/src/mk_lib_hash/src/mk_lib_hash_blake3.rs
+++ b/src/mk_lib_hash/src/mk_lib_hash_blake3.rs
@@ -1,15 +1,11 @@
 // https://docs.rs/blake3/1.0.0/blake3/
 
-use blake3;
-use mk_lib_file::mk_lib_file;
+use crate::hash_file_reader::read_file_chunks;
 use std::error::Error;
 
 pub async fn mk_file_hash_blake3(file_to_read: &str) -> Result<String, Box<dyn Error>> {
     let mut hasher = blake3::Hasher::new();
-    let mut file_data = mk_lib_file::mk_read_file_data_u8(&file_to_read)
-        .await
-        .unwrap();
-    hasher.update(&mut file_data);
+    read_file_chunks(file_to_read, |chunk| hasher.update(chunk)).await?;
     let checksum = hasher.finalize();
     Ok(format!("{}", checksum))
 }

--- a/src/mk_lib_hash/src/mk_lib_hash_crc32.rs
+++ b/src/mk_lib_hash/src/mk_lib_hash_crc32.rs
@@ -1,13 +1,10 @@
+use crate::hash_file_reader::read_file_chunks;
 use crc32fast::Hasher;
-use mk_lib_file::mk_lib_file;
 use std::error::Error;
 
 pub async fn mk_file_hash_crc32(file_to_read: &str) -> Result<String, Box<dyn Error>> {
     let mut hasher = Hasher::new();
-    let mut file_data = mk_lib_file::mk_read_file_data_u8(&file_to_read)
-        .await
-        .unwrap();
-    hasher.update(&mut file_data);
+    read_file_chunks(file_to_read, |chunk| hasher.update(chunk)).await?;
     let checksum = hasher.finalize();
     Ok(format!("{:x}", checksum))
 }

--- a/src/mk_lib_hash/src/mk_lib_hash_md5.rs
+++ b/src/mk_lib_hash/src/mk_lib_hash_md5.rs
@@ -1,11 +1,10 @@
+use crate::hash_file_reader::read_file_chunks;
 use md5::{Digest, Md5};
 use std::error::Error;
-use mk_lib_file::mk_lib_file;
 
 pub async fn mk_file_hash_md5(file_to_read: &str) -> Result<String, Box<dyn Error>> {
     let mut hasher = Md5::new();
-    let mut file_data = mk_lib_file::mk_read_file_data_u8(&file_to_read).await.unwrap();
-    hasher.update(&mut file_data);
+    read_file_chunks(file_to_read, |chunk| hasher.update(chunk)).await?;
     let result = hasher.finalize();
     Ok(format!("{:x}", result))
 }
@@ -18,9 +17,7 @@ mod tests {
     async fn test_mk_file_hash_md5() {
         assert_eq!(
             "4efd2e93b6b8525d93c310ef232639eb",
-            mk_file_hash_md5("testing_data/HashCalc.txt")
-                .await
-                .unwrap()
+            mk_file_hash_md5("testing_data/HashCalc.txt").await.unwrap()
         );
     }
 }

--- a/src/mk_lib_hash/src/mk_lib_hash_sha1.rs
+++ b/src/mk_lib_hash/src/mk_lib_hash_sha1.rs
@@ -1,10 +1,10 @@
+use crate::hash_file_reader::read_file_chunks;
 use sha1::{Digest, Sha1};
-use std::{fs, io};
+use std::io;
 
 pub async fn mk_file_hash_sha1(file_to_read: &str) -> io::Result<String> {
-    let mut file = fs::File::open(&file_to_read)?;
     let mut hasher = Sha1::new();
-    let _n = io::copy(&mut file, &mut hasher)?;
+    read_file_chunks(file_to_read, |chunk| hasher.update(chunk)).await?;
     let hash = hasher.finalize();
     Ok(format!("{:x}", hash))
 }


### PR DESCRIPTION
### Motivation

- Reduce memory use and improve performance for hashing large files by streaming file data in fixed-size async chunks instead of loading entire files into memory. 
- Replace ad-hoc file reads that used `unwrap()` with propagated errors to avoid panics in production paths.

### Description

- Add a shared async chunked reader `read_file_chunks` in `src/mk_lib_hash/src/hash_file_reader.rs` that reads files in `64 KiB` chunks and invokes a callback for each chunk. 
- Update `mk_file_hash_blake3`, `mk_file_hash_crc32`, `mk_file_hash_md5`, and `mk_file_hash_sha1` to stream input via `read_file_chunks` and feed chunks into the respective hashers. 
- Remove direct use of `mk_lib_file::mk_read_file_data_u8` and the `std::fs` synchronous read in these hash paths and propagate I/O errors using `?` instead of `unwrap()`. 
- Wire the helper into the crate root by adding `mod hash_file_reader;` to `src/mk_lib_hash/src/lib.rs`.

### Testing

- Ran `cargo fmt` in `src/mk_lib_hash` which completed (with a cargo config deprecation warning). 
- Ran `cargo check` in `src/mk_lib_hash` which failed in this environment due to the private registry returning HTTP 403 when fetching dependencies. 
- Ran `cargo clippy -- -D warnings` which similarly failed due to the private registry HTTP 403; unit tests were not executed here because dependency resolution failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f53691f908321a3c80983da255804)