### PR TITLE
pi_upc: parameterize DB queries, propagate errors, and validate input

### DIFF
--- a/src_app/pi_upc/src/database.rs
+++ b/src_app/pi_upc/src/database.rs
@@ -2,41 +2,36 @@ use sqlite::State;
 use std::error::Error;
 
 pub fn database_open() -> Result<sqlite::Connection, Box<dyn Error>> {
-    let db = sqlite::open("upc_scan.db").unwrap();
+    let db = sqlite::open("upc_scan.db")?;
     let query = "CREATE TABLE IF NOT EXISTS upc_codes \
             (upc_code INTEGER NOT NULL, \
             upc_code_type INTEGER NOT NULL, \
             added_timestamp DATETIME NOT NULL);";
-    db.execute(query).unwrap();
+    db.execute(query)?;
 
     let query = "CREATE INDEX IF NOT EXISTS upc_code_ndx on upc_codes \
             (upc_code, upc_code_type);";
-    db.execute(query).unwrap();
+    db.execute(query)?;
 
     let query = "CREATE TABLE IF NOT EXISTS logs \
             (log_timestamp DATETIME NOT NULL, \
             log_text TEXT)";
-    db.execute(query).unwrap();
+    db.execute(query)?;
 
     let query = "CREATE INDEX IF NOT EXISTS log_time_ndx on logs \
             (log_timestamp);";
-    db.execute(query).unwrap();
+    db.execute(query)?;
 
     Ok(db)
 }
 
 //pub fn database_close() -> Result<sqlx::Pool<Sqlite>, Box<dyn Error>> {}
 
-pub fn database_insert_logs(
-    db: &sqlite::Connection,
-    log_text: String,
-) -> Result<(), Box<dyn Error>> {
-    let query = format!(
-        "insert into logs (log_timestamp, log_text) \
-        values (CURRENT_TIMESTAMP, '{}');",
-        log_text,
-    );
-    db.execute(query).unwrap();
+pub fn database_insert_logs(db: &sqlite::Connection, log_text: &str) -> Result<(), Box<dyn Error>> {
+    let query = "insert into logs (log_timestamp, log_text) values (CURRENT_TIMESTAMP, ?);";
+    let mut statement = db.prepare(query)?;
+    statement.bind((1, log_text))?;
+    statement.next()?;
     Ok(())
 }
 
@@ -45,12 +40,12 @@ pub fn database_upc_insert(
     upc_code: i64,
     upc_type: i32,
 ) -> Result<(), Box<dyn Error>> {
-    let query = format!(
-        "insert into upc_codes (upc_code, upc_code_type, added_timestamp) \
-        values ({}, {}, CURRENT_TIMESTAMP);",
-        upc_code, upc_type
-    );
-    db.execute(query).unwrap();
+    let query =
+        "insert into upc_codes (upc_code, upc_code_type, added_timestamp) values (?, ?, CURRENT_TIMESTAMP);";
+    let mut statement = db.prepare(query)?;
+    statement.bind((1, upc_code))?;
+    statement.bind((2, upc_type))?;
+    statement.next()?;
     Ok(())
 }
 
@@ -59,26 +54,22 @@ pub fn database_upc_owned(
     upc_code: i64,
     upc_type: i32,
 ) -> Result<i64, Box<dyn Error>> {
-    let mut record_count: i64 = 0;
-    let query = format!(
-        "SELECT count(*) as total_found FROM upc_codes WHERE upc_code = {} and upc_code_type = {}",
-        upc_code, upc_type
-    );
-    let mut statement = db.prepare(query).unwrap();
+    let query =
+        "SELECT count(*) as total_found FROM upc_codes WHERE upc_code = ? and upc_code_type = ?";
+    let mut statement = db.prepare(query)?;
+    statement.bind((1, upc_code))?;
+    statement.bind((2, upc_type))?;
     while let Ok(State::Row) = statement.next() {
-        record_count = statement.read::<i64, _>("total_found").unwrap();
+        return Ok(statement.read::<i64, _>("total_found")?);
     }
-    Ok(record_count)
+    Ok(0)
 }
 
-pub fn database_upc_known_count(
-    db: &sqlite::Connection,
-) -> Result<i64, Box<dyn Error>> {
-    let mut record_count: i64 = 0;
+pub fn database_upc_known_count(db: &sqlite::Connection) -> Result<i64, Box<dyn Error>> {
     let query = "SELECT count(*) as total_found FROM upc_codes";
-    let mut statement = db.prepare(query).unwrap();
+    let mut statement = db.prepare(query)?;
     while let Ok(State::Row) = statement.next() {
-        record_count = statement.read::<i64, _>("total_found").unwrap();
+        return Ok(statement.read::<i64, _>("total_found")?);
     }
-    Ok(record_count)
+    Ok(0)
 }

--- a/src_app/pi_upc/src/main.rs
+++ b/src_app/pi_upc/src/main.rs
@@ -13,8 +13,8 @@ pub enum Message {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let db_instance = database::database_open().unwrap();
-    let mut total_codes: i64 = database::database_upc_known_count(&db_instance).unwrap();
+    let db_instance = database::database_open()?;
+    let mut total_codes: i64 = database::database_upc_known_count(&db_instance)?;
     let app = app::App::default().with_scheme(app::Scheme::Gleam);
     let mut window_main = Window::default().with_size(800, 480); // pi 7" screen default
 
@@ -32,7 +32,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut container_upc_codes = Pack::new(300, 25, 150, 40, "UPC Codes");
 
-    let mut frame_upc_known = Frame::default().with_size(40, 20).with_label(format!("Known: {}", total_codes).as_str());
+    let mut frame_upc_known = Frame::default()
+        .with_size(40, 20)
+        .with_label(format!("Known: {}", total_codes).as_str());
 
     container_upc_codes.end();
     container_upc_codes.set_frame(FrameType::BorderFrame);
@@ -63,39 +65,51 @@ fn main() -> Result<(), Box<dyn Error>> {
                     println!("Increment");
                 }
                 Message::Scanned => {
-                    println!("{}:", upc_input.value());
+                    let scanned_input = upc_input.value();
+                    println!("{}:", scanned_input);
 
-                    let inp1_val: i64 = upc_input.value().parse().unwrap();
-                    let mut output_text: String = "No Data".to_string();
-                    database::database_insert_logs(&db_instance, format!("{} scanned", inp1_val));
-                    let upc_count = database::database_upc_owned(
-                        &db_instance,
-                        inp1_val,
-                        choice_media_type.value(),
-                    )
-                    .unwrap();
-                    if upc_count == 0 {
-                        let _result = database::database_upc_insert(
-                            &db_instance,
-                            inp1_val,
-                            choice_media_type.value(),
-                        );
-                        output_text = format!("{} - Added", inp1_val);
-                        database::database_insert_logs(&db_instance, format!("{} added", inp1_val));
-                        total_codes += 1;
+                    match scanned_input.parse::<i64>() {
+                        Ok(inp1_val) => {
+                            let media_type = choice_media_type.value();
+                            let mut output_text: String = "No Data".to_string();
 
-                        frame_upc_known.set_label(&format!(
-                            "Known: {}",
-                            &total_codes.to_string()
-                        ));
-                    } else {
-                        output_text = format!("{} - DUPLICATE!", inp1_val);
-                        database::database_insert_logs(
-                            &db_instance,
-                            format!("{} duplicate", inp1_val),
-                        );
+                            let log_text = format!("{} scanned", inp1_val);
+                            let _ = database::database_insert_logs(&db_instance, &log_text);
+
+                            match database::database_upc_owned(&db_instance, inp1_val, media_type) {
+                                Ok(0) => {
+                                    let _ = database::database_upc_insert(
+                                        &db_instance,
+                                        inp1_val,
+                                        media_type,
+                                    );
+                                    output_text = format!("{} - Added", inp1_val);
+                                    let added_log = format!("{} added", inp1_val);
+                                    let _ =
+                                        database::database_insert_logs(&db_instance, &added_log);
+                                    total_codes += 1;
+
+                                    frame_upc_known.set_label(&format!("Known: {}", total_codes));
+                                }
+                                Ok(_) => {
+                                    output_text = format!("{} - DUPLICATE!", inp1_val);
+                                    let duplicate_log = format!("{} duplicate", inp1_val);
+                                    let _ = database::database_insert_logs(
+                                        &db_instance,
+                                        &duplicate_log,
+                                    );
+                                }
+                                Err(_) => {
+                                    output_text = "Database error".to_string();
+                                }
+                            }
+
+                            out.set_value(&output_text);
+                        }
+                        Err(_) => {
+                            out.set_value("Invalid UPC");
+                        }
                     }
-                    out.set_value(&output_text);
 
                     upc_input.set_value("");
                     upc_input.take_focus();


### PR DESCRIPTION
### Motivation
- Replace string-formatted SQL and panicking `unwrap()` calls to reduce allocations, eliminate interpolation risks, and make startup fail cleanly.
- Improve runtime performance and correctness in the UPC scan hot path by avoiding repeated parsing and redundant allocations.
- Provide clearer UI feedback for invalid input and database errors while keeping existing add/duplicate behavior.

### Description
- Replaced string-built SQL with parameterized prepared statements and `bind`/`next` usage for logs, UPC insert, UPC lookup, and UPC count in `src_app/pi_upc/src/database.rs`.
- Propagated errors from startup/database initialization by changing `database_open` and initial calls in `src_app/pi_upc/src/main.rs` to use `?` instead of `unwrap()`.
- Changed `database_insert_logs` signature to accept `&str` and updated call sites to pass borrowed strings to avoid extra ownership moves.
- Optimized scan handling in `src_app/pi_upc/src/main.rs` by reading the input once, parsing once, reusing `choice_media_type.value()`, and adding explicit branches for invalid UPC input and database errors while preserving add/duplicate logic and updating the known-count frame.

### Testing
- Ran `rustfmt` on the modified files; formatting succeeded.
- Attempted `cargo check` for the `pi_upc` crate with network access, but it failed due to crates.io access being blocked by the environment (network/proxy 403).
- Attempted `cargo check --offline` and `cargo clippy --offline`, but these failed because workspace dependencies (e.g. `brother_ql`) are not available in the offline cache.
- No additional automated tests ran because workspace-wide dependency resolution is blocked in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a35415fbbc832197d3c57fc75d1dfe)