### PR TITLE
Optimize mk_lib_logging client reuse and harden logging requests

### DIFF
--- a/src/mk_lib_logging/src/lib.rs
+++ b/src/mk_lib_logging/src/lib.rs
@@ -1,2 +1,7 @@
 pub mod mk_lib_logging_elk;
 pub mod mk_lib_logging_loki;
+
+pub use mk_lib_logging_elk::{
+    mk_logging_post_elk_ignore_ssl, mk_logging_post_elk_lib, mk_logging_post_elk_retry,
+};
+pub use mk_lib_logging_loki::{LokiLog, mk_logging_loki_push, mk_logging_loki_read};

--- a/src/mk_lib_logging/src/mk_lib_logging_elk.rs
+++ b/src/mk_lib_logging/src/mk_lib_logging_elk.rs
@@ -1,43 +1,92 @@
 use chrono::prelude::*;
-use reqwest::Client;
-use reqwest_middleware::ClientBuilder;
+use elasticsearch::cert::CertificateValidation;
+use elasticsearch::http::transport::{SingleNodeConnectionPool, TransportBuilder};
+use elasticsearch::{Elasticsearch, IndexParts};
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
+use std::sync::OnceLock;
 use tokio::time::Duration;
-use elasticsearch::{
-    Elasticsearch, Error,
-    http::transport::Transport,
-    http::transport::TransportBuilder,
-    IndexParts,
-    cert::CertificateValidation,
-};
-use elasticsearch::http::transport::SingleNodeConnectionPool;
-use elasticsearch::http::Method;
-use elasticsearch::SearchParts;
-use elasticsearch::http::headers::HeaderMap;
-use serde_json::Value;
-use serde_json::json;
 use url::Url;
+
+const ELK_POST_URL: &str =
+    "http://elasticsearch-es-http.elastic-stack.svc.mkcluster.local:9200/mklogs/_doc";
+const ELK_HTTPS_URL: &str = "https://elasticsearch-es-http.elastic-stack.svc.mkcluster.local:9200";
+
+fn elk_payload(
+    message_type: &str,
+    message_module: &str,
+    message_text: serde_json::Value,
+) -> serde_json::Value {
+    let utc: DateTime<Utc> = Utc::now();
+    serde_json::json!({
+        "@timestamp": utc.format("%Y-%m-%dT%H:%M:%S.%f").to_string(),
+        "type": message_type,
+        "message": message_text,
+        "module": message_module,
+        "user": {"id": "mediakraken"}
+    })
+}
+
+fn retrying_client() -> &'static ClientWithMiddleware {
+    static CLIENT: OnceLock<ClientWithMiddleware> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        let retry_policy = ExponentialBackoff::builder().build_with_max_retries(100);
+        ClientBuilder::new(reqwest::Client::new())
+            .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+            .build()
+    })
+}
+
+fn insecure_reqwest_client() -> Result<&'static reqwest::Client, Box<dyn std::error::Error>> {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    if let Some(client) = CLIENT.get() {
+        return Ok(client);
+    }
+
+    let built = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()?;
+    let _ = CLIENT.set(built);
+
+    CLIENT
+        .get()
+        .ok_or_else(|| "failed to initialize insecure reqwest client".into())
+}
+
+fn insecure_elasticsearch_client() -> Result<&'static Elasticsearch, Box<dyn std::error::Error>> {
+    static CLIENT: OnceLock<Elasticsearch> = OnceLock::new();
+    if let Some(client) = CLIENT.get() {
+        return Ok(client);
+    }
+
+    let url = Url::parse(ELK_HTTPS_URL)?;
+    let conn_pool = SingleNodeConnectionPool::new(url);
+    let transport = TransportBuilder::new(conn_pool)
+        .cert_validation(CertificateValidation::None)
+        .build()?;
+    let _ = CLIENT.set(Elasticsearch::new(transport));
+
+    CLIENT
+        .get()
+        .ok_or_else(|| "failed to initialize insecure elasticsearch client".into())
+}
 
 pub async fn mk_logging_post_elk_retry(
     message_type: &str,
     message_module: &str,
     message_text: serde_json::Value,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let utc: DateTime<Utc> = Utc::now();
-    let data = serde_json::json!({"@timestamp": utc.format("%Y-%m-%dT%H:%M:%S.%f").to_string(),
-        "type": message_type, "message": message_text, "module": message_module, "user": {"id": "mediakraken"}});
-    let retry_policy = ExponentialBackoff::builder().build_with_max_retries(100);
-    let client = ClientBuilder::new(reqwest::Client::new())
-        .with(RetryTransientMiddleware::new_with_policy(retry_policy))
-        .build();
-    // the internal url for below is health checks/etc
-    let response = client
-        .post("http://elasticsearch-es-http.elastic-stack.svc.mkcluster.local:9200/mklogs/_doc")
+    let data = elk_payload(message_type, message_module, message_text);
+
+    retrying_client()
+        .post(ELK_POST_URL)
         .timeout(Duration::from_secs(30))
         .header("Content-Type", "application/json")
         .json(&data)
         .send()
-        .await?;
+        .await?
+        .error_for_status()?;
+
     Ok(())
 }
 
@@ -46,20 +95,17 @@ pub async fn mk_logging_post_elk_ignore_ssl(
     message_module: &str,
     message_text: serde_json::Value,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let utc: DateTime<Utc> = Utc::now();
-    let data = serde_json::json!({"@timestamp": utc.format("%Y-%m-%dT%H:%M:%S.%f").to_string(),
-        "type": message_type, "message": message_text, "module": message_module, "user": {"id": "mediakraken"}});
-    let client = reqwest::Client::builder()
-        .danger_accept_invalid_certs(true)
-        .build()?;
-    // the internal url for below is health checks/etc
-    let response = client
-        .post("http://elasticsearch-es-http.elastic-stack.svc.mkcluster.local:9200/mklogs/_doc")
+    let data = elk_payload(message_type, message_module, message_text);
+
+    insecure_reqwest_client()?
+        .post(ELK_POST_URL)
         .timeout(Duration::from_secs(30))
         .header("Content-Type", "application/json")
         .json(&data)
         .send()
-        .await?;
+        .await?
+        .error_for_status()?;
+
     Ok(())
 }
 
@@ -68,29 +114,14 @@ pub async fn mk_logging_post_elk_lib(
     message_module: &str,
     message_text: serde_json::Value,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let utc: DateTime<Utc> = Utc::now();
-    let data = serde_json::json!({"@timestamp": utc.format("%Y-%m-%dT%H:%M:%S.%f").to_string(),
-        "type": message_type, "message": message_text, "module": message_module, "user": {"id": "mediakraken"}});
-    let url = Url::parse("https://elasticsearch-es-http.elastic-stack.svc.mkcluster.local:9200")?;
-    let conn_pool = SingleNodeConnectionPool::new(url);
-    let transport = TransportBuilder::new(conn_pool)
-        .cert_validation(CertificateValidation::None) // 👈 allow self-signed certs
-        .build()
-        .unwrap();
-    let client = Elasticsearch::new(transport);
-    let response = client   
+    let data = elk_payload(message_type, message_module, message_text);
+
+    insecure_elasticsearch_client()?
         .index(IndexParts::Index("mklogs"))
         .body(data)
         .send()
-        .await?;
+        .await?
+        .error_for_status_code()?;
+
     Ok(())
 }
-
-/*
-debug true
-TMDB here2
-http error
-thread 'tokio-runtime-worker' (24) panicked at src/main.rs:136:26:
-called `Result::unwrap()` on an `Err` value: Error { kind: Http(reqwest::Error { kind: Request, url: "http://elasticsearch-es-http.elastic-stack.svc.mkcluster.local:9200/mklogs/_doc", source: hyper_util::client::legacy::Error(SendRequest, hyper::Error(IncompleteMessage)) }) }
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-*/

--- a/src/mk_lib_logging/src/mk_lib_logging_loki.rs
+++ b/src/mk_lib_logging/src/mk_lib_logging_loki.rs
@@ -1,13 +1,18 @@
 use chrono::prelude::*;
 use reqwest::Client;
-use reqwest_middleware::ClientBuilder;
-use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
 use serde::Deserialize;
 use serde_json::json;
 use std::collections::HashMap;
 use std::env;
-use std::path::Path;
+use std::sync::OnceLock;
 use tokio::time::Duration;
+
+const LOKI_PUSH_URL: &str =
+    "http://loki-headless.monitoring.svc.mkcluster.local:3100/loki/api/v1/push";
+const LOKI_QUERY_URL: &str =
+    "http://loki-headless.monitoring.svc.mkcluster.local:3100/loki/api/v1/query_range";
 
 #[derive(Debug, Deserialize)]
 struct LokiResponse {
@@ -30,6 +35,21 @@ pub struct LokiLog {
     pub timestamp_ns: i128,
     pub labels: String,
     pub line: String,
+}
+
+fn retrying_client() -> &'static ClientWithMiddleware {
+    static CLIENT: OnceLock<ClientWithMiddleware> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        let retry_policy = ExponentialBackoff::builder().build_with_max_retries(100);
+        ClientBuilder::new(reqwest::Client::new())
+            .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+            .build()
+    })
+}
+
+fn query_client() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(Client::new)
 }
 
 pub async fn mk_logging_loki_push(
@@ -55,17 +75,16 @@ pub async fn mk_logging_loki_push(
             }
         ]
     });
-    let retry_policy = ExponentialBackoff::builder().build_with_max_retries(100);
-    let client = ClientBuilder::new(reqwest::Client::new())
-        .with(RetryTransientMiddleware::new_with_policy(retry_policy))
-        .build();
-    let response = client
-        .post("http://loki-headless.monitoring.svc.mkcluster.local:3100/loki/api/v1/push")
+
+    retrying_client()
+        .post(LOKI_PUSH_URL)
         .timeout(Duration::from_secs(30))
         .header("Content-Type", "application/json")
         .json(&payload)
         .send()
-        .await?;
+        .await?
+        .error_for_status()?;
+
     Ok(())
 }
 
@@ -86,16 +105,33 @@ fn stream_to_logql(labels: &HashMap<String, String>) -> String {
 pub async fn mk_logging_loki_read(
     message_type: &str,
 ) -> Result<Vec<LokiLog>, Box<dyn std::error::Error>> {
-    let client = Client::new();
-    let query = r#"{mediakraken=~"mk*"}"#;
-    let resp: LokiResponse = client
-        .get("http://loki-headless.monitoring.svc.mkcluster.local:3100/loki/api/v1/query_range")
-        .query(&[("query", query), ("limit", "100"), ("direction", "backward")])
+    let query = if message_type.is_empty() {
+        r#"{mediakraken=~"mk*"}"#.to_string()
+    } else {
+        format!(r#"{{mediakraken=~"mk*"}} |= "{message_type}""#)
+    };
+
+    let resp: LokiResponse = query_client()
+        .get(LOKI_QUERY_URL)
+        .query(&[
+            ("query", query.as_str()),
+            ("limit", "100"),
+            ("direction", "backward"),
+        ])
         .send()
         .await?
+        .error_for_status()?
         .json()
         .await?;
-    let mut logs = Vec::new();
+
+    let capacity = resp
+        .data
+        .result
+        .iter()
+        .map(|stream| stream.values.len())
+        .sum::<usize>();
+    let mut logs = Vec::with_capacity(capacity);
+
     for stream in resp.data.result {
         let stream_str = stream_to_logql(&stream.stream);
         for [ts, line] in stream.values {


### PR DESCRIPTION
### Motivation
- Reduce duplicated logic and improve runtime reliability of the logging library by reusing HTTP/Elasticsearch clients and adding stronger error handling. 
- Make Loki/ELK interactions more efficient and predictable under transient failures and when filtering reads.

### Description
- Reworked crate root to re-export Loki/ELK API symbols so public API is maintained in one place (`src/mk_lib_logging/src/lib.rs`).
- Loki improvements include endpoint constants, a shared retrying client via `OnceLock`, a shared query client, HTTP status checks with `.error_for_status()`, and preallocating the read result vector; query filtering now includes the optional `message_type` (`src/mk_lib_logging/src/mk_lib_logging_loki.rs`).
- ELK improvements include a centralized `elk_payload` constructor, shared clients (`reqwest` insecure client, retrying middleware client, and `Elasticsearch`) via `OnceLock`, removal of `unwrap()` panic paths in client construction, and enforcing response success with `.error_for_status()` / `.error_for_status_code()` (`src/mk_lib_logging/src/mk_lib_logging_elk.rs`).
- Small tidy-up of constants and removed commented panic backtrace noise; no dependency changes were made.

### Testing
- Ran `cargo fmt` in `src/mk_lib_logging` and formatting completed successfully.
- Ran `cargo check` in `src/mk_lib_logging` which could not complete due to the environment's private registry returning HTTP 403, so compilation could not be fully validated in this environment.
- Ran `cargo clippy -- -D warnings` in `src/mk_lib_logging` which likewise could not complete because of the same private registry access limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f537f1ee8832196a75c0dda3f6665)