### PR TITLE
Normalize movie starts_with filter and update DB queries to handle symbol buckets

### DIFF
--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
@@ -70,6 +70,21 @@ pub struct FilterQuery {
     pub starts_with: Option<String>,
 }
 
+fn normalize_starts_with(raw: Option<&str>) -> Option<String> {
+    let value = raw.map(str::trim).filter(|value| !value.is_empty())?;
+    let first_char = value.chars().next()?;
+
+    if first_char == '#' {
+        return Some("#".to_string());
+    }
+
+    if first_char.is_ascii_alphanumeric() {
+        return Some(first_char.to_ascii_uppercase().to_string());
+    }
+
+    Some("#".to_string())
+}
+
 fn build_movie_pagination(
     total_items: i64,
     page: i64,
@@ -168,6 +183,7 @@ pub async fn user_metadata_movie(
     Path(page): Path<i64>,
     Query(params): Query<FilterQuery>,
 ) -> impl IntoResponse {
+    let starts_with = normalize_starts_with(params.starts_with.as_deref());
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
         [Method::GET],
@@ -187,18 +203,18 @@ pub async fn user_metadata_movie(
         mk_lib_database::database_metadata::mk_lib_database_metadata_movie::mk_lib_database_metadata_movie_count(
            &state.sqlx_pool_ro,
             String::new(),
-            params.starts_with.clone().unwrap_or_default(),
+            starts_with.clone().unwrap_or_default(),
         )
         .await
         .unwrap();
         let pagination_html =
-            build_movie_pagination(total_pages, page, params.starts_with.as_deref()).unwrap();
+            build_movie_pagination(total_pages, page, starts_with.as_deref()).unwrap();
         let movie_list =
         mk_lib_database::database_metadata::mk_lib_database_metadata_movie::mk_lib_database_metadata_movie_read(
             &state.sqlx_pool_ro,
             String::new(),
             current_user.id,
-            params.starts_with.clone().unwrap_or_default(),
+            starts_with.clone().unwrap_or_default(),
             db_offset,
             30,
         )
@@ -288,7 +304,7 @@ pub async fn user_metadata_movie(
             pagination_bar: &pagination_html,
             page: &page_usize,
             page_title: Some("MediaKraken Metadata Movies".to_string()),
-            current: params.starts_with.clone(),
+            current: starts_with.clone(),
             base_path: "/user/metadata/movie".to_string(),
         };
         let reply_html = template.render().unwrap();

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs
@@ -1,10 +1,10 @@
 use crate::mk_lib_database::MediaStatusUpdatePayload;
 use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
 use sqlx::postgres::PgRow;
+use sqlx::types::Uuid;
 use sqlx::types::chrono::DateTime;
 use sqlx::types::chrono::Utc;
-use sqlx::types::Uuid;
-use sqlx::FromRow;
 
 pub async fn mk_lib_database_metadata_exists_movie(
     sqlx_pool: &sqlx::PgPool,
@@ -89,13 +89,15 @@ pub async fn mk_lib_database_metadata_movie_read(
             LEFT JOIN mm_metadata_user_status
             ON mm_metadata_user_status.mm_status_type_movie = mm_metadata_movie.mm_metadata_movie_guid
             and mm_metadata_user_status.mm_status_user_id = $1
-            WHERE LOWER(mm_metadata_movie_name) >= lower(left($2, 1))
-            AND LOWER(mm_metadata_movie_name) < chr(ascii(lower(left($2, 1))) + 1) 
+            WHERE (
+                ($2 = '#' AND left(lower(mm_metadata_movie_name), 1) !~ '^[a-z0-9]$')
+                OR ($2 <> '#' AND lower(mm_metadata_movie_name) LIKE lower($2) || '%')
+            )
             order by LOWER(mm_metadata_movie_name), mm_date
             offset $3 limit $4"#,
         )
         .bind(&user_id)
-        .bind(&starts_with.to_lowercase())
+        .bind(&starts_with)
         .bind(offset)
         .bind(limit)
             .fetch_all(sqlx_pool)
@@ -117,12 +119,16 @@ pub async fn mk_lib_database_metadata_movie_count(
         .await?;
         Ok(row.0)
     } else {
-        let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_metadata_movie 
-            WHERE LOWER(mm_metadata_movie_name) >= lower(left($1, 1))
-            AND LOWER(mm_metadata_movie_name) < chr(ascii(lower(left($1, 1))) + 1)"#)
-            .bind(starts_with.to_lowercase())
-            .fetch_one(sqlx_pool)
-            .await?;
+        let row: (i64,) = sqlx::query_as(
+            r#"select count(*) from mm_metadata_movie 
+            WHERE (
+                ($1 = '#' AND left(lower(mm_metadata_movie_name), 1) !~ '^[a-z0-9]$')
+                OR ($1 <> '#' AND lower(mm_metadata_movie_name) LIKE lower($1) || '%')
+            )"#,
+        )
+        .bind(starts_with)
+        .fetch_one(sqlx_pool)
+        .await?;
         Ok(row.0)
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure consistent handling of the `starts_with` query parameter by normalizing input and treating non-alphanumeric leading characters as a symbol bucket (`#`).
- Align pagination, count and read queries with the normalized filter so UI and DB results match expected behavior for letters, digits, and symbols.

### Description
- Added `normalize_starts_with` helper to trim input and convert it to a single uppercase character or `#` for symbol/non-alphanumeric buckets.
- Updated `user_metadata_movie` to use the normalized `starts_with` for pagination generation, count lookup, and movie reads.
- Rewrote SQL predicates in `mk_lib_database_metadata_movie_read` and `mk_lib_database_metadata_movie_count` to treat `'#'` as entries whose first character is not `[a-z0-9]` and otherwise use `lower(... ) LIKE lower($N) || '%'` for starts-with matching.
- Adjusted imports in the database crate to include `sqlx::FromRow` and `sqlx::types::Uuid` and updated parameter bindings to pass the normalized `starts_with` string.

### Testing
- Ran `cargo build` across the workspace and the modified crates, and the build completed successfully.
- Ran the project test suites with `cargo test` for the affected crates and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab745b26cc83219da9ff9ea24a98b7)