### PR TITLE
Optimize mk_lib_hardware discovery paths

### DIFF
--- a/src/mk_lib_hardware/src/mk_lib_hardware_main_controller.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_main_controller.rs
@@ -1,21 +1,4 @@
-use crate::mk_lib_hardware_alexa;
-use crate::mk_lib_hardware_ampro;
-use crate::mk_lib_hardware_appletv;
-use crate::mk_lib_hardware_chromecast;
-use crate::mk_lib_hardware_crestron;
-use crate::mk_lib_hardware_firetv;
-use crate::mk_lib_hardware_hdhomerun;
-use crate::mk_lib_hardware_lg;
-use crate::mk_lib_hardware_marantz;
-use crate::mk_lib_hardware_onkyo;
-use crate::mk_lib_hardware_phue;
-use crate::mk_lib_hardware_pioneer;
-use crate::mk_lib_hardware_roku;
-use crate::mk_lib_hardware_samsung;
-use crate::mk_lib_hardware_tivo;
-use crate::mk_lib_hardware_yamaha;
 use serde::{Deserialize, Serialize};
-use serde_json;
 use serde_json::json;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -26,8 +9,12 @@ pub struct DeviceJson {
 }
 //let mut device_json_array: Vec<DeviceJson> = Vec::new();
 
-pub async fn mk_hardware_main_command(machine_brand: String, machine_type: String, 
-    machine_model: String, command_type: String, command_value: String
+pub async fn mk_hardware_main_command(
+    _machine_brand: String,
+    _machine_type: String,
+    _machine_model: String,
+    _command_type: String,
+    _command_value: String,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
     // TODO pull from the web api?
     // TODO loop through the json files and find brand, type, model

--- a/src/mk_lib_hardware/src/mk_lib_hardware_sonos.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_sonos.rs
@@ -5,12 +5,18 @@ use sonos_discovery::Discover;
 use std::net::IpAddr;
 
 pub async fn mk_lib_hardware_sonos_discover() {
-    let discovery: Discover = Discover::new().unwrap();
+    let Ok(discovery) = Discover::new() else {
+        eprintln!("Failed to create Sonos discovery client");
+        return;
+    };
     // fn start(self, timeout: Option<u32>, device_count: Option<usize>)
     // timeout default: 5 | device_count: u32::MAX
     // Checks that {discovered_devices} < {device_count} && {elapsed_time} < {timeout}
     // Waits until 3 devices are found, or 5seconds have elapsed
-    let sonos_ips: Vec<IpAddr> = discovery.start(None, Some(3)).unwrap();
+    let Ok(sonos_ips): Result<Vec<IpAddr>, _> = discovery.start(None, Some(3)) else {
+        eprintln!("Failed to discover Sonos devices");
+        return;
+    };
     for sonos_ip in sonos_ips {
         println!("{}", sonos_ip);
     }

--- a/src/mk_lib_hardware/src/mk_lib_hardware_vizio.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_vizio.rs
@@ -3,8 +3,9 @@
 use smartcast::Device;
 
 pub async fn mk_hardware_vizio_discover() -> Result<(), smartcast::Error> {
-    let ssdp_devices = smartcast::discover_devices().await?;
-    let dev_by_ssdp = ssdp_devices[0].clone();
+    let Some(dev_by_ssdp) = smartcast::discover_devices().await?.into_iter().next() else {
+        return Ok(());
+    };
     let ip_addr = dev_by_ssdp.ip();
     let uuid = dev_by_ssdp.uuid();
     let _dev_by_ip = Device::from_ip(ip_addr).await?;

--- a/src/mk_lib_hardware/src/mk_lib_hardware_wemo.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_wemo.rs
@@ -1,8 +1,8 @@
 // https://github.com/Hyperchaotic/weectrl
 
+use futures::prelude::*;
 use std::time::Duration;
 use weectrl::{DiscoveryMode, WeeController};
-use futures::prelude::*;
 
 pub async fn mk_lib_hardware_wemo_discover() {
     let controller = WeeController::new();
@@ -11,7 +11,7 @@ pub async fn mk_lib_hardware_wemo_discover() {
         DiscoveryMode::CacheAndBroadcast,
         true,
         Duration::from_secs(5),
-    );    
+    );
     while let Some(d) = discovery_future.next().await {
         println!(
             " Found device {}, ID: {}, state: {:?}.",
@@ -23,10 +23,12 @@ pub async fn mk_lib_hardware_wemo_discover() {
             true,
             Duration::from_secs(5),
         );
-        println!(
-            " - Subscribed {} - {:?} seconds to resubscribe.\n",
-            d.friendly_name,
-            res.unwrap()
-        );
+        match res {
+            Ok(subscribe_seconds) => println!(
+                " - Subscribed {} - {:?} seconds to resubscribe.\n",
+                d.friendly_name, subscribe_seconds
+            ),
+            Err(error) => eprintln!(" - Failed to subscribe {} - {error}", d.friendly_name),
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Harden discovery helpers to avoid panics from unchecked `unwrap()`/indexing and improve runtime resilience when devices are not present or discovery fails.
- Reduce compiler warning noise from unused imports/parameters in the main controller stub without changing behavior.
- Make minimal, focused edits that preserve existing interfaces and behavior while improving safety.

### Description

- In `src/mk_lib_hardware/src/mk_lib_hardware_vizio.rs` consume the first discovered device via `into_iter().next()` and early-return when none are found instead of indexing into the vector.
- In `src/mk_lib_hardware/src/mk_lib_hardware_wemo.rs` replace `unwrap()` on the subscription result with a `match` that logs errors and prints the subscription seconds on success, and tidy imports order.
- In `src/mk_lib_hardware/src/mk_lib_hardware_sonos.rs` guard creation of the `Discover` client and the `start` call with `Ok(...)` checks that log and early-return on failure.
- In `src/mk_lib_hardware/src/mk_lib_hardware_main_controller.rs` prefix currently-unused parameters with `_` and remove an unused `use` to eliminate warning noise while keeping the function behavior unchanged.

### Testing

- Ran `cargo fmt` in `src/mk_lib_hardware` which completed successfully.
- Attempted `cargo check` in `src/mk_lib_hardware` but it was blocked by private registry access returning HTTP 403, so full type-checking could not complete in this environment.
- Attempted `cargo clippy -- -D warnings` in `src/mk_lib_hardware` but it was likewise blocked by the same private registry HTTP 403 error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f5359595083219ae7cbcdb6a642f1)