### PR TITLE
Normalize SQL string literals and tidy sqlx imports across database crate

### DIFF
--- a/src/mk_lib_database/src/media/mk_lib_database_media_adult.rs
+++ b/src/mk_lib_database/src/media/mk_lib_database_media_adult.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
+use sqlx::FromRow;
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
 pub struct DBMediaAdultList {
@@ -15,14 +15,14 @@ pub async fn mk_lib_database_media_adult_read(
     limit: i64,
 ) -> Result<Vec<DBMediaAdultList>, sqlx::Error> {
     if !search_value.is_empty() {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(search_value)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)
             .await
     } else {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)
@@ -35,13 +35,13 @@ pub async fn mk_lib_database_media_adult_count(
     search_value: String,
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
-        let row: (i64,) = sqlx::query_as("")
+        let row: (i64,) = sqlx::query_as(r#""#)
             .bind(search_value)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("").fetch_one(sqlx_pool).await?;
+        let row: (i64,) = sqlx::query_as(r#""#).fetch_one(sqlx_pool).await?;
         Ok(row.0)
     }
 }

--- a/src/mk_lib_database/src/media/mk_lib_database_media_anime.rs
+++ b/src/mk_lib_database/src/media/mk_lib_database_media_anime.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
+use sqlx::FromRow;
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
 pub struct DBMediaAnimeList {
@@ -15,14 +15,14 @@ pub async fn mk_lib_database_media_anime_read(
     limit: i64,
 ) -> Result<Vec<DBMediaAnimeList>, sqlx::Error> {
     if !search_value.is_empty() {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(search_value)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)
             .await
     } else {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)
@@ -35,13 +35,13 @@ pub async fn mk_lib_database_media_anime_count(
     search_value: String,
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
-        let row: (i64,) = sqlx::query_as("")
+        let row: (i64,) = sqlx::query_as(r#""#)
             .bind(search_value)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("").fetch_one(sqlx_pool).await?;
+        let row: (i64,) = sqlx::query_as(r#""#).fetch_one(sqlx_pool).await?;
         Ok(row.0)
     }
 }

--- a/src/mk_lib_database/src/media/mk_lib_database_media_game.rs
+++ b/src/mk_lib_database/src/media/mk_lib_database_media_game.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_media_game_clone_read(
     sqlx_pool: &sqlx::PgPool,
@@ -57,14 +57,14 @@ pub async fn mk_lib_database_media_game_read(
     limit: i64,
 ) -> Result<Vec<DBMediaGameList>, sqlx::Error> {
     if !search_value.is_empty() {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(search_value)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)
             .await
     } else {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)
@@ -77,7 +77,7 @@ pub async fn mk_lib_database_media_game_count(
     search_value: String,
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
-        let row: (i64,) = sqlx::query_as("")
+        let row: (i64,) = sqlx::query_as(r#""#)
             .bind(search_value)
             .fetch_one(sqlx_pool)
             .await?;

--- a/src/mk_lib_database/src/media/mk_lib_database_media_home_media.rs
+++ b/src/mk_lib_database/src/media/mk_lib_database_media_home_media.rs
@@ -1,7 +1,7 @@
 use mk_lib_common::mk_lib_common_enum_media_type;
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
+use sqlx::FromRow;
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
 pub struct DBMediaHomeMediaList {
@@ -16,14 +16,14 @@ pub async fn mk_lib_database_media_home_media_read(
     limit: i64,
 ) -> Result<Vec<DBMediaHomeMediaList>, sqlx::Error> {
     if !search_value.is_empty() {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(search_value)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)
             .await
     } else {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)

--- a/src/mk_lib_database/src/media/mk_lib_database_media_iradio.rs
+++ b/src/mk_lib_database/src/media/mk_lib_database_media_iradio.rs
@@ -51,13 +51,13 @@ pub async fn mk_lib_database_media_iradio_count(sqlx_pool: &sqlx::PgPool,
                                                   search_value: String)
                                                   -> Result<i32, sqlx::Error> {
     if !search_value.is_empty() {
-        let row: (i32, ) = sqlx::query("")
+        let row: (i32, ) = sqlx::query(r#""#)
             .bind(search_value)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
     } else {
-        let row: (i32, ) = sqlx::query("")
+        let row: (i32, ) = sqlx::query(r#""#)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)

--- a/src/mk_lib_database/src/media/mk_lib_database_media_movie.rs
+++ b/src/mk_lib_database/src/media/mk_lib_database_media_movie.rs
@@ -1,8 +1,8 @@
 use mk_lib_common::mk_lib_common_enum_media_type;
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_media_movie_genre_count(
     sqlx_pool: &sqlx::PgPool,
@@ -52,14 +52,14 @@ pub async fn mk_lib_database_media_movie_read(
     limit: i64,
 ) -> Result<Vec<DBMediaMovieList>, sqlx::Error> {
     if !search_value.is_empty() {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(search_value)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)
             .await
     } else {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)
@@ -72,13 +72,13 @@ pub async fn mk_lib_database_media_movie_count(
     search_value: String,
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
-        let row: (i64,) = sqlx::query_as("")
+        let row: (i64,) = sqlx::query_as(r#""#)
             .bind(search_value)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("").fetch_one(sqlx_pool).await?;
+        let row: (i64,) = sqlx::query_as(r#""#).fetch_one(sqlx_pool).await?;
         Ok(row.0)
     }
 }

--- a/src/mk_lib_database/src/media/mk_lib_database_media_music_video.rs
+++ b/src/mk_lib_database/src/media/mk_lib_database_media_music_video.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
+use sqlx::FromRow;
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
 pub struct DBMediaMusicVideoList {
@@ -14,14 +14,14 @@ pub async fn mk_lib_database_media_music_video_read(
     limit: i64,
 ) -> Result<Vec<DBMediaMusicVideoList>, sqlx::Error> {
     if !search_value.is_empty() {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(search_value)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)
             .await
     } else {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)

--- a/src/mk_lib_database/src/media/mk_lib_database_media_sports.rs
+++ b/src/mk_lib_database/src/media/mk_lib_database_media_sports.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
+use sqlx::FromRow;
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
 pub struct DBMediaSportsList {
@@ -14,14 +14,14 @@ pub async fn mk_lib_database_media_sports_read(
     limit: i64,
 ) -> Result<Vec<DBMediaSportsList>, sqlx::Error> {
     if !search_value.is_empty() {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(search_value)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)
             .await
     } else {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)
@@ -34,13 +34,13 @@ pub async fn mk_lib_database_media_sports_count(
     search_value: String,
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
-        let row: (i64,) = sqlx::query_as("")
+        let row: (i64,) = sqlx::query_as(r#""#)
             .bind(search_value)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("").fetch_one(sqlx_pool).await?;
+        let row: (i64,) = sqlx::query_as(r#""#).fetch_one(sqlx_pool).await?;
         Ok(row.0)
     }
 }

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata.rs
@@ -12,10 +12,7 @@ pub async fn mk_lib_database_metadata_genre_count_read(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<DBMetadataGenreCountList>, sqlx::Error> {
     let table_rows: Vec<DBMetadataGenreCountList> = sqlx::query_as(
-        "select \
-        jsonb_array_elements_text(mm_metadata_json->'genres')b as genre, \
-        count(mm_metadata_json->'genres') as mm_count from mm_metadata_movie group by genre \
-        order by jsonb_array_elements_text(mm_metadata_json->'genres')b",
+        r#"select jsonb_array_elements_text(mm_metadata_json->'genres')b as genre, count(mm_metadata_json->'genres') as mm_count from mm_metadata_movie group by genre order by jsonb_array_elements_text(mm_metadata_json->'genres')b"#,
     )
     .fetch_all(sqlx_pool)
     .await?;
@@ -33,9 +30,7 @@ pub async fn mk_lib_database_metadata_genre_read(
     limit: i64,
 ) -> Result<Vec<DBMetadataGenreList>, sqlx::Error> {
     let table_rows: Vec<DBMetadataGenreList> = sqlx::query_as(
-        "select distinct \
-        jsonb_array_elements_text(mm_metadata_json->'genres')b as genre from mm_metadata_movie \
-        order by jsonb_array_elements_text(mm_metadata_json->'genres')b offset $1 limit $2",
+        r#"select distinct jsonb_array_elements_text(mm_metadata_json->'genres')b as genre from mm_metadata_movie order by jsonb_array_elements_text(mm_metadata_json->'genres')b offset $1 limit $2"#,
     )
     .bind(offset)
     .bind(limit)
@@ -48,8 +43,7 @@ pub async fn mk_lib_database_metadata_genre_count(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<i64, sqlx::Error> {
     let row: (i64,) = sqlx::query_as(
-        "select distinct jsonb_array_elements_text(mm_metadata_json->'genres')b \
-        from mm_metadata_movie",
+        r#"select distinct jsonb_array_elements_text(mm_metadata_json->'genres')b from mm_metadata_movie"#,
     )
     .fetch_one(sqlx_pool)
     .await?;

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_adult.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_adult.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
+use sqlx::FromRow;
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
 pub struct DBMetadataAdultList {
@@ -15,14 +15,14 @@ pub async fn mk_lib_database_metadata_adult_read(
     limit: i64,
 ) -> Result<Vec<DBMetadataAdultList>, sqlx::Error> {
     if !search_value.is_empty() {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(search_value)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)
             .await
     } else {
-        sqlx::query_as("")
+        sqlx::query_as(r#""#)
             .bind(offset)
             .bind(limit)
             .fetch_all(sqlx_pool)
@@ -35,13 +35,13 @@ pub async fn mk_lib_database_metadata_adult_count(
     search_value: String,
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
-        let row: (i64,) = sqlx::query_as("")
+        let row: (i64,) = sqlx::query_as(r#""#)
             .bind(search_value)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("").fetch_one(sqlx_pool).await?;
+        let row: (i64,) = sqlx::query_as(r#""#).fetch_one(sqlx_pool).await?;
         Ok(row.0)
     }
 }

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_game.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_game.rs
@@ -1,16 +1,14 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_metadata_game_detail(
     sqlx_pool: &sqlx::PgPool,
     game_uuid: String,
 ) -> Result<(uuid::Uuid, serde_json::Value), sqlx::Error> {
     let row: (uuid::Uuid, serde_json::Value) = sqlx::query_as(
-        "select \
-        gi_game_info_system_id, gi_game_info_json \
-        from mm_metadata_game_software_info where gi_game_info_id = $1",
+        r#"select gi_game_info_system_id, gi_game_info_json from mm_metadata_game_software_info where gi_game_info_id = $1"#,
     )
     .bind(game_uuid)
     .fetch_one(sqlx_pool)
@@ -23,9 +21,7 @@ pub async fn mk_lib_database_metadata_game_by_sha1(
     sha1_hash: String,
 ) -> Result<uuid::Uuid, sqlx::Error> {
     let row: (uuid::Uuid,) = sqlx::query_as(
-        "select gi_game_info_id \
-        from mm_metadata_game_software_info \
-        where gi_game_info_sha1 = $1",
+        r#"select gi_game_info_id from mm_metadata_game_software_info where gi_game_info_sha1 = $1"#,
     )
     .bind(sha1_hash)
     .fetch_one(sqlx_pool)
@@ -38,9 +34,7 @@ pub async fn mk_lib_database_metadata_game_by_blake3(
     blake3_hash: String,
 ) -> Result<uuid::Uuid, sqlx::Error> {
     let row: (uuid::Uuid,) = sqlx::query_as(
-        "select gi_game_info_id \
-        from mm_metadata_game_software_info \
-        where gi_game_info_blake3 = $1",
+        r#"select gi_game_info_id from mm_metadata_game_software_info where gi_game_info_blake3 = $1"#,
     )
     .bind(blake3_hash)
     .fetch_one(sqlx_pool)
@@ -54,15 +48,14 @@ pub async fn mk_lib_database_metadata_game_count(
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
         let row: (i64,) = sqlx::query_as(
-            "select count(*) from mm_metadata_game_software_info \
-            where gi_game_info_name &@ $1",
+            r#"select count(*) from mm_metadata_game_software_info where gi_game_info_name &@ $1"#,
         )
         .bind(search_value)
         .fetch_one(sqlx_pool)
         .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("select count(*) from mm_metadata_game_software_info")
+        let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_metadata_game_software_info"#)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
@@ -87,13 +80,7 @@ pub async fn mk_lib_database_metadata_game_read(
 ) -> Result<Vec<DBMetaGameList>, sqlx::Error> {
     if !search_value.is_empty() {
         sqlx::query_as(
-            "select gi_game_info_id, gi_game_info_short_name, \
-             gi_game_info_name, \
-             gi_game_info_json->'machine'->>'year' as gi_year, \
-             gi_game_info_localimage, gs_game_system_name \
-             from mm_metadata_game_software_info, mm_metadata_game_systems_info \
-             where gi_game_info_system_id = gs_game_system_id and gi_game_info_name &@ $1 \
-             offset $2 limit $3",
+            r#"select gi_game_info_id, gi_game_info_short_name, gi_game_info_name, gi_game_info_json->'machine'->>'year' as gi_year, gi_game_info_localimage, gs_game_system_name from mm_metadata_game_software_info, mm_metadata_game_systems_info where gi_game_info_system_id = gs_game_system_id and gi_game_info_name &@ $1 offset $2 limit $3"#,
         )
         .bind(search_value)
         .bind(offset)
@@ -102,13 +89,7 @@ pub async fn mk_lib_database_metadata_game_read(
         .await
     } else {
         sqlx::query_as(
-            "select gi_game_info_id, gi_game_info_short_name, \
-            gi_game_info_name, \
-            gi_game_info_json->'machine'->>'year' as gi_year, \
-            gi_game_info_localimage, gs_game_system_name \
-            from mm_metadata_game_software_info, mm_metadata_game_systems_info \
-            where gi_game_info_system_id = gs_game_system_id order by gi_game_info_name, gi_year \
-            offset $1 limit $2",
+            r#"select gi_game_info_id, gi_game_info_short_name, gi_game_info_name, gi_game_info_json->'machine'->>'year' as gi_year, gi_game_info_localimage, gs_game_system_name from mm_metadata_game_software_info, mm_metadata_game_systems_info where gi_game_info_system_id = gs_game_system_id order by gi_game_info_name, gi_year offset $1 limit $2"#,
         )
         .bind(offset)
         .bind(limit)
@@ -124,9 +105,7 @@ pub async fn mk_lib_database_metadata_game_uuid_by_name_and_system(
 ) -> Result<uuid::Uuid, sqlx::Error> {
     if game_system_short_name != "" {
         let row: (uuid::Uuid,) = sqlx::query_as(
-            "select gi_id \
-            from mm_metadata_game_software_info \
-            where gi_game_info_name = $1 and game_system_short_name = $2 limit 1",
+            r#"select gi_id from mm_metadata_game_software_info where gi_game_info_name = $1 and game_system_short_name = $2 limit 1"#,
         )
         .bind(game_name)
         .bind(game_system_short_name)
@@ -135,9 +114,7 @@ pub async fn mk_lib_database_metadata_game_uuid_by_name_and_system(
         Ok(row.0)
     } else {
         let row: (uuid::Uuid,) = sqlx::query_as(
-            "select gi_id \
-            from mm_metadata_game_software_info \
-            where gi_game_info_name = $1 and gi_game_info_system_id IS NULL limit 1",
+            r#"select gi_id from mm_metadata_game_software_info where gi_game_info_name = $1 and gi_game_info_system_id IS NULL limit 1"#,
         )
         .bind(game_name)
         .fetch_one(sqlx_pool)
@@ -162,9 +139,7 @@ pub async fn mk_lib_database_metadata_game_by_name_and_system(
     if game_system_short_name != "" {
         // TODO fix game_system_short_name in query below
         sqlx::query_as(
-            "select gi_id, gi_game_info_json \
-            from mm_metadata_game_software_info \
-            where gi_game_info_name = $1 and game_system_short_name = $2",
+            r#"select gi_id, gi_game_info_json from mm_metadata_game_software_info where gi_game_info_name = $1 and game_system_short_name = $2"#,
         )
         .bind(game_name)
         .bind(game_system_short_name)
@@ -174,9 +149,7 @@ pub async fn mk_lib_database_metadata_game_by_name_and_system(
         .await
     } else {
         sqlx::query_as(
-            "select gi_id, gi_game_info_json \
-            from mm_metadata_game_software_info \
-            where gi_game_info_name = $1 and gi_game_info_system_id IS NULL",
+            r#"select gi_id, gi_game_info_json from mm_metadata_game_software_info where gi_game_info_name = $1 and gi_game_info_system_id IS NULL"#,
         )
         .bind(game_name)
         .bind(offset)
@@ -196,12 +169,7 @@ pub async fn mk_lib_database_metadata_game_insert(
     let new_guid = uuid::Uuid::now_v7();
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_metadata_game_software_info(gi_game_info_id, \
-        gi_game_info_system_id, \
-        gi_game_info_short_name, \
-        gi_game_info_name, \
-        gi_game_info_json) \
-        values ($1, $2, $3, $4, $5)",
+        r#"insert into mm_metadata_game_software_info(gi_game_info_id, gi_game_info_system_id, gi_game_info_short_name, gi_game_info_name, gi_game_info_json) values ($1, $2, $3, $4, $5)"#,
     )
     .bind(new_guid)
     .bind(game_system_id)
@@ -319,8 +287,8 @@ pub async fn mk_lib_database_metadata_game_category_insert(
     let new_guid = uuid::Uuid::now_v7();
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_game_category (gc_id, gc_category)
-        values ($1, $2)",
+        r#"insert into mm_game_category (gc_id, gc_category)
+        values ($1, $2)"#,
     )
     .bind(new_guid)
     .bind(category_name)

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_game_system.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_game_system.rs
@@ -1,15 +1,14 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_metadata_game_system_detail(
     sqlx_pool: &sqlx::PgPool,
     game_sys_uuid: Uuid,
 ) -> Result<serde_json::Value, sqlx::Error> {
     let row: (serde_json::Value,) = sqlx::query_as(
-        "select gs_game_system_json from mm_metadata_game_systems_info \
-        where gs_id = $1",
+        r#"select gs_game_system_json from mm_metadata_game_systems_info where gs_id = $1"#,
     )
     .bind(game_sys_uuid)
     .fetch_one(sqlx_pool)
@@ -23,15 +22,14 @@ pub async fn mk_lib_database_metadata_game_system_count(
 ) -> Result<i64, sqlx::Error> {
     if search_value != String::new() {
         let row: (i64,) = sqlx::query_as(
-            "select count(*) from mm_metadata_game_systems_info \
-            where gs_game_system_name &@ $1",
+            r#"select count(*) from mm_metadata_game_systems_info where gs_game_system_name &@ $1"#,
         )
         .bind(search_value)
         .fetch_one(sqlx_pool)
         .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("select count(*) from mm_metadata_game_systems_info")
+        let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_metadata_game_systems_info"#)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
@@ -56,12 +54,7 @@ pub async fn mk_lib_database_metadata_game_system_read(
     // TODO might need to sort by release year as well for machines with multiple releases
     if search_value != String::new() {
         sqlx::query_as(
-            "select gs_game_system_id, gs_game_system_name, \
-            gs_game_system_json->>'description' as gs_description, \
-            gs_game_system_json->>'year' as gs_year, \
-            gs_game_system_alias from mm_metadata_game_systems_info \
-            where gs_game_system_name &@ $1 \
-            offset $2 limit $3",
+            r#"select gs_game_system_id, gs_game_system_name, gs_game_system_json->>'description' as gs_description, gs_game_system_json->>'year' as gs_year, gs_game_system_alias from mm_metadata_game_systems_info where gs_game_system_name &@ $1 offset $2 limit $3"#,
         )
         .bind(search_value)
         .bind(offset)
@@ -70,11 +63,7 @@ pub async fn mk_lib_database_metadata_game_system_read(
         .await
     } else {
         sqlx::query_as(
-            "select gs_game_system_id, gs_game_system_name, \
-            gs_game_system_json->>'description' as gs_description, \
-            gs_game_system_json->>'year' as gs_year, \
-            gs_game_system_alias from mm_metadata_game_systems_info \
-            order by gs_game_system_json->'description' offset $1 limit $2",
+            r#"select gs_game_system_id, gs_game_system_name, gs_game_system_json->>'description' as gs_description, gs_game_system_json->>'year' as gs_year, gs_game_system_alias from mm_metadata_game_systems_info order by gs_game_system_json->'description' offset $1 limit $2"#,
         )
         .bind(offset)
         .bind(limit)
@@ -92,14 +81,7 @@ pub async fn mk_lib_database_metadata_game_system_upsert(
     let new_guid = uuid::Uuid::now_v7();
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "INSERT INTO mm_metadata_game_systems_info \
-        (gs_game_system_id, \
-        gs_game_system_name, \
-        gs_game_system_alias, \
-        gs_game_system_json) \
-        VALUES ($1, $2, $3, $4) \
-        ON CONFLICT (gs_game_system_name) \
-        DO UPDATE SET gs_game_system_alias = $5, gs_game_system_json = $6",
+        r#"INSERT INTO mm_metadata_game_systems_info (gs_game_system_id, gs_game_system_name, gs_game_system_alias, gs_game_system_json) VALUES ($1, $2, $3, $4) ON CONFLICT (gs_game_system_name) DO UPDATE SET gs_game_system_alias = $5, gs_game_system_json = $6"#,
     )
     .bind(new_guid)
     .bind(system_name)
@@ -118,9 +100,7 @@ pub async fn mk_lib_database_metadata_game_system_guid_by_short_name(
     game_system_short_name: &String,
 ) -> Result<Uuid, sqlx::Error> {
     let row: (Uuid,) = sqlx::query_as(
-        "select gs_game_system_id \
-        from mm_metadata_game_systems_info \
-        where gs_game_system_name = $1",
+        r#"select gs_game_system_id from mm_metadata_game_systems_info where gs_game_system_name = $1"#,
     )
     .bind(game_system_short_name)
     .fetch_one(sqlx_pool)
@@ -134,9 +114,7 @@ pub async fn mk_lib_database_metadata_game_system_game_count_by_short_name(
 ) -> Result<i64, sqlx::Error> {
     // TODO this query doesn't return game count.......
     let row: (i64,) = sqlx::query_as(
-        "select count(*) \
-        from mm_metadata_game_systems_info \
-        where gs_game_system_name = $1",
+        r#"select count(*) from mm_metadata_game_systems_info where gs_game_system_name = $1"#,
     )
     .bind(game_system_short_name)
     .fetch_one(sqlx_pool)

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs
@@ -1,18 +1,17 @@
 use crate::mk_lib_database::MediaStatusUpdatePayload;
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
-use sqlx::types::Uuid;
 use sqlx::types::chrono::DateTime;
 use sqlx::types::chrono::Utc;
+use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_metadata_exists_movie(
     sqlx_pool: &sqlx::PgPool,
     metadata_id: i32,
 ) -> Result<bool, sqlx::Error> {
     let row: (bool,) = sqlx::query_as(
-        "select exists(select 1 from mm_metadata_movie \
-        where mm_metadata_movie_media_id = $1 limit 1) as found_record limit 1",
+        r#"select exists(select 1 from mm_metadata_movie where mm_metadata_movie_media_id = $1 limit 1) as found_record limit 1"#,
     )
     .bind(metadata_id)
     .fetch_one(sqlx_pool)
@@ -109,15 +108,14 @@ pub async fn mk_lib_database_metadata_movie_count(
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
         let row: (i64,) = sqlx::query_as(
-            "select count(*) from mm_metadata_movie \
-            where mm_metadata_movie_name &@ $1",
+            r#"select count(*) from mm_metadata_movie where mm_metadata_movie_name &@ $1"#,
         )
         .bind(search_value)
         .fetch_one(sqlx_pool)
         .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("select count(*) from mm_metadata_movie")
+        let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_metadata_movie"#)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
@@ -137,13 +135,7 @@ pub async fn mk_lib_database_metadata_movie_insert(
     }
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_metadata_movie (mm_metadata_movie_guid, \
-        mm_metadata_movie_media_id, \
-        mm_metadata_movie_name, \
-        mm_metadata_movie_name_alt, \
-        mm_metadata_movie_json, \
-        mm_metadata_movie_localimage_json) \
-        values ($1,$2,$3,$4,$5,$6)",
+        r#"insert into mm_metadata_movie (mm_metadata_movie_guid, mm_metadata_movie_media_id, mm_metadata_movie_name, mm_metadata_movie_name_alt, mm_metadata_movie_json, mm_metadata_movie_localimage_json) values ($1,$2,$3,$4,$5,$6)"#,
     )
     .bind(uuid_id)
     .bind(series_id)
@@ -162,7 +154,7 @@ pub async fn mk_lib_database_metadata_movie_guid_by_tmdb(
     uuid_id: Uuid,
 ) -> Result<uuid::Uuid, sqlx::Error> {
     let row: (uuid::Uuid,) = sqlx::query_as(
-        "select mm_metadata_guid from mm_metadata_movie where mm_metadata_movie_media_id = $1",
+        r#"select mm_metadata_guid from mm_metadata_movie where mm_metadata_movie_media_id = $1"#,
     )
     .bind(uuid_id)
     .fetch_one(sqlx_pool)

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_music.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_music.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
+use sqlx::FromRow;
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
 pub struct DBMetaMusicList {
@@ -17,15 +17,14 @@ pub async fn mk_lib_database_metadata_music_count(
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
         let row: (i64,) = sqlx::query_as(
-            "select count(*) from mm_mtadata_album \
-            where mm_metadata_album_name &@ $1",
+            r#"select count(*) from mm_mtadata_album where mm_metadata_album_name &@ $1"#,
         )
         .bind(search_value)
         .fetch_one(sqlx_pool)
         .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("select count(*) from mm_metadata_album")
+        let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_metadata_album"#)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
@@ -42,11 +41,7 @@ pub async fn mk_lib_database_metadata_music_read(
     // TODO order by release year
     if !search_value.is_empty() {
         sqlx::query_as(
-            "select mm_metadata_album_guid, mm_metadata_album_name, \
-            mm_metadata_album_json, mm_metadata_album_localimage \
-            from mm_metadata_album where LOWER(mm_metadata_album_name) % LOWER($1) \
-            order by LOWER(mm_metadata_album_name) \
-            offset $2 limit $3",
+            r#"select mm_metadata_album_guid, mm_metadata_album_name, mm_metadata_album_json, mm_metadata_album_localimage from mm_metadata_album where LOWER(mm_metadata_album_name) % LOWER($1) order by LOWER(mm_metadata_album_name) offset $2 limit $3"#,
         )
         .bind(search_value)
         .bind(offset)
@@ -55,10 +50,7 @@ pub async fn mk_lib_database_metadata_music_read(
         .await
     } else {
         sqlx::query_as(
-            "select mm_metadata_album_guid, mm_metadata_album_name, \
-            mm_metadata_album_json, mm_metadata_album_localimage \
-            from mm_metadata_album order by LOWER(mm_metadata_album_name) \
-            offset $1 limit $2",
+            r#"select mm_metadata_album_guid, mm_metadata_album_name, mm_metadata_album_json, mm_metadata_album_localimage from mm_metadata_album order by LOWER(mm_metadata_album_name) offset $1 limit $2"#,
         )
         .bind(offset)
         .bind(limit)

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_music_brainz.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_music_brainz.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
+use sqlx::FromRow;
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
 pub struct DBMetaMusicList {
@@ -14,16 +14,13 @@ pub async fn mk_lib_database_metadata_music_album_count(
     search_value: String,
 ) -> Result<i64, sqlx::Error> {
     if search_value != String::new() {
-        let row: (i64,) = sqlx::query_as(
-            "select count(*) from release \
-            where name % $1",
-        )
-        .bind(search_value)
-        .fetch_one(sqlx_pool)
-        .await?;
+        let row: (i64,) = sqlx::query_as(r#"select count(*) from release where name % $1"#)
+            .bind(search_value)
+            .fetch_one(sqlx_pool)
+            .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("select count(*) from release")
+        let row: (i64,) = sqlx::query_as(r#"select count(*) from release"#)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
@@ -40,11 +37,7 @@ pub async fn mk_lib_database_metadata_music_album_read(
     // TODO order by release year
     if search_value != String::new() {
         sqlx::query_as(
-            "select release.id as brainz_id, release.name as brainz_name, artist.name as brainz_artist \
-            from release, artist \
-            where artist.id = artist_credit and mm_metadata_album_name % $1 \
-            order by LOWER(name) \
-            offset $2 limit $3",
+            r#"select release.id as brainz_id, release.name as brainz_name, artist.name as brainz_artist from release, artist where artist.id = artist_credit and mm_metadata_album_name % $1 order by LOWER(name) offset $2 limit $3"#,
         )
         .bind(search_value)
         .bind(offset)
@@ -53,11 +46,7 @@ pub async fn mk_lib_database_metadata_music_album_read(
             .await
     } else {
         sqlx::query_as(
-            "select release.id as brainz_id, release.name as brainz_name, artist.name as brainz_artist \
-            from release, artist \
-            where artist.id = artist_credit \
-            order by LOWER(release.name), LOWER(artist.name) \
-            offset $1 limit $2",
+            r#"select release.id as brainz_id, release.name as brainz_name, artist.name as brainz_artist from release, artist where artist.id = artist_credit order by LOWER(release.name), LOWER(artist.name) offset $1 limit $2"#,
         )
         .bind(offset)
         .bind(limit)

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_music_video.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_music_video.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
 pub struct DBMetaMusicVideoList {
@@ -19,11 +19,7 @@ pub async fn mk_lib_database_metadata_music_video_read(
 ) -> Result<Vec<DBMetaMusicVideoList>, sqlx::Error> {
     if !search_value.is_empty() {
         sqlx::query_as(
-            "select mm_metadata_music_video_guid, \
-            mm_metadata_music_video_band, \
-            mm_metadata_music_video_song, mm_metadata_music_video_localimage_json \
-            from mm_metadata_music_video where mm_metadata_music_video_song &@ $1 \
-            offset $2 limit $3",
+            r#"select mm_metadata_music_video_guid, mm_metadata_music_video_band, mm_metadata_music_video_song, mm_metadata_music_video_localimage_json from mm_metadata_music_video where mm_metadata_music_video_song &@ $1 offset $2 limit $3"#,
         )
         .bind(search_value)
         .bind(offset)
@@ -32,11 +28,7 @@ pub async fn mk_lib_database_metadata_music_video_read(
         .await
     } else {
         sqlx::query_as(
-            "select mm_metadata_music_video_guid, \
-            mm_metadata_music_video_band, \
-            mm_metadata_music_video_song, mm_metadata_music_video_localimage_json \
-            from mm_metadata_music_video order by LOWER(mm_metadata_music_video_band), \
-            LOWER(mm_metadata_music_video_song) offset $1 limit $2",
+            r#"select mm_metadata_music_video_guid, mm_metadata_music_video_band, mm_metadata_music_video_song, mm_metadata_music_video_localimage_json from mm_metadata_music_video order by LOWER(mm_metadata_music_video_band), LOWER(mm_metadata_music_video_song) offset $1 limit $2"#,
         )
         .bind(offset)
         .bind(limit)
@@ -51,10 +43,7 @@ pub async fn mk_lib_database_metadata_music_video_lookup(
     song_title: String,
 ) -> Result<uuid::Uuid, sqlx::Error> {
     let row: (Uuid,) = sqlx::query_as(
-        "select mm_metadata_music_video_guid \
-        from mm_metadata_music_video \
-        where lower(mm_media_music_video_band) = $1 \
-        and lower(mm_media_music_video_song) = $2",
+        r#"select mm_metadata_music_video_guid from mm_metadata_music_video where lower(mm_media_music_video_band) = $1 and lower(mm_media_music_video_song) = $2"#,
     )
     .bind(artist_name.to_lowercase())
     .bind(song_title.to_lowercase())
@@ -71,23 +60,21 @@ pub async fn mk_lib_database_metadata_music_video_count(
     if imvdb_id == 0 {
         if !search_value.is_empty() {
             let row: (i64,) = sqlx::query_as(
-                "select count(*) from mm_metadata_music_video \
-                where mm_media_music_video_song &@ $1",
+                r#"select count(*) from mm_metadata_music_video where mm_media_music_video_song &@ $1"#,
             )
             .bind(search_value)
             .fetch_one(sqlx_pool)
             .await?;
             Ok(row.0)
         } else {
-            let row: (i64,) = sqlx::query_as("select count(*) from mm_metadata_music_video")
+            let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_metadata_music_video"#)
                 .fetch_one(sqlx_pool)
                 .await?;
             Ok(row.0)
         }
     } else {
         let row: (i64,) = sqlx::query_as(
-            "select count(*) from mm_metadata_music_video \
-            where mm_metadata_music_video_media_id->'imvdb' ? $1",
+            r#"select count(*) from mm_metadata_music_video where mm_metadata_music_video_media_id->'imvdb' ? $1"#,
         )
         .bind(imvdb_id)
         .fetch_one(sqlx_pool)
@@ -101,10 +88,7 @@ pub async fn mk_lib_database_metadata_music_video_detail(
     music_video_uuid: String,
 ) -> Result<PgRow, sqlx::Error> {
     let row: PgRow = sqlx::query(
-        "select mm_media_music_video_band, \
-        mm_media_music_video_song, mm_metadata_music_video_json, \
-        mm_metadata_music_video_localimage_json from mm_metadata_music_video \
-        where mm_metadata_music_video_guid = $1",
+        r#"select mm_media_music_video_band, mm_media_music_video_song, mm_metadata_music_video_json, mm_metadata_music_video_localimage_json from mm_metadata_music_video where mm_metadata_music_video_guid = $1"#,
     )
     .bind(music_video_uuid)
     .fetch_one(sqlx_pool)
@@ -123,13 +107,7 @@ pub async fn mk_lib_database_metadata_music_video_insert(
     let new_guid = uuid::Uuid::now_v7();
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_metadata_music_video (mm_metadata_music_video_guid, \
-        mm_metadata_music_video_media_id, \
-        mm_media_music_video_band, \
-        mm_media_music_video_song, \
-        mm_metadata_music_video_json, \
-        mm_metadata_music_video_localimage_json) \
-        values ($1,$2,$3,$4,$5,$6)",
+        r#"insert into mm_metadata_music_video (mm_metadata_music_video_guid, mm_metadata_music_video_media_id, mm_media_music_video_band, mm_media_music_video_song, mm_metadata_music_video_json, mm_metadata_music_video_localimage_json) values ($1,$2,$3,$4,$5,$6)"#,
     )
     .bind(new_guid)
     .bind(id_json)

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_openlib.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_openlib.rs
@@ -1,14 +1,13 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_metadata_openlib_author_detail(
     sqlx_pool: &sqlx::PgPool,
     author_id: String,
 ) -> Result<serde_json::Value, sqlx::Error> {
     let row: (serde_json::Value,) = sqlx::query_as(
-        "select mm_openlib_author_json from mm_openlib_author \
-        where mm_openlib_author_id = $1",
+        r#"select mm_openlib_author_json from mm_openlib_author where mm_openlib_author_id = $1"#,
     )
     .bind(author_id)
     .fetch_one(sqlx_pool)
@@ -21,8 +20,7 @@ pub async fn mk_lib_database_metadata_openlib_edition_detail(
     edition_id: String,
 ) -> Result<serde_json::Value, sqlx::Error> {
     let row: (serde_json::Value,) = sqlx::query_as(
-        "select mm_openlib_edition_json from mm_openlib_edition \
-        where mm_openlib_edition_id = $1",
+        r#"select mm_openlib_edition_json from mm_openlib_edition where mm_openlib_edition_id = $1"#,
     )
     .bind(edition_id)
     .fetch_one(sqlx_pool)
@@ -35,8 +33,7 @@ pub async fn mk_lib_database_metadata_openlib_work_detail(
     work_id: String,
 ) -> Result<serde_json::Value, sqlx::Error> {
     let row: (serde_json::Value,) = sqlx::query_as(
-        "select mm_openlib_work_json from mm_openlib_work \
-        where mm_openlib_work_id = $1",
+        r#"select mm_openlib_work_json from mm_openlib_work where mm_openlib_work_id = $1"#,
     )
     .bind(work_id)
     .fetch_one(sqlx_pool)
@@ -59,9 +56,7 @@ pub async fn mk_lib_database_metadata_openlib_work_read(
     // TODO sort by release date
     if !search_value.is_empty() {
         sqlx::query_as(
-            "select mm_openlib_work_id, mm_openlib_work_json \
-            from mm_openlib_work where mm_metadata_book_name % $1 \
-            order by mm_openlib_work_json offset $2 limit $3",
+            r#"select mm_openlib_work_id, mm_openlib_work_json from mm_openlib_work where mm_metadata_book_name % $1 order by mm_openlib_work_json offset $2 limit $3"#,
         )
         .bind(search_value)
         .bind(offset)
@@ -70,9 +65,7 @@ pub async fn mk_lib_database_metadata_openlib_work_read(
         .await
     } else {
         sqlx::query_as(
-            "select mm_openlib_work_id, mm_openlib_work_json \
-            from mm_openlib_work order by mm_openlib_work_json \
-            offset $1 limit $2",
+            r#"select mm_openlib_work_id, mm_openlib_work_json from mm_openlib_work order by mm_openlib_work_json offset $1 limit $2"#,
         )
         .bind(offset)
         .bind(limit)
@@ -87,15 +80,14 @@ pub async fn mk_lib_database_metadata_openlib_work_count(
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
         let row: (i64,) = sqlx::query_as(
-            "select count(*) from mm_openlib_work \
-            where mm_openlib_work_json % $1",
+            r#"select count(*) from mm_openlib_work where mm_openlib_work_json % $1"#,
         )
         .bind(search_value)
         .fetch_one(sqlx_pool)
         .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("select count(*) from mm_openlib_work")
+        let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_openlib_work"#)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
@@ -108,10 +100,7 @@ pub async fn mk_lib_database_metadata_openlib_work_id_by_isbn(
     isbn13: String,
 ) -> Result<uuid::Uuid, sqlx::Error> {
     let row: (uuid::Uuid,) = sqlx::query_as(
-        "select mm_openlib_work_id \
-        from mm_openlib_work \
-        where mm_metadata_book_isbn = $1 \
-        or mm_metadata_book_isbn13 = $2",
+        r#"select mm_openlib_work_id from mm_openlib_work where mm_metadata_book_isbn = $1 or mm_metadata_book_isbn13 = $2"#,
     )
     .bind(isbn)
     .bind(isbn13)
@@ -128,10 +117,7 @@ pub async fn mk_lib_database_metadata_openlib_author_upsert(
     let json_json: serde_json::Value = serde_json::from_str(json_data).unwrap();
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_openlib_author (mm_openlib_author_id, \
-        mm_openlib_author_json) \
-        values ($1,$2) \
-        ON CONFLICT(mm_openlib_author_id) DO UPDATE SET mm_openlib_author_json = $3",
+        r#"insert into mm_openlib_author (mm_openlib_author_id, mm_openlib_author_json) values ($1,$2) ON CONFLICT(mm_openlib_author_id) DO UPDATE SET mm_openlib_author_json = $3"#,
     )
     .bind(author_id)
     .bind(&json_json)
@@ -150,10 +136,7 @@ pub async fn mk_lib_database_metadata_openlib_edition_upsert(
     let json_json: serde_json::Value = serde_json::from_str(json_data).unwrap();
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_openlib_edition (mm_openlib_edition_id, \
-        mm_openlib_edition_json) \
-        values ($1,$2) \
-        ON CONFLICT(mm_openlib_edition_id) DO UPDATE SET mm_openlib_edition_json = $3",
+        r#"insert into mm_openlib_edition (mm_openlib_edition_id, mm_openlib_edition_json) values ($1,$2) ON CONFLICT(mm_openlib_edition_id) DO UPDATE SET mm_openlib_edition_json = $3"#,
     )
     .bind(edition_id)
     .bind(&json_json)
@@ -172,10 +155,7 @@ pub async fn mk_lib_database_metadata_openlib_rating_upsert(
     let json_json: serde_json::Value = serde_json::from_str(json_data).unwrap();
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_openlib_rating (mm_openlib_rating_id, \
-        mm_openlib_rating_json) \
-        values ($1,$2) \
-        ON CONFLICT(mm_openlib_rating_id) DO UPDATE SET mm_openlib_rating_json = $3",
+        r#"insert into mm_openlib_rating (mm_openlib_rating_id, mm_openlib_rating_json) values ($1,$2) ON CONFLICT(mm_openlib_rating_id) DO UPDATE SET mm_openlib_rating_json = $3"#,
     )
     .bind(rating_id)
     .bind(&json_json)
@@ -194,10 +174,7 @@ pub async fn mk_lib_database_metadata_openlib_work_upsert(
     let json_json: serde_json::Value = serde_json::from_str(json_data).unwrap();
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_openlib_work (mm_openlib_work_id, \
-        mm_openlib_work_json) \
-        values ($1,$2) \
-        ON CONFLICT(mm_openlib_work_id) DO UPDATE SET mm_openlib_work_json = $3",
+        r#"insert into mm_openlib_work (mm_openlib_work_id, mm_openlib_work_json) values ($1,$2) ON CONFLICT(mm_openlib_work_id) DO UPDATE SET mm_openlib_work_json = $3"#,
     )
     .bind(work_id)
     .bind(&json_json)
@@ -215,9 +192,7 @@ pub async fn mk_lib_database_metadata_openlib_work_id_by_name(
     // TODO can be more than one by name
     // TODO sort by release date
     let row: (String,) = sqlx::query_as(
-        "select mm_openlib_work_id \
-        from mm_openlib_work \
-        where mm_openlib_work_json = $1",
+        r#"select mm_openlib_work_id from mm_openlib_work where mm_openlib_work_json = $1"#,
     )
     .bind(work_name)
     .fetch_one(sqlx_pool)

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_openlib_copy.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_openlib_copy.rs
@@ -26,13 +26,13 @@ pub async fn mk_lib_database_copy(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut conn = sqlx_pool.acquire().await?;
     sqlx::query(
-        "CREATE TEMPORARY TABLE mktemp_import (
+        r#"CREATE TEMPORARY TABLE mktemp_import (
             temp_type TEXT, 
             temp_key TEXT, 
             temp_revision TEXT, 
             temp_last_modified TIMESTAMP, 
             temp_json JSONB
-        ) ON COMMIT DROP;",
+        ) ON COMMIT DROP;"#,
     )
     .execute(&mut *conn)
     .await?;
@@ -51,16 +51,16 @@ pub async fn mk_lib_database_copy_author_upsert(
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "INSERT INTO mm_openlib_author (mm_openlib_author_id, mm_openlib_author_json)
+        r#"INSERT INTO mm_openlib_author (mm_openlib_author_id, mm_openlib_author_json)
         SELECT temp_key, temp_json
         FROM mktemp_import
         ON CONFLICT (mm_openlib_author_id)
         DO UPDATE SET mm_openlib_author_json = EXCLUDED.mm_openlib_author_json
-        WHERE mm_openlib_author.mm_openlib_author_json IS DISTINCT FROM EXCLUDED.mm_openlib_author_json;",
+        WHERE mm_openlib_author.mm_openlib_author_json IS DISTINCT FROM EXCLUDED.mm_openlib_author_json;"#,
     )
     .execute(&mut *transaction)
     .await?;
-    sqlx::query("truncate mktemp_import;")
+    sqlx::query(r#"truncate mktemp_import;"#)
         .execute(&mut *transaction)
         .await?;
     transaction.commit().await?;
@@ -72,16 +72,16 @@ pub async fn mk_lib_database_copy_edition_upsert(
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "INSERT INTO mm_openlib_edition (mm_openlib_edition_id, mm_openlib_edition_json)
+        r#"INSERT INTO mm_openlib_edition (mm_openlib_edition_id, mm_openlib_edition_json)
         SELECT temp_key, temp_json
         FROM mktemp_import
         ON CONFLICT (mm_openlib_edition_id)
         DO UPDATE SET mm_openlib_edition_json = EXCLUDED.mm_openlib_edition_json
-        WHERE mm_openlib_edition.mm_openlib_edition_json IS DISTINCT FROM EXCLUDED.mm_openlib_edition_json;",
+        WHERE mm_openlib_edition.mm_openlib_edition_json IS DISTINCT FROM EXCLUDED.mm_openlib_edition_json;"#,
     )
     .execute(&mut *transaction)
     .await?;
-    sqlx::query("truncate mktemp_import;")
+    sqlx::query(r#"truncate mktemp_import;"#)
         .execute(&mut *transaction)
         .await?;
     transaction.commit().await?;
@@ -91,16 +91,16 @@ pub async fn mk_lib_database_copy_edition_upsert(
 pub async fn mk_lib_database_copy_work_upsert(sqlx_pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "INSERT INTO mm_openlib_work (mm_openlib_work_id, mm_openlib_work_json)
+        r#"INSERT INTO mm_openlib_work (mm_openlib_work_id, mm_openlib_work_json)
         SELECT temp_key, temp_json
         FROM mktemp_import
         ON CONFLICT (mm_openlib_work_id)
         DO UPDATE SET mm_openlib_work_json = EXCLUDED.mm_openlib_work_json
-        WHERE mm_openlib_work.mm_openlib_work_json IS DISTINCT FROM EXCLUDED.mm_openlib_work_json;",
+        WHERE mm_openlib_work.mm_openlib_work_json IS DISTINCT FROM EXCLUDED.mm_openlib_work_json;"#,
     )
     .execute(&mut *transaction)
     .await?;
-    sqlx::query("truncate mktemp_import;")
+    sqlx::query(r#"truncate mktemp_import;"#)
         .execute(&mut *transaction)
         .await?;
     transaction.commit().await?;

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_person.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_person.rs
@@ -1,15 +1,14 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_metadata_exists_person(
     sqlx_pool: &sqlx::PgPool,
     metadata_id: i32,
 ) -> Result<bool, sqlx::Error> {
     let row: (bool,) = sqlx::query_as(
-        "select exists(select 1 from mm_metadata_person \
-        where mm_metadata_person_media_id = $1 limit 1) as found_record limit 1",
+        r#"select exists(select 1 from mm_metadata_person where mm_metadata_person_media_id = $1 limit 1) as found_record limit 1"#,
     )
     .bind(metadata_id)
     .fetch_one(sqlx_pool)
@@ -23,15 +22,14 @@ pub async fn mk_lib_database_metadata_person_count(
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
         let row: (i64,) = sqlx::query_as(
-            "select count(*) from mm_metadata_person \
-            where mm_metadata_person_name &@ $1",
+            r#"select count(*) from mm_metadata_person where mm_metadata_person_name &@ $1"#,
         )
         .bind(search_value)
         .fetch_one(sqlx_pool)
         .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("select count(*) from mm_metadata_person")
+        let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_metadata_person"#)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
@@ -55,11 +53,7 @@ pub async fn mk_lib_database_metadata_person_read(
     // TODO order by birth date
     if !search_value.is_empty() {
         sqlx::query_as(
-            "select mm_metadata_person_guid, \
-            mm_metadata_person_name, mm_metadata_person_image, \
-            mm_metadata_person_meta_json->>'profile_path' as mm_metadata_person_profile \
-            from mm_metadata_person where mm_metadata_person_name &@ $1 \
-            offset $2 limit $3",
+            r#"select mm_metadata_person_guid, mm_metadata_person_name, mm_metadata_person_image, mm_metadata_person_meta_json->>'profile_path' as mm_metadata_person_profile from mm_metadata_person where mm_metadata_person_name &@ $1 offset $2 limit $3"#,
         )
         .bind(search_value)
         .bind(offset)
@@ -68,11 +62,7 @@ pub async fn mk_lib_database_metadata_person_read(
         .await
     } else {
         sqlx::query_as(
-            "select mm_metadata_person_guid, \
-            mm_metadata_person_name, mm_metadata_person_image, \
-            mm_metadata_person_meta_json->>'profile_path' as mm_metadata_person_profile \
-            from mm_metadata_person order by LOWER(mm_metadata_person_name) \
-            offset $1 limit $2",
+            r#"select mm_metadata_person_guid, mm_metadata_person_name, mm_metadata_person_image, mm_metadata_person_meta_json->>'profile_path' as mm_metadata_person_profile from mm_metadata_person order by LOWER(mm_metadata_person_name) offset $1 limit $2"#,
         )
         .bind(offset)
         .bind(limit)
@@ -86,10 +76,7 @@ pub async fn mk_lib_database_meta_person_detail(
     person_uuid: String,
 ) -> Result<PgRow, sqlx::Error> {
     let row: PgRow = sqlx::query(
-        "select mm_metadata_person_guid, mm_metadata_person_media_id, \
-        mm_metadata_person_meta_json, mm_metadata_person_image, mm_metadata_person_name, \
-        mm_metadata_person_meta_json->'profile_path' as mm_metadata_person_profile \
-        from mm_metadata_person where mm_metadata_person_guid = $1",
+        r#"select mm_metadata_person_guid, mm_metadata_person_media_id, mm_metadata_person_meta_json, mm_metadata_person_image, mm_metadata_person_name, mm_metadata_person_meta_json->'profile_path' as mm_metadata_person_profile from mm_metadata_person where mm_metadata_person_guid = $1"#,
     )
     .bind(person_uuid)
     .fetch_one(sqlx_pool)
@@ -111,12 +98,7 @@ pub async fn mk_lib_database_meta_person_by_name(
     person_name: String,
 ) -> Result<Vec<DBMetaPersonNameList>, sqlx::Error> {
     let table_rows: Vec<DBMetaPersonNameList> = sqlx::query_as(
-        "select mm_metadata_person_guid, mm_metadata_person_person_media_id, \
-        mm_metadata_person_person_meta_json, \
-        mm_metadata_person_person_image, \
-        mm_metadata_person_person_name \
-        from mm_metadata_person \
-        where mm_metadata_person_person_name = $1",
+        r#"select mm_metadata_person_guid, mm_metadata_person_person_media_id, mm_metadata_person_person_meta_json, mm_metadata_person_person_image, mm_metadata_person_person_name from mm_metadata_person where mm_metadata_person_person_name = $1"#,
     )
     .bind(person_name)
     .fetch_all(sqlx_pool)
@@ -133,10 +115,7 @@ pub async fn mk_lib_database_metadata_person_insert(
 ) -> Result<Uuid, sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_metadata_person (mm_metadata_person_guid, mm_metadata_person_name, \
-        mm_metadata_person_media_id, mm_metadata_person_meta_json, \
-        mm_metadata_person_image) \
-        values ($1,$2,$3,$4,$5)",
+        r#"insert into mm_metadata_person (mm_metadata_person_guid, mm_metadata_person_name, mm_metadata_person_media_id, mm_metadata_person_meta_json, mm_metadata_person_image) values ($1,$2,$3,$4,$5)"#,
     )
     .bind(uuid_id)
     .bind(person_json["name"].as_str().unwrap().to_string())
@@ -207,8 +186,7 @@ pub async fn mk_lib_database_metadata_person_update(
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "update mm_metadata_person set mm_metadata_person_meta_json = $1, \
-        mm_metadata_person_image = $2 where mm_metadata_person_media_id = $3",
+        r#"update mm_metadata_person set mm_metadata_person_meta_json = $1, mm_metadata_person_image = $2 where mm_metadata_person_media_id = $3"#,
     )
     .bind(person_bio)
     .bind(person_image)

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_review.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_review.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_metadata_review_insert(
     sqlx_pool: &sqlx::PgPool,
@@ -10,8 +10,7 @@ pub async fn mk_lib_database_metadata_review_insert(
     let new_guid = Uuid::now_v7();
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_review(mm_review_guid, mm_review_metadata_guid, \
-        mm_review_json) values($1, $2, $3)",
+        r#"insert into mm_review(mm_review_guid, mm_review_metadata_guid, mm_review_json) values($1, $2, $3)"#,
     )
     .bind(new_guid)
     .bind(metadata_uuid)
@@ -26,13 +25,11 @@ pub async fn mk_lib_database_metadata_review_count(
     sqlx_pool: &sqlx::PgPool,
     metadata_uuid: Uuid,
 ) -> Result<i64, sqlx::Error> {
-    let row: (i64,) = sqlx::query_as(
-        "select count(*) from mm_review \
-        where mm_review_metadata_guid = $1",
-    )
-    .bind(metadata_uuid)
-    .fetch_one(sqlx_pool)
-    .await?;
+    let row: (i64,) =
+        sqlx::query_as(r#"select count(*) from mm_review where mm_review_metadata_guid = $1"#)
+            .bind(metadata_uuid)
+            .fetch_one(sqlx_pool)
+            .await?;
     Ok(row.0)
 }
 
@@ -48,9 +45,7 @@ pub async fn mk_lib_database_metadata_review_list_metadata(
 ) -> Result<Vec<DBMetaReviewList>, sqlx::Error> {
     // TODO order by rating? (optional?)
     let table_rows: Vec<DBMetaReviewList> = sqlx::query_as(
-        "select mm_review_guid, mm_review_json \
-        from mm_review where mm_review_metadata_guid = $1 \
-        order by mm_review_json->'results'->>'created_at' desc",
+        r#"select mm_review_guid, mm_review_json from mm_review where mm_review_metadata_guid = $1 order by mm_review_json->'results'->>'created_at' desc"#,
     )
     .bind(metadata_uuid)
     .fetch_all(sqlx_pool)

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_sports.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_sports.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_metadata_sports_count(
     sqlx_pool: &sqlx::PgPool,
@@ -8,15 +8,14 @@ pub async fn mk_lib_database_metadata_sports_count(
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
         let row: (i64,) = sqlx::query_as(
-            "select count(*) from mm_metadata_sports \
-            where mm_metadata_sports_name &@ $1",
+            r#"select count(*) from mm_metadata_sports where mm_metadata_sports_name &@ $1"#,
         )
         .bind(search_value)
         .fetch_one(sqlx_pool)
         .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("select count(*) from mm_metadata_sports")
+        let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_metadata_sports"#)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
@@ -38,10 +37,7 @@ pub async fn mk_lib_database_metadata_sports_read(
     // TODO order by year
     if !search_value.is_empty() {
         sqlx::query_as(
-            "select mm_metadata_sports_guid, mm_metadata_sports_name \
-            from mm_metadata_sports where mm_metadata_sports_guid \
-            where mm_metadata_sports_name &@ $1 \
-            offset $2 limit $3",
+            r#"select mm_metadata_sports_guid, mm_metadata_sports_name from mm_metadata_sports where mm_metadata_sports_guid where mm_metadata_sports_name &@ $1 offset $2 limit $3"#,
         )
         .bind(search_value)
         .bind(offset)
@@ -50,10 +46,8 @@ pub async fn mk_lib_database_metadata_sports_read(
         .await
     } else {
         sqlx::query_as(
-            "select mm_metadata_sports_guid, mm_metadata_sports_name \
-            from mm_metadata_sports
-            order by LOWER(mm_metadata_sports_name) \
-            offset $1 limit $2",
+            r#"select mm_metadata_sports_guid, mm_metadata_sports_name from mm_metadata_sports
+            order by LOWER(mm_metadata_sports_name) offset $1 limit $2"#,
         )
         .bind(offset)
         .bind(limit)

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_tv.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_tv.rs
@@ -1,14 +1,13 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_metadata_exists_tv(
     sqlx_pool: &sqlx::PgPool,
     metadata_id: i32,
 ) -> Result<bool, sqlx::Error> {
     let row: (bool,) = sqlx::query_as(
-        "select exists(select 1 from mm_metadata_tvshow \
-        where mm_metadata_media_tvshow_id = $1 limit 1) as found_record limit 1",
+        r#"select exists(select 1 from mm_metadata_tvshow where mm_metadata_media_tvshow_id = $1 limit 1) as found_record limit 1"#,
     )
     .bind(metadata_id)
     .fetch_one(sqlx_pool)
@@ -34,15 +33,8 @@ pub async fn mk_lib_database_metadata_tv_read(
     if !search_value.is_empty() {
         // doing union so exact matches show on top
         sqlx::query_as(
-            "select mm_metadata_tvshow_guid, \
-            mm_metadata_tvshow_name, \
-            mm_metadata_tvshow_name_alt, \
-            mm_metadata_tvshow_json->'first_air_date' as air_date, \
-            mm_metadata_tvshow_localimage_json->'Poster' as image_json \
-            from mm_metadata_tvshow \
-            where mm_metadata_tvshow_name &@ $1 \
-            or mm_metadata_tvshow_name_alt &@ $2
-            offset $3 limit $4",
+            r#"select mm_metadata_tvshow_guid, mm_metadata_tvshow_name, mm_metadata_tvshow_name_alt, mm_metadata_tvshow_json->'first_air_date' as air_date, mm_metadata_tvshow_localimage_json->'Poster' as image_json from mm_metadata_tvshow where mm_metadata_tvshow_name &@ $1 or mm_metadata_tvshow_name_alt &@ $2
+            offset $3 limit $4"#,
         )
         .bind(&search_value)
         .bind(&search_value)
@@ -52,15 +44,7 @@ pub async fn mk_lib_database_metadata_tv_read(
         .await
     } else {
         sqlx::query_as(
-            "select mm_metadata_tvshow_guid, \
-            mm_metadata_tvshow_name, \
-            mm_metadata_tvshow_name_alt, \
-            mm_metadata_tvshow_json->'first_air_date' as air_date, \
-            mm_metadata_tvshow_localimage_json->'Poster' as image_json \
-            from mm_metadata_tvshow \
-            order by LOWER(mm_metadata_tvshow_name), \
-            mm_metadata_tvshow_json->'first_air_date' \
-            offset $1 limit $2",
+            r#"select mm_metadata_tvshow_guid, mm_metadata_tvshow_name, mm_metadata_tvshow_name_alt, mm_metadata_tvshow_json->'first_air_date' as air_date, mm_metadata_tvshow_localimage_json->'Poster' as image_json from mm_metadata_tvshow order by LOWER(mm_metadata_tvshow_name), mm_metadata_tvshow_json->'first_air_date' offset $1 limit $2"#,
         )
         .bind(offset)
         .bind(limit)
@@ -75,15 +59,14 @@ pub async fn mk_lib_database_metadata_tv_count(
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
         let row: (i64,) = sqlx::query_as(
-            "select count(*) from mm_metadata_tvshow \
-            where mm_metadata_tvshow_name &@ $1",
+            r#"select count(*) from mm_metadata_tvshow where mm_metadata_tvshow_name &@ $1"#,
         )
         .bind(search_value)
         .fetch_one(sqlx_pool)
         .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("select count(*) from mm_metadata_tvshow")
+        let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_metadata_tvshow"#)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
@@ -103,13 +86,7 @@ pub async fn mk_lib_database_metadata_tv_insert(
     }
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_metadata_tvshow (mm_metadata_tvshow_guid, \
-        mm_metadata_media_tvshow_id, \
-        mm_metadata_tvshow_name, \
-        mm_metadata_tvshow_name_alt, \
-        mm_metadata_tvshow_json, \
-        mm_metadata_tvshow_localimage_json) \
-        values ($1,$2,$3,$4,$5,$6)",
+        r#"insert into mm_metadata_tvshow (mm_metadata_tvshow_guid, mm_metadata_media_tvshow_id, mm_metadata_tvshow_name, mm_metadata_tvshow_name_alt, mm_metadata_tvshow_json, mm_metadata_tvshow_localimage_json) values ($1,$2,$3,$4,$5,$6)"#,
     )
     .bind(uuid_id)
     .bind(series_id)
@@ -131,8 +108,7 @@ pub async fn mk_lib_database_metadata_tv_status(
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     let row: (serde_json::Value,) = sqlx::query_as(
-        "select mm_metadata_tv_user_json from mm_metadata_tv \
-        where mm_metadata_tv_guid = $1",
+        r#"select mm_metadata_tv_user_json from mm_metadata_tv where mm_metadata_tv_guid = $1"#,
     )
     .bind(uuid_id)
     .fetch_one(sqlx_pool)
@@ -145,9 +121,7 @@ pub async fn mk_lib_database_metadata_tv_status(
     }
     // TODO set the "keys"
     sqlx::query(
-        "update mm_metadata_tv \
-                set mm_metadata_tv_user_json = $1 \
-                where mm_metadata_tv_guid = $2",
+        r#"update mm_metadata_tv set mm_metadata_tv_user_json = $1 where mm_metadata_tv_guid = $2"#,
     )
     .bind(user_json)
     .bind(uuid_id)

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_tv_live.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_tv_live.rs
@@ -1,7 +1,7 @@
 use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
+use sqlx::FromRow;
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
 pub struct DBMetaTVLiveList {
@@ -15,10 +15,7 @@ pub async fn mk_lib_database_meta_tv_live_read(
     broadcast_time: DateTime<Utc>,
 ) -> Result<Vec<PgRow>, sqlx::Error> {
     let rows: Vec<PgRow> = sqlx::query(
-        "select mm_tv_station_name, mm_tv_station_channel, \
-        mm_tv_schedule_json from mm_tv_stations, mm_tv_schedule \
-        where mm_tv_schedule_station_id = mm_tv_station_id and mm_tv_schedule_date = $1 \
-        order by LOWER(mm_tv_station_name), mm_tv_schedule_json->'airDateTime'",
+        r#"select mm_tv_station_name, mm_tv_station_channel, mm_tv_schedule_json from mm_tv_stations, mm_tv_schedule where mm_tv_schedule_station_id = mm_tv_station_id and mm_tv_schedule_date = $1 order by LOWER(mm_tv_station_name), mm_tv_schedule_json->'airDateTime'"#,
     )
     .bind(broadcast_time)
     .fetch_all(sqlx_pool)
@@ -38,9 +35,7 @@ pub async fn mk_lib_database_meta_tv_live_station_read(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<MetaTVStationList>, sqlx::Error> {
     let table_rows: Vec<MetaTVStationList> = sqlx::query_as(
-        "select mm_tv_stations_id, mm_tv_station_name, \
-        mm_tv_station_id, mm_tv_station_channel \
-        from mm_tv_stations",
+        r#"select mm_tv_stations_id, mm_tv_station_name, mm_tv_station_id, mm_tv_station_channel from mm_tv_stations"#,
     )
     .fetch_all(sqlx_pool)
     .await?;
@@ -53,9 +48,7 @@ pub async fn mk_lib_database_meta_tv_station_exists(
     channel_id: String,
 ) -> Result<i32, sqlx::Error> {
     let row: (i32,) = sqlx::query_as(
-        "select exists(select 1 from mm_tv_stations \
-        where mm_tv_station_id = $1 \
-        and mm_tv_station_channel = $2 limit 1) limit 1",
+        r#"select exists(select 1 from mm_tv_stations where mm_tv_station_id = $1 and mm_tv_station_channel = $2 limit 1) limit 1"#,
     )
     .bind(station_id)
     .bind(channel_id)

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_upc.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_upc.rs
@@ -1,14 +1,13 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_metadata_exists_upc(
     sqlx_pool: &sqlx::PgPool,
     upc_code: &i32,
 ) -> Result<bool, sqlx::Error> {
     let row: (bool,) = sqlx::query_as(
-        "select exists(select 1 from mm_bar_codes \
-        where mm_bar_code_code = $1 limit 1) as found_record limit 1",
+        r#"select exists(select 1 from mm_bar_codes where mm_bar_code_code = $1 limit 1) as found_record limit 1"#,
     )
     .bind(upc_code)
     .fetch_one(sqlx_pool)
@@ -22,9 +21,7 @@ pub async fn mk_lib_database_metadata_exists_upc_own(
     user_id: i64,
 ) -> Result<bool, sqlx::Error> {
     let row: (bool,) = sqlx::query_as(
-        "select exists(select 1 from mm_bar_codes, mm_bar_code_own \
-        where mm_bar_code_uuid = mm_bar_code_own_uuid \
-        and mm_bar_code_code = $1 and mm_bar_code_own_user = $2 limit 1) as found_record limit 1",
+        r#"select exists(select 1 from mm_bar_codes, mm_bar_code_own where mm_bar_code_uuid = mm_bar_code_own_uuid and mm_bar_code_code = $1 and mm_bar_code_own_user = $2 limit 1) as found_record limit 1"#,
     )
     .bind(upc_code)
     .bind(user_id)
@@ -42,11 +39,7 @@ pub async fn mk_lib_database_metadata_upc_insert(
     let new_guid = uuid::Uuid::now_v7();
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_bar_codes (mm_bar_code_uuid, \
-        mm_bar_code_code, \
-        mm_bar_code_type \
-        mm_bar_code_json) \
-        values ($1, $2, $3, $4)",
+        r#"insert into mm_bar_codes (mm_bar_code_uuid, mm_bar_code_code, mm_bar_code_type mm_bar_code_json) values ($1, $2, $3, $4)"#,
     )
     .bind(new_guid)
     .bind(upc_code)
@@ -65,9 +58,7 @@ pub async fn mk_lib_database_metadata_upc_own_insert(
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_bar_codes (mm_bar_code_own_uuid, \
-        mm_bar_code_own_user) \
-        values ($1, $2)",
+        r#"insert into mm_bar_codes (mm_bar_code_own_uuid, mm_bar_code_own_user) values ($1, $2)"#,
     )
     .bind(upc_uuid)
     .bind(user_id)

--- a/src/mk_lib_database/src/mk_lib_database_backup.rs
+++ b/src/mk_lib_database/src/mk_lib_database_backup.rs
@@ -17,11 +17,7 @@ pub async fn mk_lib_database_backup_read(
     limit: i64,
 ) -> Result<Vec<DBBackupList>, sqlx::Error> {
     let table_rows: Vec<DBBackupList> = sqlx::query_as(
-        "select mm_backup_guid, mm_backup_description, \
-            mm_backup_location_type, mm_backup_location, mm_backup_created \
-            from mm_backup \
-            order by mm_backup_created desc \
-            offset $1 limit $2",
+        r#"select mm_backup_guid, mm_backup_description, mm_backup_location_type, mm_backup_location, mm_backup_created from mm_backup order by mm_backup_created desc offset $1 limit $2"#,
     )
     .bind(offset)
     .bind(limit)
@@ -31,7 +27,7 @@ pub async fn mk_lib_database_backup_read(
 }
 
 pub async fn mk_lib_database_backup_count(sqlx_pool: &sqlx::PgPool) -> Result<i64, sqlx::Error> {
-    let row: (i64,) = sqlx::query_as("select count(*) from mm_backup")
+    let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_backup"#)
         .fetch_one(sqlx_pool)
         .await?;
     Ok(row.0)

--- a/src/mk_lib_database/src/mk_lib_database_cron.rs
+++ b/src/mk_lib_database/src/mk_lib_database_cron.rs
@@ -1,7 +1,7 @@
 use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
 pub struct DBCronList {
@@ -19,11 +19,7 @@ pub async fn mk_lib_database_cron_service_read(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<DBCronList>, sqlx::Error> {
     let table_rows: Vec<DBCronList> = sqlx::query_as(
-        "select mm_cron_guid, \
-        mm_cron_name, mm_cron_description, mm_cron_enabled, \
-        mm_cron_schedule_type, mm_cron_schedule_time, \
-        mm_cron_last_run, mm_cron_json from mm_cron_jobs \
-        order by mm_cron_name",
+        r#"select mm_cron_guid, mm_cron_name, mm_cron_description, mm_cron_enabled, mm_cron_schedule_type, mm_cron_schedule_time, mm_cron_last_run, mm_cron_json from mm_cron_jobs order by mm_cron_name"#,
     )
     .fetch_all(sqlx_pool)
     .await?;
@@ -35,7 +31,7 @@ pub async fn mk_lib_database_cron_service_json(
     cron_uuid: Uuid,
 ) -> Result<serde_json::Value, sqlx::Error> {
     let row: (serde_json::Value,) =
-        sqlx::query_as("select mm_cron_json from mm_cron_jobs where mm_cron_guid = $1")
+        sqlx::query_as(r#"select mm_cron_json from mm_cron_jobs where mm_cron_guid = $1"#)
             .bind(cron_uuid)
             .fetch_one(sqlx_pool)
             .await?;
@@ -46,13 +42,10 @@ pub async fn mk_lib_database_cron_time_update(
     sqlx_pool: &sqlx::PgPool,
     cron_uuid: Uuid,
 ) -> Result<(), sqlx::Error> {
-    sqlx::query(
-        "update mm_cron_jobs set mm_cron_last_run = NOW() \
-        where mm_cron_guid = $1",
-    )
-    .bind(cron_uuid)
-    .execute(sqlx_pool)
-    .await?;
+    sqlx::query(r#"update mm_cron_jobs set mm_cron_last_run = NOW() where mm_cron_guid = $1"#)
+        .bind(cron_uuid)
+        .execute(sqlx_pool)
+        .await?;
     Ok(())
 }
 
@@ -60,7 +53,7 @@ pub async fn mk_lib_database_cron_delete(
     sqlx_pool: &sqlx::PgPool,
     cron_uuid: Uuid,
 ) -> Result<(), sqlx::Error> {
-    sqlx::query("delete from mm_cron where mm_cron_guid = $1")
+    sqlx::query(r#"delete from mm_cron where mm_cron_guid = $1"#)
         .bind(cron_uuid)
         .execute(sqlx_pool)
         .await?;
@@ -77,9 +70,7 @@ pub async fn mk_lib_database_cron_insert(
 ) -> Result<uuid::Uuid, sqlx::Error> {
     let new_guid = uuid::Uuid::now_v7();
     sqlx::query(
-        "insert into mm_cron (mm_cron_guid, mm_cron_name, mm_cron_description, \
-        mm_cron_enabled, mm_cron_schedule, mm_cron_last_run, mm_cron_json) \
-        values ($1,$2,$3,$4,$5,Null,$6)",
+        r#"insert into mm_cron (mm_cron_guid, mm_cron_name, mm_cron_description, mm_cron_enabled, mm_cron_schedule, mm_cron_last_run, mm_cron_json) values ($1,$2,$3,$4,$5,Null,$6)"#,
     )
     .bind(new_guid)
     .bind(cron_name)
@@ -96,7 +87,7 @@ pub async fn mk_lib_database_cron_count(
     sqlx_pool: &sqlx::PgPool,
     cron_enabled: bool,
 ) -> Result<i64, sqlx::Error> {
-    let row: (i64,) = sqlx::query_as("select count(*) from mm_cron where mm_cron_enabled = $1")
+    let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_cron where mm_cron_enabled = $1"#)
         .bind(cron_enabled)
         .fetch_one(sqlx_pool)
         .await?;

--- a/src/mk_lib_database/src/mk_lib_database_game_servers.rs
+++ b/src/mk_lib_database/src/mk_lib_database_game_servers.rs
@@ -1,13 +1,13 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_game_server_delete(
     sqlx_pool: &sqlx::PgPool,
     game_server_uuid: Uuid,
 ) -> Result<(), sqlx::Error> {
-    sqlx::query("delete from mm_game_dedicated_servers where mm_game_server_guid = $1")
+    sqlx::query(r#"delete from mm_game_dedicated_servers where mm_game_server_guid = $1"#)
         .bind(game_server_uuid)
         .execute(sqlx_pool)
         .await?;
@@ -29,10 +29,7 @@ pub async fn mk_lib_database_game_server_read(
 ) -> Result<Vec<DBGameServerList>, sqlx::Error> {
     if !search_value.is_empty() {
         sqlx::query_as(
-            "select mm_game_server_guid, mm_game_server_name, \
-            mm_game_server_json from mm_game_dedicated_servers \
-            where mm_game_server_name = $1 \
-            order by mm_game_server_name offset $2 limit $3",
+            r#"select mm_game_server_guid, mm_game_server_name, mm_game_server_json from mm_game_dedicated_servers where mm_game_server_name = $1 order by mm_game_server_name offset $2 limit $3"#,
         )
         .bind(search_value)
         .bind(offset)
@@ -41,9 +38,7 @@ pub async fn mk_lib_database_game_server_read(
         .await
     } else {
         sqlx::query_as(
-            "select mm_game_server_guid, mm_game_server_name, \
-            mm_game_server_json from mm_game_dedicated_servers \
-            order by mm_game_server_name offset $1 limit $2",
+            r#"select mm_game_server_guid, mm_game_server_name, mm_game_server_json from mm_game_dedicated_servers order by mm_game_server_name offset $1 limit $2"#,
         )
         .bind(offset)
         .bind(limit)
@@ -57,8 +52,7 @@ pub async fn mk_lib_database_game_server_detail(
     game_server_uuid: Uuid,
 ) -> Result<PgRow, sqlx::Error> {
     let row: PgRow = sqlx::query(
-        "select mm_game_server_name, mm_game_server_json \
-        from mm_game_dedicated_servers where mm_game_server_guid = $1",
+        r#"select mm_game_server_name, mm_game_server_json from mm_game_dedicated_servers where mm_game_server_guid = $1"#,
     )
     .bind(game_server_uuid)
     .fetch_one(sqlx_pool)
@@ -72,15 +66,14 @@ pub async fn mk_lib_database_game_server_count(
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
         let row: (i64,) = sqlx::query_as(
-            "select count(*) from mm_game_dedicated_servers \
-            where mm_game_server_name = $1",
+            r#"select count(*) from mm_game_dedicated_servers where mm_game_server_name = $1"#,
         )
         .bind(search_value)
         .fetch_one(sqlx_pool)
         .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("select count(*) from mm_game_dedicated_servers")
+        let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_game_dedicated_servers"#)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
@@ -95,9 +88,7 @@ pub async fn mk_lib_database_game_server_upsert(
     // TODO um, would return "invalid" uuid on update
     let new_guid = uuid::Uuid::now_v7();
     sqlx::query(
-        "INSERT INTO mm_game_dedicated_servers(mm_game_server_guid, \
-        mm_game_server_name, mm_game_server_json) VALUES($ 1, $2, $3) \
-        ON CONFLICT(mm_game_server_name) DO UPDATE SET mm_game_server_json = $4",
+        r#"INSERT INTO mm_game_dedicated_servers(mm_game_server_guid, mm_game_server_name, mm_game_server_json) VALUES($ 1, $2, $3) ON CONFLICT(mm_game_server_name) DO UPDATE SET mm_game_server_json = $4"#,
     )
     .bind(new_guid)
     .bind(server_name)

--- a/src/mk_lib_database/src/mk_lib_database_hardware_device.rs
+++ b/src/mk_lib_database/src/mk_lib_database_hardware_device.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_hardware_manufacturer_upsert(
     sqlx_pool: &sqlx::PgPool,
@@ -9,9 +9,7 @@ pub async fn mk_lib_database_hardware_manufacturer_upsert(
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_hardware_manufacturer (mm_hardware_manu_guid, \
-        mm_hardware_manu_name, mm_hardware_manu_gc_id) values ($1, $2, $3) \
-        ON CONFLICT (mm_hardware_manu_name) DO NOTHING",
+        r#"insert into mm_hardware_manufacturer (mm_hardware_manu_guid, mm_hardware_manu_name, mm_hardware_manu_gc_id) values ($1, $2, $3) ON CONFLICT (mm_hardware_manu_name) DO NOTHING"#,
     )
     .bind(uuid::Uuid::now_v7())
     .bind(manufacturer_name)
@@ -28,9 +26,7 @@ pub async fn mk_lib_database_hardware_type_upsert(
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_hardware_type (mm_hardware_type_guid, \
-        mm_hardware_type_name) values ($1, $2) \
-        ON CONFLICT (mm_hardware_type_name) DO NOTHING",
+        r#"insert into mm_hardware_type (mm_hardware_type_guid, mm_hardware_type_name) values ($1, $2) ON CONFLICT (mm_hardware_type_name) DO NOTHING"#,
     )
     .bind(uuid::Uuid::now_v7())
     .bind(hardware_type)
@@ -48,10 +44,7 @@ pub async fn mk_lib_database_hardware_model_insert(
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_hardware_model (mm_hardware_model_guid, \
-        mm_hardware_manufacturer, \
-        mm_hardware_model_type, \
-        mm_hardware_model_name) values ($1, $2, $3, $4)",
+        r#"insert into mm_hardware_model (mm_hardware_model_guid, mm_hardware_manufacturer, mm_hardware_model_type, mm_hardware_model_name) values ($1, $2, $3, $4)"#,
     )
     .bind(uuid::Uuid::now_v7())
     .bind(hardware_manufacturer)
@@ -70,8 +63,7 @@ pub async fn mk_lib_database_hardware_model_device_count_by_type(
     hardware_model: String,
 ) -> Result<i64, sqlx::Error> {
     let row: (i64,) = sqlx::query_as(
-            "select count(*) from mm_hardware_model \
-            where mm_hardware_manufacturer = $1 and mm_hardware_model_type = $2 and mm_hardware_model_name = $3",
+            r#"select count(*) from mm_hardware_model where mm_hardware_manufacturer = $1 and mm_hardware_model_type = $2 and mm_hardware_model_name = $3"#,
         )
         .bind(hardware_manufacturer)
         .bind(hardware_type)
@@ -87,8 +79,7 @@ pub async fn mk_lib_database_hardware_json_read_by_type(
     model_name: String,
 ) -> Result<serde_json::Value, sqlx::Error> {
     let row: (serde_json::Value,) = sqlx::query_as(
-        "select mm_hardware_json \
-        from mm_hardware_json where mm_hardware_manufacturer = $1 and mm_hardware_model = $2",
+        r#"select mm_hardware_json from mm_hardware_json where mm_hardware_manufacturer = $1 and mm_hardware_model = $2"#,
     )
     .bind(manufacturer)
     .bind(model_name)
@@ -100,7 +91,7 @@ pub async fn mk_lib_database_hardware_json_read_by_type(
 pub async fn mk_lib_database_hardware_device_count(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<i64, sqlx::Error> {
-    let row: (i64,) = sqlx::query_as("select count(*) from mm_hardware_json")
+    let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_hardware_json"#)
         .fetch_one(sqlx_pool)
         .await?;
     Ok(row.0)
@@ -117,11 +108,7 @@ pub async fn mk_lib_database_hardware_device_read(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<DBDeviceList>, sqlx::Error> {
     let table_rows: Vec<DBDeviceList> = sqlx::query_as(
-        "select mm_hardware_manufacturer, \
-            mm_hardware_model_type, \
-            mm_hardware_model_name \
-            from mm_hardware_model order by mm_hardware_manufacturer, \
-            mm_hardware_model_type, mm_hardware_model_name desc",
+        r#"select mm_hardware_manufacturer, mm_hardware_model_type, mm_hardware_model_name from mm_hardware_model order by mm_hardware_manufacturer, mm_hardware_model_type, mm_hardware_model_name desc"#,
     )
     .fetch_all(sqlx_pool)
     .await?;
@@ -137,8 +124,7 @@ pub async fn mk_lib_database_hardware_insert(
     let new_guid = uuid::Uuid::now_v7();
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_hardware_json(mm_hardware_id, mm_hardware_manufacturer, \
-        mm_hardware_model, mm_hardware_json) values($1, $2, $3, $4)",
+        r#"insert into mm_hardware_json(mm_hardware_id, mm_hardware_manufacturer, mm_hardware_model, mm_hardware_json) values($1, $2, $3, $4)"#,
     )
     .bind(new_guid)
     .bind(manufacturer)
@@ -155,7 +141,7 @@ pub async fn mk_lib_database_hardware_delete(
     hardware_uuid: Uuid,
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
-    sqlx::query("delete from mm_hardware_json where mm_hardware_id = $1")
+    sqlx::query(r#"delete from mm_hardware_json where mm_hardware_id = $1"#)
         .bind(hardware_uuid)
         .execute(&mut *transaction)
         .await?;

--- a/src/mk_lib_database/src/mk_lib_database_library.rs
+++ b/src/mk_lib_database/src/mk_lib_database_library.rs
@@ -1,7 +1,7 @@
 use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
 pub struct DBLibraryList {
@@ -14,8 +14,8 @@ pub async fn mk_lib_database_library_read(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<DBLibraryList>, sqlx::Error> {
     let table_rows: Vec<DBLibraryList> = sqlx::query_as(
-        "select mm_media_dir_guid, mm_media_dir_path, mm_media_dir_share_guid \
-        from mm_library_dir",
+        r#"select mm_media_dir_guid, mm_media_dir_path, mm_media_dir_share_guid
+        from mm_library_dir"#,
     )
     .fetch_all(sqlx_pool)
     .await?;
@@ -35,12 +35,12 @@ pub async fn mk_lib_database_library_path_audit_read(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<DBLibraryAuditList>, sqlx::Error> {
     let table_rows: Vec<DBLibraryAuditList> = sqlx::query_as(
-        "select mm_media_dir_guid, \
-        mm_media_dir_path, \
-        mm_media_dir_class_enum, \
-        mm_media_dir_last_scanned, \
-        mm_media_dir_share_guid \
-        from mm_library_dir",
+        r#"select mm_media_dir_guid,
+        mm_media_dir_path,
+        mm_media_dir_class_enum,
+        mm_media_dir_last_scanned,
+        mm_media_dir_share_guid
+        from mm_library_dir"#,
     )
     .fetch_all(sqlx_pool)
     .await?;
@@ -57,9 +57,9 @@ pub async fn mk_lib_database_library_path_status(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<DBLibraryPathStatus>, sqlx::Error> {
     let table_rows: Vec<DBLibraryPathStatus> = sqlx::query_as(
-        "select mm_media_dir_path, mm_media_dir_status \
-        from mm_library_dir where mm_media_dir_status IS NOT NULL \
-        order by mm_media_dir_path",
+        r#"select mm_media_dir_path, mm_media_dir_status
+        from mm_library_dir where mm_media_dir_status IS NOT NULL
+        order by mm_media_dir_path"#,
     )
     .fetch_all(sqlx_pool)
     .await?;
@@ -72,8 +72,8 @@ pub async fn mk_lib_database_library_path_status_update(
     library_status_json: serde_json::Value,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
-        "update mm_library_dir set mm_media_dir_status = $1 \
-        where mm_media_dir_guid = $2",
+        r#"update mm_library_dir set mm_media_dir_status = $1
+        where mm_media_dir_guid = $2"#,
     )
     .bind(library_status_json)
     .bind(library_uuid)
@@ -87,8 +87,8 @@ pub async fn mk_lib_database_library_path_timestamp_update(
     library_uuid: Uuid,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
-        "update mm_library_dir set mm_media_dir_last_scanned = NOW() \
-        where mm_media_dir_guid = $1",
+        r#"update mm_library_dir set mm_media_dir_last_scanned = NOW()
+        where mm_media_dir_guid = $1"#,
     )
     .bind(library_uuid)
     .execute(sqlx_pool)
@@ -101,9 +101,9 @@ pub async fn mk_lib_database_library_file_exists(
     file_name: &str,
 ) -> Result<bool, sqlx::Error> {
     let row: (bool,) = sqlx::query_as(
-        "select exists(select 1 from mm_media \
-        where mm_media_path = $1) \
-        as found_record",
+        r#"select exists(select 1 from mm_media
+        where mm_media_path = $1)
+        as found_record"#,
     )
     .bind(file_name)
     .fetch_one(sqlx_pool)
@@ -112,7 +112,7 @@ pub async fn mk_lib_database_library_file_exists(
 }
 
 pub async fn mk_lib_database_library_count(sqlx_pool: &sqlx::PgPool) -> Result<i64, sqlx::Error> {
-    let row: (i64,) = sqlx::query_as("select count(*) from mm_library_dir")
+    let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_library_dir"#)
         .fetch_one(sqlx_pool)
         .await?;
     Ok(row.0)

--- a/src/mk_lib_database/src/mk_lib_database_link_server.rs
+++ b/src/mk_lib_database/src/mk_lib_database_link_server.rs
@@ -1,13 +1,13 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_link_delete(
     sqlx_pool: &sqlx::PgPool,
     link_uuid: Uuid,
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
-    sqlx::query("delete from mm_link where mm_link_guid = $1")
+    sqlx::query(r#"delete from mm_link where mm_link_guid = $1"#)
         .bind(link_uuid)
         .execute(&mut *transaction)
         .await?;
@@ -28,10 +28,7 @@ pub async fn mk_lib_database_link_read(
     records: i64,
 ) -> Result<Vec<DBLinkList>, sqlx::Error> {
     let table_rows: Vec<DBLinkList> = sqlx::query_as(
-        "select mm_link_guid, mm_link_name, \
-        mm_link_json from mm_link \
-        order by mm_link_name \
-        offset $1 limit $2",
+        r#"select mm_link_guid, mm_link_name, mm_link_json from mm_link order by mm_link_name offset $1 limit $2"#,
     )
     .bind(offset)
     .bind(records)
@@ -46,14 +43,11 @@ pub async fn mk_lib_database_link_insert(
 ) -> Result<uuid::Uuid, sqlx::Error> {
     let new_guid = Uuid::now_v7();
     let mut transaction = sqlx_pool.begin().await?;
-    sqlx::query(
-        "insert into mm_link (mm_link_guid, mm_link_json) \
-        values ($1, $2)",
-    )
-    .bind(new_guid)
-    .bind(link_json)
-    .execute(&mut *transaction)
-    .await?;
+    sqlx::query(r#"insert into mm_link (mm_link_guid, mm_link_json) values ($1, $2)"#)
+        .bind(new_guid)
+        .bind(link_json)
+        .execute(&mut *transaction)
+        .await?;
     transaction.commit().await?;
     Ok(new_guid)
 }
@@ -63,16 +57,14 @@ pub async fn mk_lib_database_link_list_count(
     search_value: String,
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
-        let row: (i64,) = sqlx::query_as(
-            "select count(*) from mm_library_link \
-            where mm_link_name % $1",
-        )
-        .bind(search_value)
-        .fetch_one(sqlx_pool)
-        .await?;
+        let row: (i64,) =
+            sqlx::query_as(r#"select count(*) from mm_library_link where mm_link_name % $1"#)
+                .bind(search_value)
+                .fetch_one(sqlx_pool)
+                .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("select count(*) from mm_library_link")
+        let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_library_link"#)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)

--- a/src/mk_lib_database/src/mk_lib_database_network_share.rs
+++ b/src/mk_lib_database/src/mk_lib_database_network_share.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_network_share_exists(
     sqlx_pool: &sqlx::PgPool,
@@ -8,8 +8,7 @@ pub async fn mk_lib_database_network_share_exists(
     network_share_path: serde_json::Value,
 ) -> Result<bool, sqlx::Error> {
     let row: (bool,) = sqlx::query_as(
-        "select exists(select 1 from mm_network_shares \
-        where mm_network_share_ip = $1 and mm_network_share_path = $2 limit 1) as found_record limit 1",
+        r#"select exists(select 1 from mm_network_shares where mm_network_share_ip = $1 and mm_network_share_path = $2 limit 1) as found_record limit 1"#,
     )
     .bind(network_share_ip)
     .bind(network_share_path)
@@ -21,7 +20,7 @@ pub async fn mk_lib_database_network_share_exists(
 pub async fn mk_lib_database_network_share_count(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<i64, sqlx::Error> {
-    let row: (i64,) = sqlx::query_as("select count(*) from mm_network_shares")
+    let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_network_shares"#)
         .fetch_one(sqlx_pool)
         .await?;
     Ok(row.0)
@@ -37,10 +36,7 @@ pub async fn mk_lib_database_network_share_user_read(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<DBShareAuthUserList>, sqlx::Error> {
     let table_rows: Vec<DBShareAuthUserList> = sqlx::query_as(
-        "select mm_share_auth_guid, \
-        mm_share_auth_user \
-        from mm_share_auth \
-        order by mm_share_auth_user",
+        r#"select mm_share_auth_guid, mm_share_auth_user from mm_share_auth order by mm_share_auth_user"#,
     )
     .fetch_all(sqlx_pool)
     .await?;
@@ -64,17 +60,7 @@ pub async fn mk_lib_database_network_share_detail(
     share_guid: uuid::Uuid,
 ) -> Result<DBShareList, sqlx::Error> {
     let table_row: DBShareList = sqlx::query_as(
-        "select mm_network_share_guid, \
-        mm_network_share_ip, \
-        mm_network_share_path, \
-        mm_network_share_comment, \
-        mm_share_auth_user, \
-        mm_share_auth_password, \
-        mm_network_share_version, \
-        mm_network_share_workgroup \
-        from mm_network_shares, mm_share_auth \
-        where mm_network_share_user_guid = mm_share_auth_guid \
-        and mm_network_share_guid = $1",
+        r#"select mm_network_share_guid, mm_network_share_ip, mm_network_share_path, mm_network_share_comment, mm_share_auth_user, mm_share_auth_password, mm_network_share_version, mm_network_share_workgroup from mm_network_shares, mm_share_auth where mm_network_share_user_guid = mm_share_auth_guid and mm_network_share_guid = $1"#,
     )
     .bind(share_guid)
     .fetch_one(sqlx_pool)
@@ -86,17 +72,7 @@ pub async fn mk_lib_database_network_share_read(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<DBShareList>, sqlx::Error> {
     let table_rows: Vec<DBShareList> = sqlx::query_as(
-        "select mm_network_share_guid, \
-        mm_network_share_ip, \
-        mm_network_share_path, \
-        mm_network_share_comment, \
-        mm_share_auth_user, \
-        mm_share_auth_password, \
-        mm_network_share_version, \
-        mm_network_share_workgroup \
-        from mm_network_shares, mm_share_auth \
-        where mm_network_share_user_guid = mm_share_auth_guid \
-        order by mm_network_share_path",
+        r#"select mm_network_share_guid, mm_network_share_ip, mm_network_share_path, mm_network_share_comment, mm_share_auth_user, mm_share_auth_password, mm_network_share_version, mm_network_share_workgroup from mm_network_shares, mm_share_auth where mm_network_share_user_guid = mm_share_auth_guid order by mm_network_share_path"#,
     )
     .fetch_all(sqlx_pool)
     .await?;
@@ -108,13 +84,10 @@ pub async fn mk_lib_database_network_share_delete(
     network_share_uuid: Uuid,
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
-    sqlx::query(
-        "delete from mm_network_shares \
-        where mm_network_share_guid = $1",
-    )
-    .bind(network_share_uuid)
-    .execute(&mut *transaction)
-    .await?;
+    sqlx::query(r#"delete from mm_network_shares where mm_network_share_guid = $1"#)
+        .bind(network_share_uuid)
+        .execute(&mut *transaction)
+        .await?;
     transaction.commit().await?;
     Ok(())
 }
@@ -130,12 +103,7 @@ pub async fn mk_lib_database_network_share_insert(
     let path_name = network_share_path.replace("\\\\", "/");
     let path_vec: Vec<&str> = path_name.splitn(3, '/').collect();
     sqlx::query(
-        "insert into mm_network_shares \
-        (mm_network_share_guid, \
-        mm_network_share_ip, \
-        mm_network_share_path, \
-        mm_network_share_comment) \
-        values ($1, $2, $3, $4)",
+        r#"insert into mm_network_shares (mm_network_share_guid, mm_network_share_ip, mm_network_share_path, mm_network_share_comment) values ($1, $2, $3, $4)"#,
     )
     .bind(new_guid)
     .bind(network_share_ip)
@@ -155,9 +123,7 @@ pub async fn mk_lib_database_network_share_update_user_info(
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "udpate mm_network_shares set mm_network_share_user = $1, \
-        mm_network_share_password = $2 \
-        where mm_network_share_guid = $3",
+        r#"udpate mm_network_shares set mm_network_share_user = $1, mm_network_share_password = $2 where mm_network_share_guid = $3"#,
     )
     .bind(network_share_user)
     .bind(network_share_password)

--- a/src/mk_lib_database/src/mk_lib_database_notification.rs
+++ b/src/mk_lib_database/src/mk_lib_database_notification.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
 pub struct DBNotificationList {
@@ -16,10 +16,7 @@ pub async fn mk_lib_database_notification_read(
     limit: i64,
 ) -> Result<Vec<DBNotificationList>, sqlx::Error> {
     let table_rows: Vec<DBNotificationList> = sqlx::query_as(
-        "select mm_notification_guid, mm_notification_text, \
-        mm_notification_time, \
-        mm_notification_dismissible from mm_notification \
-        order by mm_notification_time desc offset $1 limit $2",
+        r#"select mm_notification_guid, mm_notification_text, mm_notification_time, mm_notification_dismissible from mm_notification order by mm_notification_time desc offset $1 limit $2"#,
     )
     .bind(offset)
     .bind(limit)
@@ -34,11 +31,7 @@ pub async fn mk_lib_database_notification_insert(
     mm_notification_dismissable: bool,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
-        "insert into mm_notification (mm_notification_guid, \
-        mm_notification_text, \
-        mm_notification_time = NOW(), \
-        mm_notification_dismissible) \
-        values ($1, $2, $3)",
+        r#"insert into mm_notification (mm_notification_guid, mm_notification_text, mm_notification_time = NOW(), mm_notification_dismissible) values ($1, $2, $3)"#,
     )
     .bind(Uuid::now_v7())
     .bind(mm_notification_text)
@@ -53,7 +46,7 @@ pub async fn mk_lib_database_notification_delete(
     mk_notification_guid: Uuid,
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
-    sqlx::query("delete from mm_notification where mm_notification_guid = $1")
+    sqlx::query(r#"delete from mm_notification where mm_notification_guid = $1"#)
         .bind(mk_notification_guid)
         .execute(&mut *transaction)
         .await?;

--- a/src/mk_lib_database/src/mk_lib_database_option_status.rs
+++ b/src/mk_lib_database/src/mk_lib_database_option_status.rs
@@ -14,7 +14,7 @@ pub async fn mk_lib_database_option_api_read(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<serde_json::Value, sqlx::Error> {
     let row: (serde_json::Value,) =
-        sqlx::query_as("select mm_options_json->'API' from mm_options_and_status")
+        sqlx::query_as(r#"select mm_options_json->'API' from mm_options_and_status"#)
             .fetch_one(sqlx_pool)
             .await?;
     Ok(row.0)
@@ -24,7 +24,7 @@ pub async fn mk_lib_database_option_read(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<serde_json::Value, sqlx::Error> {
     let row: (serde_json::Value,) =
-        sqlx::query_as("select mm_options_json from mm_options_and_status")
+        sqlx::query_as(r#"select mm_options_json from mm_options_and_status"#)
             .fetch_one(sqlx_pool)
             .await?;
     Ok(row.0)
@@ -34,7 +34,7 @@ pub async fn mk_lib_database_status_read(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<serde_json::Value, sqlx::Error> {
     let row: (serde_json::Value,) =
-        sqlx::query_as("select mm_status_json from mm_options_and_status")
+        sqlx::query_as(r#"select mm_status_json from mm_options_and_status"#)
             .fetch_one(sqlx_pool)
             .await?;
     Ok(row.0)
@@ -43,12 +43,9 @@ pub async fn mk_lib_database_status_read(
 pub async fn mk_lib_database_option_status_read(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<PgRow, sqlx::Error> {
-    let rows = sqlx::query(
-        "select mm_options_json, mm_status_json \
-        from mm_options_and_status",
-    )
-    .fetch_one(sqlx_pool)
-    .await?;
+    let rows = sqlx::query(r#"select mm_options_json, mm_status_json from mm_options_and_status"#)
+        .fetch_one(sqlx_pool)
+        .await?;
     Ok(rows)
 }
 
@@ -58,7 +55,7 @@ pub async fn mk_lib_database_option_update(
 ) -> Result<(), sqlx::Error> {
     // no need for where clause as it's only the one record
     let mut transaction = sqlx_pool.begin().await?;
-    sqlx::query("update mm_options_and_status set mm_options_json = $1")
+    sqlx::query(r#"update mm_options_and_status set mm_options_json = $1"#)
         .bind(option_json)
         .execute(&mut *transaction)
         .await?;
@@ -73,7 +70,7 @@ pub async fn mk_lib_database_option_status_update(
 ) -> Result<(), sqlx::Error> {
     // no need for where clause as it's only the one record
     let mut transaction = sqlx_pool.begin().await?;
-    sqlx::query("update mm_options_and_status set mm_options_json = $1, mm_status_json = $2")
+    sqlx::query(r#"update mm_options_and_status set mm_options_json = $1, mm_status_json = $2"#)
         .bind(option_json)
         .bind(status_json)
         .execute(&mut *transaction)
@@ -88,7 +85,7 @@ pub async fn mk_lib_database_status_update_scan(
 ) -> Result<(), sqlx::Error> {
     // no need for where clause as it's only the one record
     let mut transaction = sqlx_pool.begin().await?;
-    sqlx::query("update mm_options_and_status set mm_status_json = $1")
+    sqlx::query(r#"update mm_options_and_status set mm_status_json = $1"#)
         .bind(status_json)
         .execute(&mut *transaction)
         .await?;

--- a/src/mk_lib_database/src/mk_lib_database_postgresql.rs
+++ b/src/mk_lib_database/src/mk_lib_database_postgresql.rs
@@ -4,10 +4,7 @@ use sqlx::FromRow;
 pub async fn mk_lib_database_table_row_count(sqlx_pool: &sqlx::PgPool) -> Result<f32, sqlx::Error> {
     // query provided by postgresql wiki
     let row: (f32,) = sqlx::query_as(
-        "SELECT sum(reltuples) \
-        FROM pg_class C LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) \
-        WHERE nspname NOT IN ('pg_catalog', 'information_schema') \
-        AND relkind='r'",
+        r#"SELECT sum(reltuples) FROM pg_class C LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) WHERE nspname NOT IN ('pg_catalog', 'information_schema') AND relkind='r'"#,
     )
     .fetch_one(sqlx_pool)
     .await?;
@@ -26,10 +23,7 @@ pub async fn mk_lib_database_table_rows(
 ) -> Result<Vec<PGTableRows>, sqlx::Error> {
     // query provided by postgresql wiki
     let table_rows: Vec<PGTableRows> = sqlx::query_as(
-        "SELECT nspname AS schemaname,relname,reltuples \
-        FROM pg_class C LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) \
-        WHERE nspname NOT IN ('pg_catalog', 'information_schema') \
-        AND relkind='r' ORDER BY reltuples DESC",
+        r#"SELECT nspname AS schemaname,relname,reltuples FROM pg_class C LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) WHERE nspname NOT IN ('pg_catalog', 'information_schema') AND relkind='r' ORDER BY reltuples DESC"#,
     )
     .fetch_all(sqlx_pool)
     .await?;
@@ -44,11 +38,11 @@ pub struct PGTable {
 pub async fn mk_lib_database_tables(sqlx_pool: &sqlx::PgPool) -> Result<Vec<PGTable>, sqlx::Error> {
     // this does NOT return sequences like the tables size does
     let table_rows: Vec<PGTable> = sqlx::query_as(
-        "SELECT tablename
+        r#"SELECT tablename
         FROM pg_catalog.pg_tables
         WHERE schemaname != 'pg_catalog' AND 
         schemaname != 'information_schema'
-        order by tablename;",
+        order by tablename;"#,
     )
     .fetch_all(sqlx_pool)
     .await?;
@@ -66,12 +60,7 @@ pub async fn mk_lib_database_table_size(
 ) -> Result<Vec<PGTableSize>, sqlx::Error> {
     // query provided by postgresql wiki
     let table_rows: Vec<PGTableSize> = sqlx::query_as(
-        "SELECT relname AS \"relation\", \
-        pg_total_relation_size(C.oid) AS \"total_size\" FROM pg_class C \
-        LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) \
-        WHERE nspname NOT IN ('pg_catalog', 'information_schema') \
-        AND C.relkind <> 'i' AND nspname!~ '^pg_toast' \
-        ORDER BY pg_total_relation_size(C.oid) DESC",
+        r##"SELECT relname AS "relation", pg_total_relation_size(C.oid) AS "total_size" FROM pg_class C LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) WHERE nspname NOT IN ('pg_catalog', 'information_schema') AND C.relkind <> 'i' AND nspname!~ '^pg_toast' ORDER BY pg_total_relation_size(C.oid) DESC"##,
     )
     .fetch_all(sqlx_pool)
     .await?;
@@ -83,10 +72,7 @@ pub async fn mk_lib_database_table_size_total(
 ) -> Result<i64, sqlx::Error> {
     // query provided by postgresql wiki
     let row: (i64,) = sqlx::query_as(
-        "SELECT sum(pg_total_relation_size(C.oid))::bigint AS \"total_size\" FROM pg_class C \
-        LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) \
-        WHERE nspname NOT IN ('pg_catalog', 'information_schema') \
-        AND C.relkind <> 'i' AND nspname!~ '^pg_toast'",
+        r##"SELECT sum(pg_total_relation_size(C.oid))::bigint AS "total_size" FROM pg_class C LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace) WHERE nspname NOT IN ('pg_catalog', 'information_schema') AND C.relkind <> 'i' AND nspname!~ '^pg_toast'"##,
     )
     .fetch_one(sqlx_pool)
     .await?;
@@ -96,7 +82,7 @@ pub async fn mk_lib_database_table_size_total(
 pub async fn mk_lib_database_parallel_workers(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<String, sqlx::Error> {
-    let row: (String,) = sqlx::query_as("show max_parallel_workers_per_gather")
+    let row: (String,) = sqlx::query_as(r#"show max_parallel_workers_per_gather"#)
         .fetch_one(sqlx_pool)
         .await?;
     Ok(row.0)
@@ -112,7 +98,7 @@ pub async fn mk_lib_database_extension_active(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<PGExtensionActive>, sqlx::Error> {
     let table_rows: Vec<PGExtensionActive> =
-        sqlx::query_as("SELECT extname, extversion from pg_extension order by extname")
+        sqlx::query_as(r#"SELECT extname, extversion from pg_extension order by extname"#)
             .fetch_all(sqlx_pool)
             .await?;
     Ok(table_rows)
@@ -127,10 +113,11 @@ pub struct PGExtensionAvailable {
 pub async fn mk_lib_database_extension_available(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<PGExtensionAvailable>, sqlx::Error> {
-    let table_rows: Vec<PGExtensionAvailable> =
-        sqlx::query_as("SELECT name, default_version FROM pg_available_extensions order by name")
-            .fetch_all(sqlx_pool)
-            .await?;
+    let table_rows: Vec<PGExtensionAvailable> = sqlx::query_as(
+        r#"SELECT name, default_version FROM pg_available_extensions order by name"#,
+    )
+    .fetch_all(sqlx_pool)
+    .await?;
     Ok(table_rows)
 }
 

--- a/src/mk_lib_database/src/mk_lib_database_report.rs
+++ b/src/mk_lib_database/src/mk_lib_database_report.rs
@@ -5,7 +5,7 @@ use sqlx::FromRow;
 pub async fn mk_lib_database_report_known_media_count(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<i64, sqlx::Error> {
-    let row: (i64,) = sqlx::query_as("select count(*) from mm_media")
+    let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_media"#)
         .fetch_one(sqlx_pool)
         .await?;
     Ok(row.0)
@@ -24,10 +24,7 @@ pub async fn mk_lib_database_report_known_media_read(
     limit: i64,
 ) -> Result<Vec<DBReportKnownMediaList>, sqlx::Error> {
     let table_rows: Vec<DBReportKnownMediaList> = sqlx::query_as(
-        "select mm_media_path, \
-        mm_media_class_enum, \
-        (mm_media_json->>'Added')::timestamptz as mm_media_json_added \
-        from mm_media order by mm_media_json_added desc offset $1 limit $2",
+        r#"select mm_media_path, mm_media_class_enum, (mm_media_json->>'Added')::timestamptz as mm_media_json_added from mm_media order by mm_media_json_added desc offset $1 limit $2"#,
     )
     .bind(offset)
     .bind(limit)

--- a/src/mk_lib_database/src/mk_lib_database_sync.rs
+++ b/src/mk_lib_database/src/mk_lib_database_sync.rs
@@ -1,14 +1,14 @@
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
 use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_sync_delete(
     sqlx_pool: &sqlx::PgPool,
     sync_guid: Uuid,
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
-    sqlx::query("delete from mm_media_sync where mm_sync_guid = $1")
+    sqlx::query(r#"delete from mm_media_sync where mm_sync_guid = $1"#)
         .bind(sync_guid)
         .execute(&mut *transaction)
         .await?;
@@ -23,8 +23,8 @@ pub async fn mk_lib_database_sync_process_update(
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "update mm_media_sync set mm_sync_options_json->'Progress' = $1
-        where mm_sync_guid = $2",
+        r#"update mm_media_sync set mm_sync_options_json->'Progress' = $1
+        where mm_sync_guid = $2"#,
     )
     .bind(sync_percent)
     .bind(sync_guid)
@@ -35,7 +35,7 @@ pub async fn mk_lib_database_sync_process_update(
 }
 
 pub async fn mk_lib_database_sync_count(sqlx_pool: &sqlx::PgPool) -> Result<i64, sqlx::Error> {
-    let row: (i64,) = sqlx::query_as("select count(*) from mm_media_sync")
+    let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_media_sync"#)
         .fetch_one(sqlx_pool)
         .await?;
     Ok(row.0)
@@ -50,9 +50,7 @@ pub async fn mk_lib_database_sync_insert(
     let new_guid = uuid::Uuid::now_v7();
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_media_sync (mm_sync_guid, mm_sync_path, \
-        mm_sync_path_to, mm_sync_options_json) \
-        values ($1, $2, $3, $4)",
+        r#"insert into mm_media_sync (mm_sync_guid, mm_sync_path, mm_sync_path_to, mm_sync_options_json) values ($1, $2, $3, $4)"#,
     )
     .bind(new_guid)
     .bind(sync_path)
@@ -80,12 +78,7 @@ pub async fn mk_lib_database_sync_list(
 ) -> Result<Vec<DBSyncList>, sqlx::Error> {
     if user_id == uuid::Uuid::nil() {
         sqlx::query_as(
-            "select mm_sync_guid, mm_sync_path, \
-            mm_sync_path_to, mm_sync_options_json \
-            from mm_media_sync where mm_sync_guid in (select mm_sync_guid \
-            from mm_media_sync order by mm_sync_options_json->'Priority' desc, \
-            mm_sync_path offset $1 limit $2) \
-            order by mm_sync_options_json->'Priority' desc, mm_sync_path",
+            r#"select mm_sync_guid, mm_sync_path, mm_sync_path_to, mm_sync_options_json from mm_media_sync where mm_sync_guid in (select mm_sync_guid from mm_media_sync order by mm_sync_options_json->'Priority' desc, mm_sync_path offset $1 limit $2) order by mm_sync_options_json->'Priority' desc, mm_sync_path"#,
         )
         .bind(offset)
         .bind(limit)
@@ -93,13 +86,7 @@ pub async fn mk_lib_database_sync_list(
         .await
     } else {
         sqlx::query_as(
-            "select mm_sync_guid, mm_sync_path, \
-            mm_sync_path_to, mm_sync_options_json \
-            from mm_media_sync where mm_sync_guid in (select mm_sync_guid \
-            from mm_media_sync where mm_sync_options_json->'User'::text = $1 \
-            order by mm_sync_options_json->'Priority' desc, \
-            mm_sync_path offset $2 limit $3) \
-            order by mm_sync_options_json->'Priority' desc, mm_sync_path",
+            r#"select mm_sync_guid, mm_sync_path, mm_sync_path_to, mm_sync_options_json from mm_media_sync where mm_sync_guid in (select mm_sync_guid from mm_media_sync where mm_sync_options_json->'User'::text = $1 order by mm_sync_options_json->'Priority' desc, mm_sync_path offset $2 limit $3) order by mm_sync_options_json->'Priority' desc, mm_sync_path"#,
         )
         .bind(user_id)
         .bind(offset)

--- a/src/mk_lib_database/src/mk_lib_database_usage.rs
+++ b/src/mk_lib_database/src/mk_lib_database_usage.rs
@@ -11,9 +11,7 @@ pub async fn mk_lib_database_usage_top10_movie(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<DBMUsageMovieList>, sqlx::Error> {
     let table_rows: Vec<DBMUsageMovieList> = sqlx::query_as(
-        "select mm_metadata_name, \
-        mm_metadata_user_json->'Watched'->'Times' as mm_metadata_times \
-        from mm_metadata_movie order by mm_metadata_user_json->'Watched'->'Times' desc limit 10",
+        r#"select mm_metadata_name, mm_metadata_user_json->'Watched'->'Times' as mm_metadata_times from mm_metadata_movie order by mm_metadata_user_json->'Watched'->'Times' desc limit 10"#,
     )
     .fetch_all(sqlx_pool)
     .await?;
@@ -30,10 +28,7 @@ pub async fn mk_lib_database_usage_top10_tv(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<DBUsageTVList>, sqlx::Error> {
     let table_rows: Vec<DBUsageTVList> = sqlx::query_as(
-        "select mm_metadata_tvshow_name, \
-        mm_metadata_tvshow_user_json->'Watched'->'Times' as mm_metadata_times \
-        from mm_metadata_tvshow order by mm_metadata_tvshow_user_json->'Watched'->'Times' \
-        desc limit 10",
+        r#"select mm_metadata_tvshow_name, mm_metadata_tvshow_user_json->'Watched'->'Times' as mm_metadata_times from mm_metadata_tvshow order by mm_metadata_tvshow_user_json->'Watched'->'Times' desc limit 10"#,
     )
     .fetch_all(sqlx_pool)
     .await?;

--- a/src/mk_lib_database/src/mk_lib_database_user.rs
+++ b/src/mk_lib_database/src/mk_lib_database_user.rs
@@ -3,8 +3,8 @@ use axum_session_auth::Authentication;
 use axum_session_auth::*;
 use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgPool;
+use sqlx::FromRow;
 use std::collections::HashSet;
 
 /*
@@ -80,7 +80,7 @@ impl HasPermission<PgPool> for User {
 impl User {
     pub async fn get_user(id: i64, pool: &PgPool) -> Option<Self> {
         let sqluser = sqlx::query_as::<_, SqlUser>(
-            "SELECT id, anonymous, username FROM mm_axum_users WHERE id = $1",
+            r#"SELECT id, anonymous, username FROM mm_axum_users WHERE id = $1"#,
         )
         .bind(id)
         .fetch_one(pool)
@@ -88,7 +88,7 @@ impl User {
         .ok()?;
         // lets just get all the tokens the user can use, we will only use the full permissions if modifing them.
         let sql_user_perms = sqlx::query_as::<_, SqlPermissionTokens>(
-            "SELECT token FROM mm_axum_user_permissions WHERE user_id = $1",
+            r#"SELECT token FROM mm_axum_user_permissions WHERE user_id = $1"#,
         )
         .bind(id)
         .fetch_all(pool)
@@ -134,8 +134,7 @@ pub async fn mk_lib_database_user_exists(
     user_name: &String,
 ) -> Result<bool, sqlx::Error> {
     let row: (bool,) = sqlx::query_as(
-        "select exists(select 1 from mm_axum_users \
-        where username = $1 limit 1) limit 1",
+        r#"select exists(select 1 from mm_axum_users where username = $1 limit 1) limit 1"#,
     )
     .bind(user_name)
     .fetch_one(sqlx_pool)
@@ -159,8 +158,7 @@ pub async fn mk_lib_database_user_read(
     limit: i64,
 ) -> Result<Vec<DBUserList>, sqlx::Error> {
     let table_rows: Vec<DBUserList> = sqlx::query_as(
-        "select id, anonymous, username, email, last_signin, last_signoff \
-        from mm_axum_users order by LOWER(username) offset $1 limit $2",
+        r#"select id, anonymous, username, email, last_signin, last_signoff from mm_axum_users order by LOWER(username) offset $1 limit $2"#,
     )
     .bind(offset)
     .bind(limit)
@@ -174,15 +172,16 @@ pub async fn mk_lib_database_user_count(
     user_name: String,
 ) -> Result<i64, sqlx::Error> {
     if user_name == "" {
-        let row: (i64,) = sqlx::query_as("select count(*) from mm_axum_users")
+        let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_axum_users"#)
             .fetch_one(sqlx_pool)
             .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as("select count(*) from mm_axum_users where username = $1")
-            .bind(user_name)
-            .fetch_one(sqlx_pool)
-            .await?;
+        let row: (i64,) =
+            sqlx::query_as(r#"select count(*) from mm_axum_users where username = $1"#)
+                .bind(user_name)
+                .fetch_one(sqlx_pool)
+                .await?;
         Ok(row.0)
     }
 }
@@ -192,7 +191,7 @@ pub async fn mk_lib_database_user_delete(
     user_id: i64,
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
-    sqlx::query("delete from mm_axum_users where id = $1")
+    sqlx::query(r#"delete from mm_axum_users where id = $1"#)
         .bind(user_id)
         .execute(&mut *transaction)
         .await?;
@@ -205,17 +204,17 @@ pub async fn mk_lib_database_user_set_admin(
     user_id: i64,
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
-    sqlx::query("insert into mm_axum_user_permissions (user_id, token) values ($1, $2)")
+    sqlx::query(r#"insert into mm_axum_user_permissions (user_id, token) values ($1, $2)"#)
         .bind(user_id)
         .bind("Admin::View")
         .execute(&mut *transaction)
         .await?;
-    // sqlx::query("insert into mm_axum_user_permissions (user_id, token) values ($1, $2)")
+    // sqlx::query(r#"insert into mm_axum_user_permissions (user_id, token) values ($1, $2)"#)
     //     .bind(user_id)
     //     .bind("Category::View")
     //     .execute(&mut *transaction)
     //     .await?;
-    sqlx::query("insert into mm_axum_user_permissions (user_id, token) values ($1, $2)")
+    sqlx::query(r#"insert into mm_axum_user_permissions (user_id, token) values ($1, $2)"#)
         .bind(user_id)
         .bind("User::View")
         .execute(&mut *transaction)
@@ -231,10 +230,7 @@ pub async fn mk_lib_database_user_insert(
 ) -> Result<i64, sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     let row: (i64,) = sqlx::query_as(
-        "insert into mm_axum_users \
-        (username, password, anonymous) \
-        values ($1, crypt($2, gen_salt('bf', 10)), false) \
-        RETURNING id",
+        r#"insert into mm_axum_users (username, password, anonymous) values ($1, crypt($2, gen_salt('bf', 10)), false) RETURNING id"#,
     )
     .bind(username)
     .bind(password)
@@ -250,8 +246,7 @@ pub async fn mk_lib_database_user_login_verification(
     password: &String,
 ) -> Result<i64, sqlx::Error> {
     let row: (i64,) = sqlx::query_as(
-        "select coalesce((select id from mm_axum_users \
-        where username = $1 and password = crypt($2, password) limit 1), 0)",
+        r#"select coalesce((select id from mm_axum_users where username = $1 and password = crypt($2, password) limit 1), 0)"#,
     )
     .bind(username)
     .bind(password)
@@ -265,7 +260,7 @@ pub async fn mk_lib_database_user_login(
     user_id: i64,
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
-    sqlx::query("update mm_axum_users set last_signin = now() where id = $1")
+    sqlx::query(r#"update mm_axum_users set last_signin = now() where id = $1"#)
         .bind(user_id)
         .execute(&mut *transaction)
         .await?;
@@ -278,7 +273,7 @@ pub async fn mk_lib_database_user_logout(
     user_id: i64,
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
-    sqlx::query("update mm_axum_users set last_signoff = now() where id = $1")
+    sqlx::query(r#"update mm_axum_users set last_signoff = now() where id = $1"#)
         .bind(user_id)
         .execute(&mut *transaction)
         .await?;

--- a/src/mk_lib_database/src/mk_lib_database_user_activity.rs
+++ b/src/mk_lib_database/src/mk_lib_database_user_activity.rs
@@ -14,12 +14,7 @@ pub async fn mk_lib_database_activity_insert(
     let new_guid = Uuid::now_v7();
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_user_activity (mm_activity_guid, mm_activity_name, \
-        mm_activity_overview, mm_activity_short_overview, \
-        mm_activity_type, mm_activity_itemid, \
-        mm_activity_userid, mm_activity_datecreated, \
-        mm_activity_log_severity) \
-        values ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
+        r#"insert into mm_user_activity (mm_activity_guid, mm_activity_name, mm_activity_overview, mm_activity_short_overview, mm_activity_type, mm_activity_itemid, mm_activity_userid, mm_activity_datecreated, mm_activity_log_severity) values ($1,$2,$3,$4,$5,$6,$7,$8,$9)"#,
     )
     .bind(new_guid)
     .bind(activity_name)
@@ -42,8 +37,7 @@ pub async fn mk_lib_database_activity_delete(
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "delete from mm_user_activity \
-        where mm_activity_datecreated < now() - interval $1 day;",
+        r#"delete from mm_user_activity where mm_activity_datecreated < now() - interval $1 day;"#,
     )
     .bind(day_range)
     .execute(&mut *transaction)

--- a/src/mk_lib_database/src/mk_lib_database_user_profile.rs
+++ b/src/mk_lib_database/src/mk_lib_database_user_profile.rs
@@ -6,8 +6,7 @@ pub async fn mk_lib_database_user_profile_insert(
     let new_guid = uuid::Uuid::now_v7();
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        "insert into mm_user_profile(mm_user_profile_guid, \
-        mm_user_profile_name, mm_user_profile_json) values($1, $2, $3)",
+        r#"insert into mm_user_profile(mm_user_profile_guid, mm_user_profile_name, mm_user_profile_json) values($1, $2, $3)"#,
     )
     .bind(new_guid)
     .bind(profile_name)

--- a/src/mk_lib_database/src/mk_lib_database_user_queue.rs
+++ b/src/mk_lib_database/src/mk_lib_database_user_queue.rs
@@ -7,8 +7,7 @@ pub async fn mk_lib_database_meta_queue_count(
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
         let row: (i64,) = sqlx::query_as(
-            "select count(*) from mm_user_queue \
-            where mm_user_queue_name % $1 and mm_user_queue_user_id = $2",
+            r#"select count(*) from mm_user_queue where mm_user_queue_name % $1 and mm_user_queue_user_id = $2"#,
         )
         .bind(search_value)
         .bind(user_uuid)
@@ -17,8 +16,7 @@ pub async fn mk_lib_database_meta_queue_count(
         Ok(row.0)
     } else {
         let row: (i64,) = sqlx::query_as(
-            "select count(*) from mm_user_queue \
-            where mm_user_queue_user_id = $1",
+            r#"select count(*) from mm_user_queue where mm_user_queue_user_id = $1"#,
         )
         .bind(user_uuid)
         .fetch_one(sqlx_pool)

--- a/src/mk_lib_database/src/mk_lib_database_version.rs
+++ b/src/mk_lib_database/src/mk_lib_database_version.rs
@@ -1,20 +1,20 @@
 use crate::mk_lib_database_postgresql;
 use crate::mk_lib_database_version_schema;
-use tokio::time::{Duration, sleep};
+use tokio::time::{sleep, Duration};
 
 pub static DATABASE_VERSION: i32 = 78;
 
 pub async fn mk_lib_database_postgresql_version(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<String, sqlx::Error> {
-    let row: (String,) = sqlx::query_as("SELECT version();")
+    let row: (String,) = sqlx::query_as(r#"SELECT version();"#)
         .fetch_one(sqlx_pool)
         .await?;
     Ok(row.0)
 }
 
 pub async fn mk_lib_database_version(sqlx_pool: &sqlx::PgPool) -> Result<i32, sqlx::Error> {
-    let row: (i32,) = sqlx::query_as("select mm_version_number from mm_version")
+    let row: (i32,) = sqlx::query_as(r#"select mm_version_number from mm_version"#)
         .fetch_one(sqlx_pool)
         .await?;
     Ok(row.0)

--- a/src/mk_lib_database/src/mk_lib_database_version_schema.rs
+++ b/src/mk_lib_database/src/mk_lib_database_version_schema.rs
@@ -1,6 +1,6 @@
 use crate::mk_lib_database_option_status;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 pub async fn mk_lib_database_update_schema(
     sqlx_pool: &sqlx::PgPool,
@@ -19,14 +19,12 @@ pub async fn mk_lib_database_update_schema(
     if version_no < 45 {
         let mut transaction = sqlx_pool.begin().await?;
         sqlx::query(
-            "ALTER TABLE mm_metadata_game_software_info \
-            RENAME COLUMN gi_id TO gi_game_info_id;",
+            r#"ALTER TABLE mm_metadata_game_software_info RENAME COLUMN gi_id TO gi_game_info_id;"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "ALTER TABLE mm_metadata_game_software_info \
-            RENAME COLUMN gi_system_id TO gi_game_info_system_id;",
+            r#"ALTER TABLE mm_metadata_game_software_info RENAME COLUMN gi_system_id TO gi_game_info_system_id;"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -36,17 +34,12 @@ pub async fn mk_lib_database_update_schema(
     if version_no < 46 {
         let mut transaction = sqlx_pool.begin().await?;
         sqlx::query(
-            "ALTER TABLE mm_metadata_game_systems_info \
-            RENAME COLUMN gs_id TO gs_game_system_id;",
+            r#"ALTER TABLE mm_metadata_game_systems_info RENAME COLUMN gs_id TO gs_game_system_id;"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "INSERT INTO mm_metadata_game_systems_info \
-            (gs_game_system_id, \
-            gs_game_system_name, \
-            gs_game_system_alias) \
-            VALUES ($1, 'Arcade', 'Arcade')",
+            r#"INSERT INTO mm_metadata_game_systems_info (gs_game_system_id, gs_game_system_name, gs_game_system_alias) VALUES ($1, 'Arcade', 'Arcade')"#,
         )
         .bind(uuid::Uuid::nil())
         .execute(&mut *transaction)
@@ -57,12 +50,12 @@ pub async fn mk_lib_database_update_schema(
     if version_no < 47 {
         let mut transaction = sqlx_pool.begin().await?;
         sqlx::query(
-            "CREATE TABLE mm_hardware_model (
+            r#"CREATE TABLE mm_hardware_model (
                 mm_hardware_model_guid uuid NOT NULL,
                 mm_hardware_manufacturer text,
                 mm_hardware_model_type text,
                 mm_hardware_model_name text
-            );",
+            );"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -72,20 +65,18 @@ pub async fn mk_lib_database_update_schema(
     if version_no < 48 {
         let mut transaction = sqlx_pool.begin().await?;
         sqlx::query(
-            "ALTER TABLE ONLY mm_hardware_model
-            ADD CONSTRAINT mm_hardware_model_guid_pk PRIMARY KEY (mm_hardware_model_guid);",
+            r#"ALTER TABLE ONLY mm_hardware_model
+            ADD CONSTRAINT mm_hardware_model_guid_pk PRIMARY KEY (mm_hardware_model_guid);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX mm_hardware_manufacturer_name \
-            ON mm_hardware_model USING btree (mm_hardware_manufacturer);",
+            r#"CREATE INDEX mm_hardware_manufacturer_name ON mm_hardware_model USING btree (mm_hardware_manufacturer);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX mm_hardware_model_type_name \
-            ON mm_hardware_model USING btree (mm_hardware_model_type);",
+            r#"CREATE INDEX mm_hardware_model_type_name ON mm_hardware_model USING btree (mm_hardware_model_type);"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -95,9 +86,7 @@ pub async fn mk_lib_database_update_schema(
     if version_no < 49 {
         let mut transaction = sqlx_pool.begin().await?;
         sqlx::query(
-            "CREATE TABLE IF NOT EXISTS mm_network_shares (\
-            mm_network_share_guid uuid NOT NULL, \
-            mm_network_share_xml text);",
+            r#"CREATE TABLE IF NOT EXISTS mm_network_shares (mm_network_share_guid uuid NOT NULL, mm_network_share_xml text);"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -108,33 +97,22 @@ pub async fn mk_lib_database_update_schema(
     if version_no < 50 {
         let mut transaction = sqlx_pool.begin().await?;
         sqlx::query(
-            "CREATE TABLE IF NOT EXISTS mm_axum_users (\
-            id bigint Primary Key Generated Always as Identity, \
-            anonymous BOOLEAN NOT NULL, \
-            username VARCHAR(256) NOT NULL, \
-            password TEXT NOT NULL, \
-            email VARCHAR(256), \
-            last_signin timestamp, \
-            last_signoff timestamp);",
+            r#"CREATE TABLE IF NOT EXISTS mm_axum_users (id bigint Primary Key Generated Always as Identity, anonymous BOOLEAN NOT NULL, username VARCHAR(256) NOT NULL, password TEXT NOT NULL, email VARCHAR(256), last_signin timestamp, last_signoff timestamp);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "INSERT INTO mm_axum_users (anonymous, username, email, password) \
-            values (true, 'Guest', 'guest@fake.com', crypt('fakepass', gen_salt('bf', 10)));",
+            r#"INSERT INTO mm_axum_users (anonymous, username, email, password) values (true, 'Guest', 'guest@fake.com', crypt('fakepass', gen_salt('bf', 10)));"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE TABLE IF NOT EXISTS mm_axum_user_permissions (\
-            user_id INTEGER NOT NULL, \
-            token VARCHAR(256) NOT NULL);",
+            r#"CREATE TABLE IF NOT EXISTS mm_axum_user_permissions (user_id INTEGER NOT NULL, token VARCHAR(256) NOT NULL);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX mm_axum_user_permissions_user_id \
-            ON mm_axum_user_permissions USING btree (user_id);",
+            r#"CREATE INDEX mm_axum_user_permissions_user_id ON mm_axum_user_permissions USING btree (user_id);"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -144,16 +122,16 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 51 {
         let mut transaction = sqlx_pool.begin().await?;
-        sqlx::query("ALTER TABLE mm_network_shares DROP COLUMN mm_network_share_xml;")
+        sqlx::query(r#"ALTER TABLE mm_network_shares DROP COLUMN mm_network_share_xml;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_ip INET;")
+        sqlx::query(r#"ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_ip INET;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_path TEXT;")
+        sqlx::query(r#"ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_path TEXT;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_comment TEXT;")
+        sqlx::query(r#"ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_comment TEXT;"#)
             .execute(&mut *transaction)
             .await?;
         transaction.commit().await?;
@@ -163,18 +141,12 @@ pub async fn mk_lib_database_update_schema(
     if version_no < 52 {
         let mut transaction = sqlx_pool.begin().await?;
         sqlx::query(
-            "CREATE TABLE IF NOT EXISTS mm_backup (\
-                mm_backup_guid uuid NOT NULL, \
-                mm_backup_description TEXT NOT NULL, \
-                mm_backup_location_type integer NOT NULL, \
-                mm_backup_location TEXT NOT NULL, \
-                mm_backup_created timestamp NOT NULL);",
+            r#"CREATE TABLE IF NOT EXISTS mm_backup (mm_backup_guid uuid NOT NULL, mm_backup_description TEXT NOT NULL, mm_backup_location_type integer NOT NULL, mm_backup_location TEXT NOT NULL, mm_backup_created timestamp NOT NULL);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX mm_backup_created_ndx \
-           ON mm_backup USING btree (mm_backup_created);",
+            r#"CREATE INDEX mm_backup_created_ndx ON mm_backup USING btree (mm_backup_created);"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -184,7 +156,7 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 53 {
         let mut transaction = sqlx_pool.begin().await?;
-        sqlx::query("DROP TABLE IF EXISTS mm_user, mm_user_group, mm_user_profile;")
+        sqlx::query(r#"DROP TABLE IF EXISTS mm_user, mm_user_group, mm_user_profile;"#)
             .execute(&mut *transaction)
             .await?;
         transaction.commit().await?;
@@ -193,13 +165,13 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 54 {
         let mut transaction = sqlx_pool.begin().await?;
-        sqlx::query("DROP INDEX IF EXISTS mm_metadata_game_systems_info_ndx_name;")
+        sqlx::query(r#"DROP INDEX IF EXISTS mm_metadata_game_systems_info_ndx_name;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("CREATE UNIQUE INDEX IF NOT EXISTS mm_metadata_game_systems_info_ndx_name ON mm_metadata_game_systems_info USING btree (gs_game_system_name);")
+        sqlx::query(r#"CREATE UNIQUE INDEX IF NOT EXISTS mm_metadata_game_systems_info_ndx_name ON mm_metadata_game_systems_info USING btree (gs_game_system_name);"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("ALTER TABLE mm_metadata_game_systems_info ADD CONSTRAINT system_name_unique UNIQUE (gs_game_system_name);")
+        sqlx::query(r#"ALTER TABLE mm_metadata_game_systems_info ADD CONSTRAINT system_name_unique UNIQUE (gs_game_system_name);"#)
             .execute(&mut *transaction)
             .await?;
         transaction.commit().await?;
@@ -208,12 +180,11 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 55 {
         let mut transaction = sqlx_pool.begin().await?;
-        sqlx::query("ALTER TABLE mm_library_dir ADD COLUMN mm_media_dir_share_guid uuid;")
+        sqlx::query(r#"ALTER TABLE mm_library_dir ADD COLUMN mm_media_dir_share_guid uuid;"#)
             .execute(&mut *transaction)
             .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_media_dir_share_guid_ndx \
-            ON mm_library_dir USING btree (mm_media_dir_share_guid);",
+            r#"CREATE INDEX IF NOT EXISTS mm_media_dir_share_guid_ndx ON mm_library_dir USING btree (mm_media_dir_share_guid);"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -223,51 +194,48 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 56 {
         let mut transaction = sqlx_pool.begin().await?;
-        sqlx::query("ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_user text;")
+        sqlx::query(r#"ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_user text;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_password text;")
+        sqlx::query(r#"ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_password text;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_version smallint;")
-            .execute(&mut *transaction)
-            .await?;
+        sqlx::query(
+            r#"ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_version smallint;"#,
+        )
+        .execute(&mut *transaction)
+        .await?;
         transaction.commit().await?;
         mk_lib_database_version_update(&sqlx_pool, 56).await?;
     }
 
     if version_no < 57 {
         let mut transaction = sqlx_pool.begin().await?;
-        sqlx::query("ALTER TABLE mm_network_shares DROP COLUMN mm_network_share_user;")
+        sqlx::query(r#"ALTER TABLE mm_network_shares DROP COLUMN mm_network_share_user;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("ALTER TABLE mm_network_shares DROP COLUMN mm_network_share_password;")
+        sqlx::query(r#"ALTER TABLE mm_network_shares DROP COLUMN mm_network_share_password;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_user_guid uuid;")
+        sqlx::query(r#"ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_user_guid uuid;"#)
             .execute(&mut *transaction)
             .await?;
         sqlx::query(
-            "CREATE TABLE IF NOT EXISTS mm_share_auth (\
-                mm_share_auth_guid uuid NOT NULL, \
-                mm_share_auth_user TEXT NOT NULL, \
-                mm_share_auth_password TEXT NOT NULL);",
+            r#"CREATE TABLE IF NOT EXISTS mm_share_auth (mm_share_auth_guid uuid NOT NULL, mm_share_auth_user TEXT NOT NULL, mm_share_auth_password TEXT NOT NULL);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_share_auth_user_ndx \
-                ON mm_share_auth USING btree (mm_share_auth_user);",
+            r#"CREATE INDEX IF NOT EXISTS mm_share_auth_user_ndx ON mm_share_auth USING btree (mm_share_auth_user);"#,
         )
         .execute(&mut *transaction)
         .await?;
         let new_guid = uuid::Uuid::now_v7();
-        sqlx::query("INSERT INTO mm_share_auth (mm_share_auth_guid, mm_share_auth_user, mm_share_auth_password) \
-            values ($1, 'guest', crypt('guest', gen_salt('bf', 10)));")
+        sqlx::query(r#"INSERT INTO mm_share_auth (mm_share_auth_guid, mm_share_auth_user, mm_share_auth_password) values ($1, 'guest', crypt('guest', gen_salt('bf', 10)));"#)
             .bind(new_guid)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_workgroup text;")
+        sqlx::query(r#"ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_workgroup text;"#)
             .execute(&mut *transaction)
             .await?;
         transaction.commit().await?;
@@ -276,7 +244,7 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 58 {
         let mut transaction = sqlx_pool.begin().await?;
-        sqlx::query("ALTER TABLE mm_network_shares ADD PRIMARY KEY (mm_network_share_guid);")
+        sqlx::query(r#"ALTER TABLE mm_network_shares ADD PRIMARY KEY (mm_network_share_guid);"#)
             .execute(&mut *transaction)
             .await?;
         transaction.commit().await?;
@@ -285,18 +253,17 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 59 {
         let mut transaction = sqlx_pool.begin().await?;
-        sqlx::query("ALTER TABLE mm_library_dir DROP COLUMN mm_media_dir_username;")
+        sqlx::query(r#"ALTER TABLE mm_library_dir DROP COLUMN mm_media_dir_username;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("ALTER TABLE mm_library_dir DROP COLUMN mm_media_dir_password;")
+        sqlx::query(r#"ALTER TABLE mm_library_dir DROP COLUMN mm_media_dir_password;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("ALTER TABLE mm_library_dir ADD COLUMN mm_media_dir_auth_user uuid;")
+        sqlx::query(r#"ALTER TABLE mm_library_dir ADD COLUMN mm_media_dir_auth_user uuid;"#)
             .execute(&mut *transaction)
             .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_media_dir_auth_user_ndx \
-            ON mm_library_dir USING btree (mm_media_dir_auth_user);",
+            r#"CREATE INDEX IF NOT EXISTS mm_media_dir_auth_user_ndx ON mm_library_dir USING btree (mm_media_dir_auth_user);"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -306,7 +273,7 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 60 {
         let mut transaction = sqlx_pool.begin().await?;
-        sqlx::query("ALTER TABLE mm_library_dir DROP COLUMN mm_media_dir_auth_user;")
+        sqlx::query(r#"ALTER TABLE mm_library_dir DROP COLUMN mm_media_dir_auth_user;"#)
             .execute(&mut *transaction)
             .await?;
         transaction.commit().await?;
@@ -315,7 +282,7 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 61 {
         // let mut transaction = sqlx_pool.begin().await?;
-        // sqlx::query("CREATE EXTENSION IF NOT EXISTS citus WITH SCHEMA pg_catalog;")
+        // sqlx::query(r#"CREATE EXTENSION IF NOT EXISTS citus WITH SCHEMA pg_catalog;"#)
         //     .execute(&mut *transaction)
         //     .await?;
         // transaction.commit().await?;
@@ -325,59 +292,47 @@ pub async fn mk_lib_database_update_schema(
     if version_no < 62 {
         let mut transaction = sqlx_pool.begin().await?;
         sqlx::query(
-            "CREATE TABLE IF NOT EXISTS mm_openlib_author (\
-                mm_openlib_author_id TEXT NOT NULL, \
-                mm_openlib_author_json JSONB NOT NULL);",
+            r#"CREATE TABLE IF NOT EXISTS mm_openlib_author (mm_openlib_author_id TEXT NOT NULL, mm_openlib_author_json JSONB NOT NULL);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_openlib_author_id_ndx \
-                ON mm_openlib_author USING btree (mm_openlib_author_id);",
+            r#"CREATE INDEX IF NOT EXISTS mm_openlib_author_id_ndx ON mm_openlib_author USING btree (mm_openlib_author_id);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_openlib_author_json_ndx \
-                ON mm_openlib_author USING gin (mm_openlib_author_json);",
+            r#"CREATE INDEX IF NOT EXISTS mm_openlib_author_json_ndx ON mm_openlib_author USING gin (mm_openlib_author_json);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE TABLE IF NOT EXISTS mm_openlib_edition (\
-                mm_openlib_edition_id TEXT NOT NULL, \
-                mm_openlib_edition_json JSONB NOT NULL);",
+            r#"CREATE TABLE IF NOT EXISTS mm_openlib_edition (mm_openlib_edition_id TEXT NOT NULL, mm_openlib_edition_json JSONB NOT NULL);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_openlib_edition_id_ndx \
-                ON mm_openlib_edition USING btree (mm_openlib_edition_id);",
+            r#"CREATE INDEX IF NOT EXISTS mm_openlib_edition_id_ndx ON mm_openlib_edition USING btree (mm_openlib_edition_id);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_openlib_edition_json_ndx \
-            ON mm_openlib_edition USING gin (mm_openlib_edition_json);",
+            r#"CREATE INDEX IF NOT EXISTS mm_openlib_edition_json_ndx ON mm_openlib_edition USING gin (mm_openlib_edition_json);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE TABLE IF NOT EXISTS mm_openlib_work (\
-                mm_openlib_work_id TEXT NOT NULL, \
-                mm_openlib_work_json JSONB NOT NULL);",
+            r#"CREATE TABLE IF NOT EXISTS mm_openlib_work (mm_openlib_work_id TEXT NOT NULL, mm_openlib_work_json JSONB NOT NULL);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_openlib_work_id_ndx \
-                ON mm_openlib_work USING btree (mm_openlib_work_id);",
+            r#"CREATE INDEX IF NOT EXISTS mm_openlib_work_id_ndx ON mm_openlib_work USING btree (mm_openlib_work_id);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_openlib_work_json_ndx \
-            ON mm_openlib_work USING gin (mm_openlib_work_json);",
+            r#"CREATE INDEX IF NOT EXISTS mm_openlib_work_json_ndx ON mm_openlib_work USING gin (mm_openlib_work_json);"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -388,21 +343,17 @@ pub async fn mk_lib_database_update_schema(
     if version_no < 63 {
         let mut transaction = sqlx_pool.begin().await?;
         sqlx::query(
-            "CREATE TABLE IF NOT EXISTS mm_openlib_rating (\
-                mm_openlib_rating_id TEXT NOT NULL, \
-                mm_openlib_rating_json JSONB NOT NULL);",
+            r#"CREATE TABLE IF NOT EXISTS mm_openlib_rating (mm_openlib_rating_id TEXT NOT NULL, mm_openlib_rating_json JSONB NOT NULL);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_openlib_rating_id_ndx \
-                ON mm_openlib_rating USING btree (mm_openlib_rating_id);",
+            r#"CREATE INDEX IF NOT EXISTS mm_openlib_rating_id_ndx ON mm_openlib_rating USING btree (mm_openlib_rating_id);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_openlib_rating_json_ndx \
-                ON mm_openlib_rating USING gin (mm_openlib_rating_json);",
+            r#"CREATE INDEX IF NOT EXISTS mm_openlib_rating_json_ndx ON mm_openlib_rating USING gin (mm_openlib_rating_json);"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -412,39 +363,35 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 64 {
         let mut transaction = sqlx_pool.begin().await?;
-        sqlx::query("DROP INDEX IF EXISTS mm_openlib_author_id_ndx;")
+        sqlx::query(r#"DROP INDEX IF EXISTS mm_openlib_author_id_ndx;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("DROP INDEX IF EXISTS mm_openlib_edition_id_ndx;")
+        sqlx::query(r#"DROP INDEX IF EXISTS mm_openlib_edition_id_ndx;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("DROP INDEX IF EXISTS mm_openlib_rating_id_ndx;")
+        sqlx::query(r#"DROP INDEX IF EXISTS mm_openlib_rating_id_ndx;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("DROP INDEX IF EXISTS mm_openlib_work_id_ndx;")
+        sqlx::query(r#"DROP INDEX IF EXISTS mm_openlib_work_id_ndx;"#)
             .execute(&mut *transaction)
             .await?;
         sqlx::query(
-            "CREATE UNIQUE INDEX IF NOT EXISTS mm_openlib_author_id_ndx \
-                ON mm_openlib_author USING btree (mm_openlib_author_id);",
+            r#"CREATE UNIQUE INDEX IF NOT EXISTS mm_openlib_author_id_ndx ON mm_openlib_author USING btree (mm_openlib_author_id);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE UNIQUE INDEX IF NOT EXISTS mm_openlib_edition_id_ndx \
-                ON mm_openlib_edition USING btree (mm_openlib_edition_id);",
+            r#"CREATE UNIQUE INDEX IF NOT EXISTS mm_openlib_edition_id_ndx ON mm_openlib_edition USING btree (mm_openlib_edition_id);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE UNIQUE INDEX IF NOT EXISTS mm_openlib_rating_id_ndx \
-                ON mm_openlib_rating USING btree (mm_openlib_rating_id);",
+            r#"CREATE UNIQUE INDEX IF NOT EXISTS mm_openlib_rating_id_ndx ON mm_openlib_rating USING btree (mm_openlib_rating_id);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE UNIQUE INDEX IF NOT EXISTS mm_openlib_work_id_ndx \
-                ON mm_openlib_work USING btree (mm_openlib_work_id);",
+            r#"CREATE UNIQUE INDEX IF NOT EXISTS mm_openlib_work_id_ndx ON mm_openlib_work USING btree (mm_openlib_work_id);"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -454,7 +401,7 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 65 {
         let mut transaction = sqlx_pool.begin().await?;
-        sqlx::query("DROP TABLE IF EXISTS mm_openlib_rating;")
+        sqlx::query(r#"DROP TABLE IF EXISTS mm_openlib_rating;"#)
             .execute(&mut *transaction)
             .await?;
         transaction.commit().await?;
@@ -464,12 +411,12 @@ pub async fn mk_lib_database_update_schema(
     if version_no < 66 {
         let mut transaction = sqlx_pool.begin().await?;
         sqlx::query(
-            "ALTER TABLE mm_axum_users ALTER COLUMN last_signin TYPE timestamp with time zone;",
+            r#"ALTER TABLE mm_axum_users ALTER COLUMN last_signin TYPE timestamp with time zone;"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "ALTER TABLE mm_axum_users ALTER COLUMN last_signoff TYPE timestamp with time zone;",
+            r#"ALTER TABLE mm_axum_users ALTER COLUMN last_signoff TYPE timestamp with time zone;"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -480,42 +427,32 @@ pub async fn mk_lib_database_update_schema(
     if version_no < 67 {
         let mut transaction = sqlx_pool.begin().await?;
         sqlx::query(
-            "CREATE TABLE IF NOT EXISTS mm_bar_codes (\
-            mm_bar_code_uuid UUID NOT NULL, \
-            mm_bar_code_code TEXT NOT NULL, \
-            mm_bar_code_type SMALLINT NOT NULL, \
-            mm_bar_code_json JSONB);",
+            r#"CREATE TABLE IF NOT EXISTS mm_bar_codes (mm_bar_code_uuid UUID NOT NULL, mm_bar_code_code TEXT NOT NULL, mm_bar_code_type SMALLINT NOT NULL, mm_bar_code_json JSONB);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE UNIQUE INDEX IF NOT EXISTS mm_bar_code_uuid_ndx \
-            ON mm_bar_codes USING btree (mm_bar_code_uuid);",
+            r#"CREATE UNIQUE INDEX IF NOT EXISTS mm_bar_code_uuid_ndx ON mm_bar_codes USING btree (mm_bar_code_uuid);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_bar_code_code_ndx \
-            ON mm_bar_codes USING btree (mm_bar_code_code);",
+            r#"CREATE INDEX IF NOT EXISTS mm_bar_code_code_ndx ON mm_bar_codes USING btree (mm_bar_code_code);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_bar_code_type_ndx \
-            ON mm_bar_codes USING btree (mm_bar_code_type);",
+            r#"CREATE INDEX IF NOT EXISTS mm_bar_code_type_ndx ON mm_bar_codes USING btree (mm_bar_code_type);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE TABLE IF NOT EXISTS mm_bar_code_own (\
-            mm_bar_code_own_uuid UUID NOT NULL, \
-            mm_bar_code_own_user INTEGER NOT NULL);",
+            r#"CREATE TABLE IF NOT EXISTS mm_bar_code_own (mm_bar_code_own_uuid UUID NOT NULL, mm_bar_code_own_user INTEGER NOT NULL);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_bar_code_own_ndx \
-            ON mm_bar_code_own USING btree (mm_bar_code_own_user, mm_bar_code_own_uuid);",
+            r#"CREATE INDEX IF NOT EXISTS mm_bar_code_own_ndx ON mm_bar_code_own USING btree (mm_bar_code_own_user, mm_bar_code_own_uuid);"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -525,26 +462,18 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 68 {
         let mut transaction = sqlx_pool.begin().await?;
-        sqlx::query("ALTER TABLE mm_metadata_movie ADD COLUMN mm_metadata_movie_name_alt text;")
+        sqlx::query(r#"ALTER TABLE mm_metadata_movie ADD COLUMN mm_metadata_movie_name_alt text;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("ALTER TABLE mm_metadata_tvshow ADD COLUMN mm_metadata_tvshow_name_alt text;")
+        sqlx::query(
+            r#"ALTER TABLE mm_metadata_tvshow ADD COLUMN mm_metadata_tvshow_name_alt text;"#,
+        )
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(r#"alter table mm_metadata_movie add title_search tsvector generated always as	( setweight(to_tsvector('simple', coalesce(mm_metadata_movie_name, '')), 'A') || ' ' || setweight(to_tsvector('simple', coalesce(mm_metadata_movie_name_alt, '')), 'B') :: tsvector ) stored;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("alter table mm_metadata_movie \
-            add title_search tsvector \
-            generated always as	( \
-                setweight(to_tsvector('simple', coalesce(mm_metadata_movie_name, '')), 'A') || ' ' || \
-                setweight(to_tsvector('simple', coalesce(mm_metadata_movie_name_alt, '')), 'B') :: tsvector \
-            ) stored;")
-            .execute(&mut *transaction)
-            .await?;
-        sqlx::query("alter table mm_metadata_tvshow \
-            add title_search tsvector \
-            generated always as	( \
-                setweight(to_tsvector('simple', coalesce(mm_metadata_tvshow_name, '')), 'A') || ' ' || \
-                setweight(to_tsvector('simple', coalesce(mm_metadata_tvshow_name_alt, '')), 'B') :: tsvector \
-            ) stored;")
+        sqlx::query(r#"alter table mm_metadata_tvshow add title_search tsvector generated always as	( setweight(to_tsvector('simple', coalesce(mm_metadata_tvshow_name, '')), 'A') || ' ' || setweight(to_tsvector('simple', coalesce(mm_metadata_tvshow_name_alt, '')), 'B') :: tsvector ) stored;"#)
             .execute(&mut *transaction)
             .await?;
         transaction.commit().await?;
@@ -554,14 +483,12 @@ pub async fn mk_lib_database_update_schema(
     if version_no < 69 {
         let mut transaction = sqlx_pool.begin().await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_metadata_movie_fts_ndx \
-                ON mm_metadata_movie USING gin (title_search);",
+            r#"CREATE INDEX IF NOT EXISTS mm_metadata_movie_fts_ndx ON mm_metadata_movie USING gin (title_search);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_metadata_tvshow_fts_ndx \
-                ON mm_metadata_tvshow USING gin (title_search);",
+            r#"CREATE INDEX IF NOT EXISTS mm_metadata_tvshow_fts_ndx ON mm_metadata_tvshow USING gin (title_search);"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -571,7 +498,7 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 70 {
         // let mut transaction = sqlx_pool.begin().await?;
-        // sqlx::query("CREATE EXTENSION IF NOT EXISTS pgroonga")
+        // sqlx::query(r#"CREATE EXTENSION IF NOT EXISTS pgroonga"#)
         //     .execute(&mut *transaction)
         //     .await?;
         // sqlx::query(
@@ -646,16 +573,16 @@ pub async fn mk_lib_database_update_schema(
 
     // if version_no < 71 {
     //     // let mut transaction = sqlx_pool.begin().await?;
-    //     sqlx::query("CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA pg_catalog;")
+    //     sqlx::query(r#"CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA pg_catalog;"#)
     //         .execute(&mut *transaction)
     //         .await?;
-    //     sqlx::query("CREATE EXTENSION IF NOT EXISTS timescaledb WITH SCHEMA pg_catalog;")
+    //     sqlx::query(r#"CREATE EXTENSION IF NOT EXISTS timescaledb WITH SCHEMA pg_catalog;"#)
     //         .execute(&mut *transaction)
     //         .await?;
-    //     sqlx::query("CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA pg_catalog;")
+    //     sqlx::query(r#"CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA pg_catalog;"#)
     //         .execute(&mut *transaction)
     //         .await?;
-    //     sqlx::query("CREATE EXTENSION IF NOT EXISTS vectorscale WITH SCHEMA pg_catalog;")
+    //     sqlx::query(r#"CREATE EXTENSION IF NOT EXISTS vectorscale WITH SCHEMA pg_catalog;"#)
     //         .execute(&mut *transaction)
     //         .await?;
     //     transaction.commit().await?;
@@ -664,7 +591,7 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 72 {
         let mut transaction = sqlx_pool.begin().await?;
-        sqlx::query("ALTER TABLE mm_notification RENAME COLUMN mm_notification_dismissable TO mm_notification_dismissible;")
+        sqlx::query(r#"ALTER TABLE mm_notification RENAME COLUMN mm_notification_dismissable TO mm_notification_dismissible;"#)
             .execute(&mut *transaction)
             .await?;
         transaction.commit().await?;
@@ -678,7 +605,7 @@ pub async fn mk_lib_database_update_schema(
           "route_key": "mktmdbnetfetchbulk",
         });
         sqlx::query(
-            "update mm_cron_jobs set mm_cron_json = $1 where mm_cron_name = 'The Movie Database';",
+            r#"update mm_cron_jobs set mm_cron_json = $1 where mm_cron_name = 'The Movie Database';"#,
         )
         .bind(json_data)
         .execute(&mut *transaction)
@@ -687,7 +614,7 @@ pub async fn mk_lib_database_update_schema(
           "Type": "HDTrailers",
           "route_key": "mkdownload",
         });
-        sqlx::query("update mm_cron_jobs set mm_cron_json = $1 where mm_cron_name = 'Trailer';")
+        sqlx::query(r#"update mm_cron_jobs set mm_cron_json = $1 where mm_cron_name = 'Trailer';"#)
             .bind(json_data)
             .execute(&mut *transaction)
             .await?;
@@ -696,7 +623,7 @@ pub async fn mk_lib_database_update_schema(
           "route_key": "mkschedulesdirectupdate",
         });
         sqlx::query(
-            "update mm_cron_jobs set mm_cron_json = $1 where mm_cron_name = 'Schedules Direct';",
+            r#"update mm_cron_jobs set mm_cron_json = $1 where mm_cron_name = 'Schedules Direct';"#,
         )
         .bind(json_data)
         .execute(&mut *transaction)
@@ -705,26 +632,28 @@ pub async fn mk_lib_database_update_schema(
           "Type": "Library Scan",
           "route_key": "mkmediascanner",
         });
-        sqlx::query("update mm_cron_jobs set mm_cron_json = $1 where mm_cron_name = 'Media Scan';")
-            .bind(json_data)
+        sqlx::query(
+            r#"update mm_cron_jobs set mm_cron_json = $1 where mm_cron_name = 'Media Scan';"#,
+        )
+        .bind(json_data)
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(r#"delete from mm_cron_jobs where mm_cron_name = 'Sync';"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("delete from mm_cron_jobs where mm_cron_name = 'Sync';")
+        sqlx::query(r#"delete from mm_cron_jobs where mm_cron_name = 'DB Vacuum';"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("delete from mm_cron_jobs where mm_cron_name = 'DB Vacuum';")
+        sqlx::query(r#"delete from mm_cron_jobs where mm_cron_name = 'Retro game data';"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("delete from mm_cron_jobs where mm_cron_name = 'Retro game data';")
+        sqlx::query(r#"delete from mm_cron_jobs where mm_cron_name = 'Anime';"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("delete from mm_cron_jobs where mm_cron_name = 'Anime';")
+        sqlx::query(r#"delete from mm_cron_jobs where mm_cron_name = 'Collections';"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("delete from mm_cron_jobs where mm_cron_name = 'Collections';")
-            .execute(&mut *transaction)
-            .await?;
-        sqlx::query("delete from mm_cron_jobs where mm_cron_name = 'Backup';")
+        sqlx::query(r#"delete from mm_cron_jobs where mm_cron_name = 'Backup';"#)
             .execute(&mut *transaction)
             .await?;
         transaction.commit().await?;
@@ -733,12 +662,11 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 74 {
         let mut transaction = sqlx_pool.begin().await?;
-        sqlx::query("ALTER TABLE mm_bar_codes ADD COLUMN mm_bar_code_metadata_uuid uuid;")
+        sqlx::query(r#"ALTER TABLE mm_bar_codes ADD COLUMN mm_bar_code_metadata_uuid uuid;"#)
             .execute(&mut *transaction)
             .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_bar_codes_metadata_uuid_ndx \
-                ON mm_bar_codes USING btree (mm_bar_code_metadata_uuid);",
+            r#"CREATE INDEX IF NOT EXISTS mm_bar_codes_metadata_uuid_ndx ON mm_bar_codes USING btree (mm_bar_code_metadata_uuid);"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -749,82 +677,65 @@ pub async fn mk_lib_database_update_schema(
     if version_no < 75 {
         let mut transaction = sqlx_pool.begin().await?;
         // remove user jsons from metadata tables
-        sqlx::query("ALTER TABLE mm_metadata_book DROP COLUMN mm_metadata_book_user_json;")
+        sqlx::query(r#"ALTER TABLE mm_metadata_book DROP COLUMN mm_metadata_book_user_json;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("ALTER TABLE mm_metadata_movie DROP COLUMN mm_metadata_movie_user_json;")
+        sqlx::query(r#"ALTER TABLE mm_metadata_movie DROP COLUMN mm_metadata_movie_user_json;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("ALTER TABLE mm_metadata_music DROP COLUMN mm_metadata_music_user_json;")
+        sqlx::query(r#"ALTER TABLE mm_metadata_music DROP COLUMN mm_metadata_music_user_json;"#)
             .execute(&mut *transaction)
             .await?;
         sqlx::query(
-            "ALTER TABLE mm_metadata_music_video DROP COLUMN mm_metadata_music_video_user_json;",
+            r#"ALTER TABLE mm_metadata_music_video DROP COLUMN mm_metadata_music_video_user_json;"#,
         )
         .execute(&mut *transaction)
         .await?;
-        sqlx::query("ALTER TABLE mm_metadata_sports DROP COLUMN mm_metadata_sports_user_json;")
+        sqlx::query(r#"ALTER TABLE mm_metadata_sports DROP COLUMN mm_metadata_sports_user_json;"#)
             .execute(&mut *transaction)
             .await?;
-        sqlx::query("ALTER TABLE mm_metadata_tvshow DROP COLUMN mm_metadata_tvshow_user_json;")
+        sqlx::query(r#"ALTER TABLE mm_metadata_tvshow DROP COLUMN mm_metadata_tvshow_user_json;"#)
             .execute(&mut *transaction)
             .await?;
         // create metadata status table
         sqlx::query(
-            "CREATE TABLE IF NOT EXISTS mm_metadata_user_status ( \
-            mm_status_guid uuid NOT NULL, \
-            mm_status_user_id bigint NOT NULL, \
-            mm_status_user_json jsonb NOT NULL, \
-            mm_status_type_book uuid, \
-            mm_status_type_movie uuid, \
-            mm_status_type_music uuid, \
-            mm_status_type_music_video uuid, \
-            mm_status_type_sports uuid, \
-            mm_status_type_tvshow uuid, \
-            CONSTRAINT mm_metadata_user_status_pkey PRIMARY KEY (mm_status_guid));",
+            r#"CREATE TABLE IF NOT EXISTS mm_metadata_user_status ( mm_status_guid uuid NOT NULL, mm_status_user_id bigint NOT NULL, mm_status_user_json jsonb NOT NULL, mm_status_type_book uuid, mm_status_type_movie uuid, mm_status_type_music uuid, mm_status_type_music_video uuid, mm_status_type_sports uuid, mm_status_type_tvshow uuid, CONSTRAINT mm_metadata_user_status_pkey PRIMARY KEY (mm_status_guid));"#,
         )
         .execute(&mut *transaction)
         .await?;
         // create indexes
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_metadata_user_status_user_id_ndx \
-                ON mm_metadata_user_status USING btree (mm_status_user_id);",
+            r#"CREATE INDEX IF NOT EXISTS mm_metadata_user_status_user_id_ndx ON mm_metadata_user_status USING btree (mm_status_user_id);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_status_type_book_uuid_ndx \
-                ON mm_metadata_user_status USING btree (mm_status_type_book);",
+            r#"CREATE INDEX IF NOT EXISTS mm_status_type_book_uuid_ndx ON mm_metadata_user_status USING btree (mm_status_type_book);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_status_type_movie_uuid_ndx \
-                ON mm_metadata_user_status USING btree (mm_status_type_movie);",
+            r#"CREATE INDEX IF NOT EXISTS mm_status_type_movie_uuid_ndx ON mm_metadata_user_status USING btree (mm_status_type_movie);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mmm_status_type_music_uuid_ndx \
-                ON mm_metadata_user_status USING btree (mm_status_type_music);",
+            r#"CREATE INDEX IF NOT EXISTS mmm_status_type_music_uuid_ndx ON mm_metadata_user_status USING btree (mm_status_type_music);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_status_type_music_video_uuid_ndx \
-                ON mm_metadata_user_status USING btree (mm_status_type_music_video);",
+            r#"CREATE INDEX IF NOT EXISTS mm_status_type_music_video_uuid_ndx ON mm_metadata_user_status USING btree (mm_status_type_music_video);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_status_type_sports_uuid_ndx \
-                ON mm_metadata_user_status USING btree (mm_status_type_sports);",
+            r#"CREATE INDEX IF NOT EXISTS mm_status_type_sports_uuid_ndx ON mm_metadata_user_status USING btree (mm_status_type_sports);"#,
         )
         .execute(&mut *transaction)
         .await?;
         sqlx::query(
-            "CREATE INDEX IF NOT EXISTS mm_status_type_tvshow_uuid_ndx \
-                ON mm_metadata_user_status USING btree (mm_status_type_tvshow);",
+            r#"CREATE INDEX IF NOT EXISTS mm_status_type_tvshow_uuid_ndx ON mm_metadata_user_status USING btree (mm_status_type_tvshow);"#,
         )
         .execute(&mut *transaction)
         .await?;
@@ -942,7 +853,7 @@ pub async fn mk_lib_database_version_update(
     version_number: i32,
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
-    sqlx::query("update mm_version set mm_version_number = $1")
+    sqlx::query(r#"update mm_version set mm_version_number = $1"#)
         .bind(version_number)
         .execute(&mut *transaction)
         .await?;


### PR DESCRIPTION
### Motivation

- Standardize SQL query string handling to avoid escape noise and make queries easier to read and maintain. 
- Ensure consistent `sqlx` imports and minor import ordering fixes for clarity. 
- Prepare code for safer future edits to SQL statements and schema migrations by using raw string literals.

### Description

- Converted many SQL string literals to raw string literals using `r#"..."#` (and `r##"..."##` where needed) throughout the `mk_lib_database` crate to preserve query formatting and remove embedded newline/escape clutter. 
- Normalized placement of the `use sqlx::FromRow;` import across modules and tidied a few other imports (for example `tokio::time::{sleep, Duration}`).
- Replaced a number of multi-line concatenated/escaped query strings with single raw string queries in many modules including `media`, `metadata`, and top-level database helpers to improve readability. 
- Small syntax cleanups where necessary (single-line query formatting, minor query fixes and placeholder empty query string raw-literal conversions). 

### Testing

- Ran `cargo build` for the workspace and the build completed successfully. 
- Ran `cargo test` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa0875e7dc8321851e57269927fdb2)