### PR TITLE
Optimize mktmdbnetfetchbulk bulk ingestion loop

### DIFF
--- a/docker/core/mktmdbnetfetchbulk/src/main.rs
+++ b/docker/core/mktmdbnetfetchbulk/src/main.rs
@@ -1,3 +1,4 @@
+use chrono::Local;
 use mk_lib_common;
 use mk_lib_compression;
 use mk_lib_database;
@@ -8,7 +9,6 @@ use serde_json::json;
 use serde_json::Value;
 use std::error::Error;
 use tokio::sync::Notify;
-use chrono::Local;
 
 #[derive(Serialize, Deserialize)]
 struct MetadataMovie {
@@ -47,31 +47,25 @@ struct MetadataGeneral {
 
 pub async fn find_date_to_use(url_template: &str) -> Result<String, Box<dyn Error>> {
     let mut date_to_use = Local::now().format("%m_%d_%Y").to_string();
-    let mut found = false;
     for _ in 0..7 {
-        let test_url = url_template.replace("{}", &date_to_use.clone());
-        if mk_lib_network::mk_lib_network::is_url_available(&test_url.clone().as_str()).await {
-            found = true;
-            break;
-        } else {
-            let date = chrono::NaiveDate::parse_from_str(&date_to_use, "%m_%d_%Y")?;
-            let previous_date = date - chrono::Duration::days(1);
-            date_to_use = previous_date.format("%m_%d_%Y").to_string();
+        let test_url = url_template.replace("{}", &date_to_use);
+        if mk_lib_network::mk_lib_network::is_url_available(test_url.as_str()).await {
+            return Ok(date_to_use);
         }
+        let date = chrono::NaiveDate::parse_from_str(&date_to_use, "%m_%d_%Y")?;
+        let previous_date = date - chrono::Duration::days(1);
+        date_to_use = previous_date.format("%m_%d_%Y").to_string();
     }
-    if found {
-        Ok(date_to_use)
-    } else {
-        Err("No valid date found within the last 7 days".into())
-    }
+    Err("No valid date found within the last 7 days".into())
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // connect to db and do a version check
-    let (sqlx_pool_rw, sqlx_pool_ro) = mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120)
-        .await
-        .unwrap();
+    let (sqlx_pool_rw, sqlx_pool_ro) =
+        mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120)
+            .await
+            .unwrap();
     mk_lib_database::mk_lib_database_version::mk_lib_database_version_check(&sqlx_pool_ro, false)
         .await
         .unwrap();
@@ -93,11 +87,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     serde_json::from_str(&String::from_utf8_lossy(&payload)).unwrap();
                 println!(" [x] Received {:?}", json_message);
                 if json_message["Type"] == "Bulk" {
-                     let mut record_limit = 0;
+                    let mut record_limit = i64::MAX;
                     if json_message["Limit"].is_number() {
                         record_limit = json_message["Limit"].as_i64().unwrap_or(i64::MAX);
                     }
-                    let date_to_use = find_date_to_use("http://files.tmdb.org/p/exports/movie_ids_{}.json.gz").await.unwrap();
+                    let date_to_use =
+                        find_date_to_use("http://files.tmdb.org/p/exports/movie_ids_{}.json.gz")
+                            .await
+                            .unwrap();
                     // grab the movie id's
                     let fetch_result_movie =
                         mk_lib_network::mk_lib_network::mk_network_download_file_to_vec(
@@ -105,24 +102,29 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 "http://files.tmdb.org/p/exports/movie_ids_{}.json.gz",
                                 date_to_use
                             )
-                            .replace("\"", "")
+                            .replace("\"", ""),
                         )
                         .await
                         .unwrap();
                     let json_result =
-                        mk_lib_compression::mk_lib_compression::mk_decompress_gz_bytes(fetch_result_movie)
-                            .await
-                            .unwrap();
+                        mk_lib_compression::mk_lib_compression::mk_decompress_gz_bytes(
+                            fetch_result_movie,
+                        )
+                        .await
+                        .unwrap();
                     // Please note that the data is NOT in id order
                     let mut record_count = 0;
-                    for json_item in json_result.split('\n') {
+                    for json_item in json_result.lines() {
                         if !json_item.trim().is_empty() {
                             let metadata_struct: MetadataMovie =
                                 serde_json::from_str(json_item.trim()).unwrap();
+                            let Some(metadata_id) = metadata_struct.id else {
+                                continue;
+                            };
                             let result =
                                 mk_lib_database::database_metadata::mk_lib_database_metadata_movie::mk_lib_database_metadata_exists_movie(
                                     &sqlx_pool_rw,
-                                    metadata_struct.id.unwrap_or(0),
+                                    metadata_id,
                                 )
                                 .await
                                 .unwrap();
@@ -130,7 +132,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 let download_result = mk_lib_database::database_metadata::mk_lib_database_metadata_download_queue::mk_lib_database_metadata_download_queue_exists(&sqlx_pool_rw,
                                                                                                                               "themoviedb".to_string(),
                                                                                                                               mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::MOVIE,
-                                                                                                                              metadata_struct.id.unwrap_or(0)).await.unwrap();
+                                                                                                                              metadata_id).await.unwrap();
                                 if download_result == false {
                                     record_count += 1;
                                     if record_count > record_limit {
@@ -140,14 +142,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                                                                             "themoviedb".to_string(),
                                                                                                             mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::MOVIE,
                                                                                                             uuid::Uuid::now_v7(),
-                                                                                                            metadata_struct.id,
+                                                                                                            Some(metadata_id),
                                                                                                             "Fetch".to_string(), None).await.unwrap();
                                 }
                             }
                         }
                     }
 
-                    let date_to_use = find_date_to_use("http://files.tmdb.org/p/exports/tv_series_ids_{}.json.gz").await.unwrap();
+                    let date_to_use = find_date_to_use(
+                        "http://files.tmdb.org/p/exports/tv_series_ids_{}.json.gz",
+                    )
+                    .await
+                    .unwrap();
                     // grab the TV id's
                     let fetch_result_tv =
                         mk_lib_network::mk_lib_network::mk_network_download_file_to_vec(
@@ -155,23 +161,28 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 "http://files.tmdb.org/p/exports/tv_series_ids_{}.json.gz",
                                 date_to_use
                             )
-                            .replace("\"", "")
+                            .replace("\"", ""),
                         )
                         .await
                         .unwrap();
                     let json_result =
-                        mk_lib_compression::mk_lib_compression::mk_decompress_gz_bytes(fetch_result_tv)
-                            .await
-                            .unwrap();
+                        mk_lib_compression::mk_lib_compression::mk_decompress_gz_bytes(
+                            fetch_result_tv,
+                        )
+                        .await
+                        .unwrap();
                     let mut record_count = 0;
-                    for json_item in json_result.split('\n') {
+                    for json_item in json_result.lines() {
                         if !json_item.trim().is_empty() {
                             let metadata_struct: MetadataTV =
                                 serde_json::from_str(json_item.trim()).unwrap();
+                            let Some(metadata_id) = metadata_struct.id else {
+                                continue;
+                            };
                             let result =
                                 mk_lib_database::database_metadata::mk_lib_database_metadata_tv::mk_lib_database_metadata_exists_tv(
                                     &sqlx_pool_rw,
-                                    metadata_struct.id.unwrap_or(0),
+                                    metadata_id,
                                 )
                                 .await
                                 .unwrap();
@@ -179,7 +190,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 let download_result = mk_lib_database::database_metadata::mk_lib_database_metadata_download_queue::mk_lib_database_metadata_download_queue_exists(&sqlx_pool_rw,
                                                                                                                               "themoviedb".to_string(),
                                                                                                                               mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV,
-                                                                                                                              metadata_struct.id.unwrap_or(0)).await.unwrap();
+                                                                                                                              metadata_id).await.unwrap();
                                 if download_result == false {
                                     record_count += 1;
                                     if record_count > record_limit {
@@ -189,14 +200,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                                                                             "themoviedb".to_string(),
                                                                                                             mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV,
                                                                                                             uuid::Uuid::now_v7(),
-                                                                                                            metadata_struct.id,
+                                                                                                            Some(metadata_id),
                                                                                                             "Fetch".to_string(), None).await.unwrap();
                                 }
                             }
                         }
                     }
 
-                    let date_to_use = find_date_to_use("http://files.tmdb.org/p/exports/person_ids_{}.json.gz").await.unwrap();
+                    let date_to_use =
+                        find_date_to_use("http://files.tmdb.org/p/exports/person_ids_{}.json.gz")
+                            .await
+                            .unwrap();
                     // grab the Person id's
                     let fetch_result_person =
                         mk_lib_network::mk_lib_network::mk_network_download_file_to_vec(
@@ -204,23 +218,28 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 "http://files.tmdb.org/p/exports/person_ids_{}.json.gz",
                                 date_to_use
                             )
-                            .replace("\"", "")
+                            .replace("\"", ""),
                         )
                         .await
                         .unwrap();
                     let json_result =
-                        mk_lib_compression::mk_lib_compression::mk_decompress_gz_bytes(fetch_result_person)
-                            .await
-                            .unwrap();
+                        mk_lib_compression::mk_lib_compression::mk_decompress_gz_bytes(
+                            fetch_result_person,
+                        )
+                        .await
+                        .unwrap();
                     let mut record_count = 0;
-                    for json_item in json_result.split('\n') {
+                    for json_item in json_result.lines() {
                         if !json_item.trim().is_empty() {
                             let metadata_struct: MetadataPerson =
                                 serde_json::from_str(json_item.trim()).unwrap();
+                            let Some(metadata_id) = metadata_struct.id else {
+                                continue;
+                            };
                             let result =
                                 mk_lib_database::database_metadata::mk_lib_database_metadata_person::mk_lib_database_metadata_exists_person(
                                     &sqlx_pool_rw,
-                                    metadata_struct.id.unwrap_or(0),
+                                    metadata_id,
                                 )
                                 .await
                                 .unwrap();
@@ -228,7 +247,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 let download_result = mk_lib_database::database_metadata::mk_lib_database_metadata_download_queue::mk_lib_database_metadata_download_queue_exists(&sqlx_pool_rw,
                                                                                                                               "themoviedb".to_string(),
                                                                                                                               mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::PERSON,
-                                                                                                                              metadata_struct.id.unwrap_or(0)).await.unwrap();
+                                                                                                                              metadata_id).await.unwrap();
                                 if download_result == false {
                                     record_count += 1;
                                     if record_count > record_limit {
@@ -238,7 +257,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                                                                             "themoviedb".to_string(),
                                                                                                             mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::PERSON,
                                                                                                             uuid::Uuid::now_v7(),
-                                                                                                            metadata_struct.id,
+                                                                                                            Some(metadata_id),
                                                                                                             "Fetch".to_string(), None).await.unwrap();
                                 }
                             }


### PR DESCRIPTION
### Motivation
- Reduce allocation and control-flow overhead when locating TMDB export dates and processing large bulk files. 
- Ensure bulk mode behaves sensibly when no `Limit` is provided and avoid enqueuing invalid records.

### Description
- Streamlined date lookup in `find_date_to_use` to return immediately when a valid export URL is found and removed unnecessary cloning. 
- Defaulted `record_limit` to `i64::MAX` when `Limit` is absent so bulk runs are not inadvertently capped at zero. 
- Replaced `split('\n')` with `.lines()` for lower overhead and switched to early-skipping records with missing IDs using `let Some(metadata_id) = metadata_struct.id else { continue };`. 
- Reused the parsed `metadata_id` for existence checks and inserts (replacing repeated `unwrap_or(0)` usage) to avoid redundant parsing and make intent explicit. 
- Modified file: `docker/core/mktmdbnetfetchbulk/src/main.rs`.

### Testing
- Ran `rustfmt --edition 2021 docker/core/mktmdbnetfetchbulk/src/main.rs` which completed successfully. 
- `cargo check --manifest-path docker/core/mktmdbnetfetchbulk/Cargo.toml` could not be completed in this environment due to missing private registry configuration (`kellnr`). 
- `cargo clippy --manifest-path docker/core/mktmdbnetfetchbulk/Cargo.toml -- -D warnings` could not be completed in this environment due to the same private registry issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a50525c2108321ba4c02f2096c4671)