### PR TITLE
Optimize mktranscode cast command handling

### DIFF
--- a/docker/core/mktranscode/src/main.rs
+++ b/docker/core/mktranscode/src/main.rs
@@ -1,19 +1,39 @@
 use mk_lib_common::mk_lib_common_ffmpeg;
 use mk_lib_database;
 use mk_lib_rabbitmq;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::error::Error;
-use std::process::{Command, Stdio};
+use tokio::process::Command;
 use tokio::sync::Notify;
+
+const STREAM2CHROMECAST_PATH: &str = "/mediakraken/stream2chromecast/stream2chromecast.py";
+
+async fn run_cast_command(device_name: &str, command_flag: &str, extra: Option<&str>) {
+    let mut process = Command::new("python3");
+    process.args([
+        STREAM2CHROMECAST_PATH,
+        "-devicename",
+        device_name,
+        command_flag,
+    ]);
+    if let Some(extra_arg) = extra {
+        process.arg(extra_arg);
+    }
+    let _result = process.status().await;
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // open the database
-    let (sqlx_pool_rw, sqlx_pool_ro) = mk_lib_database::mk_lib_database::mk_lib_database_open_pool(1, 120)
-        .await
-        .unwrap();
-    let _results = mk_lib_database::mk_lib_database_version::mk_lib_database_version_check(&sqlx_pool_ro, false)
-        .await;
+    let (sqlx_pool_rw, sqlx_pool_ro) =
+        mk_lib_database::mk_lib_database::mk_lib_database_open_pool(1, 120)
+            .await
+            .unwrap();
+    let _results = mk_lib_database::mk_lib_database_version::mk_lib_database_version_check(
+        &sqlx_pool_ro,
+        false,
+    )
+    .await;
 
     // pull options for metadata/chapters/images location
     let option_json: serde_json::Value =
@@ -59,83 +79,27 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     )
                     .await;
                     } else if json_message["Subtype"] == "Cast" {
+                        let device_name = json_message["Device"].as_str().unwrap_or_default();
                         if json_message["Command"] == "Chapter Back" {
                         } else if json_message["Command"] == "Chapter Forward" {
                         } else if json_message["Command"] == "Fast Forward" {
                         } else if json_message["Command"] == "Mute" {
-                            let output = Command::new("python3")
-                                .args([
-                                    "/mediakraken/stream2chromecast/stream2chromecast.py",
-                                    "-devicename",
-                                    &json_message["Device"].to_string(),
-                                    "-mute",
-                                ])
-                                .stdout(Stdio::piped())
-                                .output()
-                                .unwrap();
-                            let stdout = String::from_utf8(output.stdout).unwrap();
+                            run_cast_command(device_name, "-mute", None).await;
                         } else if json_message["Command"] == "Pause" {
-                            let output = Command::new("python3")
-                                .args([
-                                    "/mediakraken/stream2chromecast/stream2chromecast.py",
-                                    "-devicename",
-                                    &json_message["Device"].to_string(),
-                                    "-pause",
-                                ])
-                                .stdout(Stdio::piped())
-                                .output()
-                                .unwrap();
-                            let stdout = String::from_utf8(output.stdout).unwrap();
+                            run_cast_command(device_name, "-pause", None).await;
                         } else if json_message["Command"] == "Rewind" {
                         } else if json_message["Command"] == "Stop" {
-                            let output = Command::new("python3")
-                                .args([
-                                    "/mediakraken/stream2chromecast/stream2chromecast.py",
-                                    "-devicename",
-                                    &json_message["Device"].to_string(),
-                                    "-stop",
-                                ])
-                                .stdout(Stdio::piped())
-                                .output()
-                                .unwrap();
-                            let stdout = String::from_utf8(output.stdout).unwrap();
+                            run_cast_command(device_name, "-stop", None).await;
                         } else if json_message["Command"] == "Volume Down" {
-                            let output = Command::new("python3")
-                                .args([
-                                    "/mediakraken/stream2chromecast/stream2chromecast.py",
-                                    "-devicename",
-                                    &json_message["Device"].to_string(),
-                                    "-voldown",
-                                ])
-                                .stdout(Stdio::piped())
-                                .output()
-                                .unwrap();
-                            let stdout = String::from_utf8(output.stdout).unwrap();
+                            run_cast_command(device_name, "-voldown", None).await;
                         } else if json_message["Command"] == "Volume Set" {
-                            let output = Command::new("python3")
-                                .args([
-                                    "/mediakraken/stream2chromecast/stream2chromecast.py",
-                                    "-devicename",
-                                    &json_message["Device"].to_string(),
-                                    "-setvol",
-                                    &json_message["Data"].to_string(),
-                                ])
-                                .stdout(Stdio::piped())
-                                .output()
-                                .unwrap();
-                            let stdout = String::from_utf8(output.stdout).unwrap();
+                            let volume = json_message["Data"]
+                                .as_str()
+                                .map(String::from)
+                                .unwrap_or_else(|| json_message["Data"].to_string());
+                            run_cast_command(device_name, "-setvol", Some(&volume)).await;
                         } else if json_message["Command"] == "Volume Up" {
-                            let output = Command::new("python3")
-                                .args([
-                                    "/mediakraken/stream2chromecast/stream2chromecast.py",
-                                    "-devicename",
-                                    &json_message["Device"].to_string(),
-                                    "-volup",
-                                ])
-                                .stdout(Stdio::piped())
-                                .output()
-                                .unwrap();
-                            let stdout = String::from_utf8(output.stdout).unwrap();
+                            run_cast_command(device_name, "-volup", None).await;
                         }
                     } else if json_message["Subtype"] == "ChapterImage" {
                         // begin image generation
@@ -147,9 +111,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         if json_message["Data"].get("chapters").is_some() {
                             // for chapter_data in json_message["Data"]["chapters"].iter() {
                             //     chapter_count += 1;
-                                // file path, time, output name
-                                // check image save option whether to
-                                // save this in media folder or metadata folder
+                            // file path, time, output name
+                            // check image save option whether to
+                            // save this in media folder or metadata folder
                             //     if option_json["MetadataImageLocal"] == false {
                             //         image_file_path = os.path.join(
                             //             common_metadata.com_meta_image_file_path(
@@ -177,7 +141,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             //             .path
                             //             .join(image_file_path, chapter_count.as_str() + ".png");
                             //     }
-                                 // format the seconds to what ffmpeg is looking for
+                            // format the seconds to what ffmpeg is looking for
                             //     (minutes, seconds) =
                             //         divmod(float(chapter_data["start_time"]), 60);
                             //     (hours, minutes) = divmod(minutes, 60);
@@ -199,7 +163,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             //         .output()
                             //         .unwrap();
                             //     let stdout = String::from_utf8(output.stdout).unwrap();
-                                 // as the worker might see it as finished if allowed to continue
+                            // as the worker might see it as finished if allowed to continue
                             //     chapter_image_list[chapter_data["tags"]["title"]] =
                             //         image_file_path;
                             //     first_image = false;


### PR DESCRIPTION
### Motivation
- Reduce blocking subprocess usage in the `mktranscode` message loop and eliminate duplicated command construction for cast control messages.
- Improve maintainability by centralizing stream2chromecast invocation and normalizing how device and volume payloads are read from incoming messages.

### Description
- Replaced synchronous `std::process::Command::output()` usage with async `tokio::process::Command::status().await` via a new helper `run_cast_command(device_name, command_flag, extra)` and added `STREAM2CHROMECAST_PATH` constant.
- Centralized cast-control handling so `Mute`, `Pause`, `Stop`, `Volume Down`, `Volume Up`, and `Volume Set` call `run_cast_command` instead of repeating subprocess construction logic.
- Extracted `device_name` with a safe `.as_str().unwrap_or_default()` and normalized `Volume Set` to use `Data.as_str()` when available or fall back to `Data.to_string()` to avoid extra quoting.
- Kept other message handling untouched and preserved existing commented-out logic for chapter image generation.

### Testing
- Ran `cargo fmt` in `docker/core/mktranscode` and it completed successfully.
- Ran `cargo check` in `docker/core/mktranscode` which failed in this environment due to a private registry HTTP 403 preventing dependency resolution.
- Ran `cargo clippy -- -D warnings` which also failed for the same private registry access issue preventing full linting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a504de5cdc8321bb1da4d7514bf80d)