### PR TITLE
Optimize mkrabbitconsume message parsing and ack handling

### DIFF
--- a/docker/core/mkrabbitconsume/src/main.rs
+++ b/docker/core/mkrabbitconsume/src/main.rs
@@ -1,19 +1,19 @@
 use mk_lib_database;
-use mk_lib_network;
 use mk_lib_rabbitmq;
-use serde_json::{json, Value};
+use serde_json::Value;
 use std::error::Error;
 use tokio::sync::Notify;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // connect to db and do a version check
-    let (sqlx_pool_rw, sqlx_pool_ro) = mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120)
-        .await
-        .unwrap();
+    let (_sqlx_pool_rw, sqlx_pool_ro) =
+        mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120)
+            .await
+            .unwrap();
     mk_lib_database::mk_lib_database_version::mk_lib_database_version_check(&sqlx_pool_ro, false)
         .await;
-    let option_config_json =
+    let _option_config_json =
         &mk_lib_database::mk_lib_database_option_status::mk_lib_database_option_read(&sqlx_pool_ro)
             .await?;
 
@@ -31,8 +31,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     tokio::spawn(async move {
         while let Some(msg) = rabbit_consumer.recv().await {
             if let Some(payload) = msg.content {
-                let json_message: Value =
-                    serde_json::from_str(&String::from_utf8_lossy(&payload)).unwrap();
+                let _json_message: Value = match serde_json::from_slice(&payload) {
+                    Ok(message) => message,
+                    Err(_) => continue,
+                };
 
                 /*
                 Do I actually launch a docker swarm container that checks for cuda
@@ -164,11 +166,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             #     else if json_message["Command"] == "Stop":
                             #         os.killpg(self.proc_ffmpeg_stream.pid, signal.SIGTERM)
                              */
-                let _result = mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_ack(
-                    &rabbit_channel,
-                    msg.deliver.unwrap().delivery_tag(),
-                )
-                .await;
+                if let Some(delivery) = msg.deliver {
+                    let _result = mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_ack(
+                        &rabbit_channel,
+                        delivery.delivery_tag(),
+                    )
+                    .await;
+                }
             }
         }
     });


### PR DESCRIPTION
### Motivation
- Reduce allocations and improve resilience in the RabbitMQ consumer by making payload decoding and delivery acknowledgment safer and more efficient.
- Eliminate unused imports and clearly mark intentionally-unused values to keep the file tidy and avoid compiler warnings.

### Description
- Replace `String::from_utf8_lossy` + `serde_json::from_str` with `serde_json::from_slice` to parse payloads directly from the byte slice and avoid an intermediate `String` allocation (`docker/core/mkrabbitconsume/src/main.rs`).
- Guard JSON parsing by matching the `from_slice` result and `continue` on parse failure to avoid panics from `unwrap()`.
- Replace `msg.deliver.unwrap()` with an `if let Some(delivery) = msg.deliver` match and only ack when a delivery is present to avoid panics on missing delivery metadata.
- Remove an unused `mk_lib_network` import and prefix intentionally-unused bindings (DB pool and option config) with `_` to indicate they are intentionally retained but unused.

### Testing
- Ran `rustfmt --edition 2021 docker/core/mkrabbitconsume/src/main.rs`, which completed successfully.
- Attempted `cargo check --manifest-path docker/core/mkrabbitconsume/Cargo.toml`, which failed in this environment due to the external `kellnr` registry index not being configured.
- Attempted `cargo clippy --manifest-path docker/core/mkrabbitconsume/Cargo.toml -- -D warnings`, which also failed for the same `kellnr` registry configuration reason.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a097bd2358832194cf0dcbf914e893)