### PR TITLE
Optimize theater_full button image setup

### DIFF
--- a/src_app/theater_full/src/main.rs
+++ b/src_app/theater_full/src/main.rs
@@ -1,9 +1,19 @@
-use fltk::{app, button::Button, image::SharedImage, prelude::*, window::Window};
-use fltk_theme::widget_schemes::fluent::colors::*;
-use fltk_theme::widget_schemes::fluent::frames::*;
+use fltk::{app, button::Button, image::PngImage, prelude::*, window::Window};
 use fltk_theme::{SchemeType, WidgetScheme};
 use mk_lib_network;
 use std::error::Error;
+
+fn set_button_image(
+    button: &mut Button,
+    image_bytes: &[u8],
+    width: i32,
+    height: i32,
+) -> Result<(), Box<dyn Error>> {
+    let mut image = PngImage::from_data(image_bytes)?;
+    image.scale(width, height, true, true);
+    button.set_image(Some(image));
+    Ok(())
+}
 
 fn main() -> Result<(), Box<dyn Error>> {
     // load images
@@ -33,7 +43,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let bytes_image_books = include_bytes!("../../../docker/core/mkwebaxum/static/image/books.png");
     let bytes_image_settings =
         include_bytes!("../../../docker/core/mkwebaxum/static/image/settings.png");
-    let bytes_image_return = include_bytes!("../../../docker/core/mkwebaxum/static/image/navigation/return.png");
+    let bytes_image_return =
+        include_bytes!("../../../docker/core/mkwebaxum/static/image/navigation/return.png");
 
     let _server_list =
         mk_lib_network::mk_lib_network_mediakraken::mk_lib_network_find_mediakraken_server();
@@ -42,77 +53,50 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut window_menu = Window::default().with_size(800, 480);
     // window_menu - left side buttons
     let mut button_in_progress = Button::new(0, 0, 133, 96, "In Progress");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_rectangle)?;
-    image.scale(133, 96, true, true);
-    button_in_progress.set_image(Some(image));
+    set_button_image(&mut button_in_progress, bytes_image_rectangle, 133, 96)?;
     let mut button_new = Button::new(0, 96, 133, 96, "New");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_new)?;
-    image.scale(133, 96, true, true);
-    button_new.set_image(Some(image));
+    set_button_image(&mut button_new, bytes_image_new, 133, 96)?;
     let mut button_movie = Button::new(0, 192, 133, 96, "Movie");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_movie_ticket)?;
-    image.scale(133, 96, true, true);
-    button_movie.set_image(Some(image));
+    set_button_image(&mut button_movie, bytes_image_movie_ticket, 133, 96)?;
     let mut button_tv = Button::new(0, 288, 133, 96, "TV");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_television)?;
-    image.scale(133, 96, true, true);
-    button_tv.set_image(Some(image));
+    set_button_image(&mut button_tv, bytes_image_television, 133, 96)?;
     let mut button_game = Button::new(0, 384, 133, 96, "Games");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_vid_game)?;
-    image.scale(133, 96, true, true);
-    button_game.set_image(Some(image));
+    set_button_image(&mut button_game, bytes_image_vid_game, 133, 96)?;
     // window_menu - top middle button
     let mut button_demo = Button::new(133, 0, 532, 384, "Demo");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_theater)?;
-    image.scale(532, 384, true, true);
-    button_demo.set_image(Some(image));
+    set_button_image(&mut button_demo, bytes_image_theater, 532, 384)?;
     // window_menu - bottom middle buttons
     let mut button_music = Button::new(133, 384, 133, 96, "Music");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_headphone)?;
-    image.scale(133, 96, true, true);
-    button_music.set_image(Some(image));
+    set_button_image(&mut button_music, bytes_image_headphone, 133, 96)?;
     let mut button_live_tv = Button::new(266, 384, 133, 96, "Live TV");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_television_live)?;
-    image.scale(133, 96, true, true);
-    button_live_tv.set_image(Some(image));
+    set_button_image(&mut button_live_tv, bytes_image_television_live, 133, 96)?;
     let mut button_home_video = Button::new(399, 384, 133, 96, "Home Video");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_vid_camera)?;
-    image.scale(133, 96, true, true);
-    button_home_video.set_image(Some(image));
+    set_button_image(&mut button_home_video, bytes_image_vid_camera, 133, 96)?;
     let mut button_internet = Button::new(532, 384, 133, 96, "Internet");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_earth)?;
-    image.scale(133, 96, true, true);
-    button_internet.set_image(Some(image));
+    set_button_image(&mut button_internet, bytes_image_earth, 133, 96)?;
     // window_menu - right side buttons
     let mut button_music_video = Button::new(666, 0, 133, 96, "Music Video");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_listening_music_video_clip_with_auricular)?;
-    image.scale(133, 96, true, true);
-    button_music_video.set_image(Some(image));
+    set_button_image(
+        &mut button_music_video,
+        bytes_image_listening_music_video_clip_with_auricular,
+        133,
+        96,
+    )?;
     let mut button_pictures = Button::new(666, 96, 133, 96, "Pictures");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_photo)?;
-    image.scale(133, 96, true, true);
-    button_pictures.set_image(Some(image));
+    set_button_image(&mut button_pictures, bytes_image_photo, 133, 96)?;
     let mut button_radio = Button::new(666, 192, 133, 96, "Radio");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_radio)?;
-    image.scale(133, 96, true, true);
-    button_radio.set_image(Some(image));
+    set_button_image(&mut button_radio, bytes_image_radio, 133, 96)?;
     let mut button_books = Button::new(666, 288, 133, 96, "Books");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_books)?;
-    image.scale(133, 96, true, true);
-    button_books.set_image(Some(image));
+    set_button_image(&mut button_books, bytes_image_books, 133, 96)?;
     let mut button_settings = Button::new(666, 384, 133, 96, "Settings");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_settings)?;
-    image.scale(133, 96, true, true);
-    button_settings.set_image(Some(image));
+    set_button_image(&mut button_settings, bytes_image_settings, 133, 96)?;
     window_menu.end();
     window_menu.make_resizable(true);
     window_menu.fullscreen(true);
 
     let mut window_settings = Window::default().with_size(800, 480);
     let mut button_settings_back = Button::new(666, 384, 133, 96, "Back");
-    let mut image = fltk::image::PngImage::from_data(bytes_image_return)?;
-    image.scale(133, 96, true, true);
-    button_settings_back.set_image(Some(image));
+    set_button_image(&mut button_settings_back, bytes_image_return, 133, 96)?;
     window_settings.end();
     window_settings.make_resizable(true);
     window_settings.fullscreen(true);


### PR DESCRIPTION
### Motivation
- Reduce duplicated PNG decode/scale/assign logic across many FLTK button initializations to improve maintainability and reduce risk of inconsistent behavior.
- Centralize image handling so future changes to scaling or error handling are made in one place.
- Keep UI layout and behavior unchanged while making the code clearer and smaller.

### Description
- Add a `set_button_image(button: &mut Button, image_bytes: &[u8], width: i32, height: i32) -> Result<(), Box<dyn Error>>` helper that decodes, scales, and assigns `PngImage` to buttons.
- Replace repeated per-button `PngImage::from_data(...); image.scale(...); button.set_image(...)` blocks with calls to the new helper across the menu and settings buttons in `src_app/theater_full/src/main.rs`.
- Replace the earlier `SharedImage`/duplicate imports with `PngImage` usage and tidy a long `include_bytes!` line for improved clarity.

### Testing
- Ran `rustfmt src_app/theater_full/src/main.rs` successfully to format the modified file.
- Attempted `cargo fmt --manifest-path src_app/Cargo.toml`, which failed in this environment due to a private registry configuration error for `kellnr`.
- Attempted `cargo check --manifest-path src_app/theater_full/Cargo.toml` and `cargo clippy --manifest-path src_app/theater_full/Cargo.toml -- -D warnings`, both of which were blocked by the same missing private registry `kellnr` error in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3545dfa98832185d6bc5ffa14e5e5)