### PR TITLE
Add Schedules Direct Rust client library module

### DIFF
--- a/src/mk_lib_network/src/lib.rs
+++ b/src/mk_lib_network/src/lib.rs
@@ -11,6 +11,7 @@ pub mod mk_lib_network_mediakraken;
 pub mod mk_lib_network_openweather;
 pub mod mk_lib_network_ping;
 pub mod mk_lib_network_rss;
+pub mod mk_lib_network_schedules_direct;
 pub mod mk_lib_network_serial;
 pub mod mk_lib_network_share;
 pub mod mk_lib_network_speedtest;

--- a/src/mk_lib_network/src/mk_lib_network_schedules_direct.rs
+++ b/src/mk_lib_network/src/mk_lib_network_schedules_direct.rs
@@ -1,0 +1,170 @@
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fmt::{Display, Formatter};
+
+const SCHEDULES_DIRECT_API_BASE: &str = "https://json.schedulesdirect.org/20141201";
+
+#[derive(Debug)]
+pub enum SchedulesDirectError {
+    Http(reqwest::Error),
+    Api { status: StatusCode, message: String },
+    AuthenticationTokenMissing,
+}
+
+impl Display for SchedulesDirectError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http(err) => write!(f, "http error: {err}"),
+            Self::Api { status, message } => {
+                write!(f, "schedules direct api error ({status}): {message}")
+            }
+            Self::AuthenticationTokenMissing => {
+                write!(f, "schedules direct token response did not contain a token")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SchedulesDirectError {}
+
+impl From<reqwest::Error> for SchedulesDirectError {
+    fn from(value: reqwest::Error) -> Self {
+        Self::Http(value)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SchedulesDirectClient {
+    http_client: reqwest::Client,
+    base_url: String,
+    token: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SchedulesDirectStatus {
+    #[serde(rename = "systemStatus")]
+    pub system_status: Vec<SchedulesDirectSystemStatus>,
+    #[serde(flatten)]
+    pub extra: Value,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SchedulesDirectSystemStatus {
+    pub date: String,
+    pub status: String,
+    pub message: Option<String>,
+    #[serde(flatten)]
+    pub extra: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct SchedulesDirectLoginRequest<'a> {
+    username: &'a str,
+    password: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct SchedulesDirectTokenResponse {
+    token: Option<String>,
+}
+
+impl SchedulesDirectClient {
+    pub async fn login(username: &str, password: &str) -> Result<Self, SchedulesDirectError> {
+        let http_client = reqwest::Client::builder()
+            .user_agent("MediaKraken")
+            .build()?;
+        let login_payload = SchedulesDirectLoginRequest { username, password };
+
+        let response = http_client
+            .post(format!("{SCHEDULES_DIRECT_API_BASE}/token"))
+            .json(&login_payload)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let message = response.text().await.unwrap_or_default();
+            return Err(SchedulesDirectError::Api { status, message });
+        }
+
+        let token_response = response.json::<SchedulesDirectTokenResponse>().await?;
+        let token = token_response
+            .token
+            .ok_or(SchedulesDirectError::AuthenticationTokenMissing)?;
+
+        Ok(Self {
+            http_client,
+            base_url: SCHEDULES_DIRECT_API_BASE.to_string(),
+            token,
+        })
+    }
+
+    pub async fn status(&self) -> Result<SchedulesDirectStatus, SchedulesDirectError> {
+        self.get_json("status").await
+    }
+
+    pub async fn lineups(&self) -> Result<Value, SchedulesDirectError> {
+        self.get_json("lineups").await
+    }
+
+    pub async fn lineup_channel_map(&self, lineup: &str) -> Result<Value, SchedulesDirectError> {
+        self.get_json(&format!("lineups/{lineup}")).await
+    }
+
+    pub async fn schedules_by_station_ids(
+        &self,
+        station_ids: &[String],
+    ) -> Result<Value, SchedulesDirectError> {
+        self.post_json("schedules", station_ids).await
+    }
+
+    pub async fn program_details(
+        &self,
+        program_ids: &[String],
+    ) -> Result<Value, SchedulesDirectError> {
+        self.post_json("programs", program_ids).await
+    }
+
+    async fn get_json<T: for<'de> Deserialize<'de>>(
+        &self,
+        path: &str,
+    ) -> Result<T, SchedulesDirectError> {
+        let response = self
+            .http_client
+            .get(format!("{}/{}", self.base_url, path))
+            .header("token", &self.token)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let message = response.text().await.unwrap_or_default();
+            return Err(SchedulesDirectError::Api { status, message });
+        }
+
+        Ok(response.json::<T>().await?)
+    }
+
+    async fn post_json<TReq: Serialize, TResp: for<'de> Deserialize<'de>>(
+        &self,
+        path: &str,
+        payload: &TReq,
+    ) -> Result<TResp, SchedulesDirectError> {
+        let response = self
+            .http_client
+            .post(format!("{}/{}", self.base_url, path))
+            .header("token", &self.token)
+            .json(payload)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let message = response.text().await.unwrap_or_default();
+            return Err(SchedulesDirectError::Api { status, message });
+        }
+
+        Ok(response.json::<TResp>().await?)
+    }
+}

--- a/src/mk_lib_network/src/mk_lib_network_schedules_direct.rs
+++ b/src/mk_lib_network/src/mk_lib_network_schedules_direct.rs
@@ -34,11 +34,20 @@ impl From<reqwest::Error> for SchedulesDirectError {
     }
 }
 
-#[derive(Debug, Clone)]
 pub struct SchedulesDirectClient {
     http_client: reqwest::Client,
-    base_url: String,
+    base_url: &'static str,
     token: String,
+}
+
+impl std::fmt::Debug for SchedulesDirectClient {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SchedulesDirectClient")
+            .field("http_client", &self.http_client)
+            .field("base_url", &self.base_url)
+            .field("token", &"REDACTED")
+            .finish()
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -95,7 +104,7 @@ impl SchedulesDirectClient {
 
         Ok(Self {
             http_client,
-            base_url: SCHEDULES_DIRECT_API_BASE.to_string(),
+            base_url: SCHEDULES_DIRECT_API_BASE,
             token,
         })
     }


### PR DESCRIPTION
### Motivation

- Provide a small, reusable client for the Schedules Direct JSON API to centralize login/token handling and reduce duplicated HTTP code.
- Expose common API operations (status, lineups, channel maps, schedules and program details) for other parts of the codebase to consume.

### Description

- Add a new module at `src/mk_lib_network/src/mk_lib_network_schedules_direct.rs` that implements `SchedulesDirectClient` with `login`, `status`, `lineups`, `lineup_channel_map`, `schedules_by_station_ids`, and `program_details` methods.
- Introduce a focused `SchedulesDirectError` enum to represent HTTP, API response, and missing-token errors instead of panics.
- Implement authenticated helpers `get_json` and `post_json` used by the high-level methods.
- Export the module from `src/mk_lib_network/src/lib.rs` by adding `pub mod mk_lib_network_schedules_direct;` so it is available to the workspace.

### Testing

- Ran `cargo fmt` in `src/mk_lib_network` and formatting completed successfully.
- Attempted `cargo check` in `src/mk_lib_network`, but dependency resolution failed due to the environment’s configured registry endpoint returning HTTP 403, so full type-checked compilation could not be completed here.
- Attempted `cargo clippy -- -D warnings` in `src/mk_lib_network`, but it could not run to completion for the same external registry HTTP 403 error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a50547cba4832192947a53924e1398)