### PR TITLE
Optimize metadata status dispatch in mk_lib_metadata

### DIFF
--- a/src/mk_lib_metadata/src/base.rs
+++ b/src/mk_lib_metadata/src/base.rs
@@ -53,35 +53,31 @@ pub async fn metadata_process(
     provider_api_key: &str,
 ) -> Result<(), Box<dyn Error>> {
     // TODO art, posters, trailers, etc in here as well
-    if download_data.mm_download_status == "Search" {
-        metadata_search(&sqlx_pool, provider_name, download_data, provider_api_key)
-            .await
-            .unwrap();
-    } else if download_data.mm_download_status == "Update" {
-        metadata_update(&sqlx_pool, provider_name, download_data, provider_api_key)
-            .await
-            .unwrap();
-    } else if download_data.mm_download_status == "Fetch" {
-        metadata_fetch(&sqlx_pool, provider_name, download_data, provider_api_key)
-            .await
-            .unwrap();
-    } else if download_data.mm_download_status == "FetchCastCrew" {
-        metadata_castcrew(&sqlx_pool, provider_name, download_data, provider_api_key)
-            .await
-            .unwrap();
-    } else if download_data.mm_download_status == "FetchReview" {
-        metadata_review(&sqlx_pool, provider_name, download_data, provider_api_key)
-            .await
-            .unwrap();
-    } else if download_data.mm_download_status == "FetchImage" {
-        metadata_image(&sqlx_pool, provider_name, download_data, provider_api_key)
-            .await
-            .unwrap();
-    } else if download_data.mm_download_status == "FetchCollection" {
-        metadata_collection(&sqlx_pool, provider_name, download_data, provider_api_key)
-            .await
-            .unwrap();
+    match download_data.mm_download_status.as_str() {
+        "Search" => {
+            metadata_search(sqlx_pool, provider_name, download_data, provider_api_key).await?
+        }
+        "Update" => {
+            metadata_update(sqlx_pool, provider_name, download_data, provider_api_key).await?
+        }
+        "Fetch" => {
+            metadata_fetch(sqlx_pool, provider_name, download_data, provider_api_key).await?
+        }
+        "FetchCastCrew" => {
+            metadata_castcrew(sqlx_pool, provider_name, download_data, provider_api_key).await?
+        }
+        "FetchReview" => {
+            metadata_review(sqlx_pool, provider_name, download_data, provider_api_key).await?
+        }
+        "FetchImage" => {
+            metadata_image(sqlx_pool, provider_name, download_data, provider_api_key).await?
+        }
+        "FetchCollection" => {
+            metadata_collection(sqlx_pool, provider_name, download_data, provider_api_key).await?
+        }
+        _ => {}
     }
+
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- Reduce repeated string comparisons and improve clarity in the `metadata_process` dispatcher.
- Prevent panics from `.unwrap()` in the dispatcher by propagating errors through the existing `Result` path.

### Description

- Replace the long `if/else` chain in `metadata_process` with a `match` on `download_data.mm_download_status.as_str()` and invoke the appropriate handler for each status.
- Replace the per-call `.await.unwrap()` calls in the dispatcher with `await?` so handler failures are returned instead of causing a panic, and keep unknown statuses as a no-op.

### Testing

- Ran `rustfmt --edition 2021 src/mk_lib_metadata/src/base.rs`, which succeeded.
- Ran `cargo check --manifest-path src/mk_lib_metadata/Cargo.toml` and `cargo clippy --manifest-path src/mk_lib_metadata/Cargo.toml -- -D warnings`, both of which failed in this environment due to a missing registry configuration (`kellnr`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f538b54848321990781b5a37c4a96)