### PR TITLE
Handle mpv spawn and app.run errors; minor formatting and Cargo cleanup

### DIFF
--- a/src_app/theater_thin/Cargo.toml
+++ b/src_app/theater_thin/Cargo.toml
@@ -11,7 +11,6 @@ codegen-units = 1
 
 [dependencies]
 mk_lib_network = { version = "0.0.137", registry = "kellnr" }
-
 fltk = { version = "1.5.22", features = ["fltk-bundled"] }
 reqwest = { version = "0.12.28", default-features = false, features = [
     "json",

--- a/src_app/theater_thin/src/main.rs
+++ b/src_app/theater_thin/src/main.rs
@@ -3,7 +3,8 @@ use fltk::{enums::Color, *};
 use mk_lib_network;
 
 fn main() {
-    let _server_list = mk_lib_network::mk_lib_network_mediakraken::mk_lib_network_find_mediakraken_server();
+    let _server_list =
+        mk_lib_network::mk_lib_network_mediakraken::mk_lib_network_find_mediakraken_server();
     let app = app::App::default().with_scheme(app::AppScheme::Gtk);
     let mut win = window::Window::new(100, 100, 800, 600, "Media Player");
 
@@ -17,10 +18,15 @@ fn main() {
     win.make_resizable(true);
 
     let handle = mpv_win.raw_handle();
-    std::process::Command::new("mpv")
-        .args(&[&format!("--wid={}", handle as u64), "../libvlc/video.mp4"])
+    if let Err(error) = std::process::Command::new("mpv")
+        .arg(format!("--wid={}", handle as u64))
+        .arg("../libvlc/video.mp4")
         .spawn()
-        .unwrap();
+    {
+        eprintln!("Failed to launch mpv: {error}");
+    }
 
-    app.run().unwrap();
+    if let Err(error) = app.run() {
+        eprintln!("Application exited with error: {error}");
+    }
 }


### PR DESCRIPTION
### Motivation
- Prevent panics when launching the external `mpv` player or when running the FLTK application by handling errors instead of unwrapping. 
- Tidy small formatting issues in the main binary and `Cargo.toml` for readability.

### Description
- Replace the previous `.args(...).spawn().unwrap()` pattern with chained `.arg(...)` calls and an error check that logs spawn failures via `eprintln!` instead of panicking. 
- Replace `app.run().unwrap()` with an `if let Err(error) = app.run()` branch that logs any application runtime error via `eprintln!`. 
- Reformat the `_server_list` assignment line for readability. 
- Remove a stray blank line in `src_app/theater_thin/Cargo.toml` (formatting-only change).

### Testing
- Ran `cargo build --release` which completed successfully. 
- Ran `cargo test` and existing automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3544db4a88321a18e4d1d02793c5c)