### PR TITLE
mkwebaxum: add movie genre filtering via card tags and clear filters UI

### DIFF
--- a/docker/core/mkwebaxum/Cargo.toml
+++ b/docker/core/mkwebaxum/Cargo.toml
@@ -79,6 +79,7 @@ tower-http = { version = "0.6.8", features = ["fs", "set-header"] }
 tower-sessions = "0.14.0"
 transmission-rpc = "0.5.0"
 uuid = { version = "1.20.0", features = ["serde", "v4", "v7"] }
+urlencoding = "2.1.3"
 validator = { version = "0.20.0", features = ["derive"] }
 
 

--- a/docker/core/mkwebaxum/src/api/bp_api_title_search.rs
+++ b/docker/core/mkwebaxum/src/api/bp_api_title_search.rs
@@ -1,13 +1,13 @@
+use crate::AppState;
 use crate::axum_custom_filters::filters;
 use crate::mk_lib_database;
-use crate::AppState;
 use askama::Template;
 use axum::extract::State;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -55,7 +55,7 @@ pub async fn api_title_search(
     } else {
         let title = title.replace("%20", " ");
         let movie_metadata = mk_lib_database::database_metadata::mk_lib_database_metadata_movie::mk_lib_database_metadata_movie_read(
-        &state.sqlx_pool_ro, title.clone(), current_user.id, "a".to_string(), 0, 100
+        &state.sqlx_pool_ro, title.clone(), current_user.id, "a".to_string(), String::new(), 0, 100
     )
     .await
     .unwrap();

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
@@ -27,6 +27,7 @@ use sqlx::{FromRow, Row};
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Genre {
     pub name: String,
+    pub query_value: String,
 }
 
 #[derive(Template)]
@@ -62,12 +63,15 @@ struct TemplateMetaMovieContext<'a> {
     page: &'a usize,
     page_title: Option<String>,
     pub current: Option<String>,
+    pub genre_filter: Option<String>,
+    pub genre_filter_query: Option<String>,
     pub base_path: String,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct FilterQuery {
     pub starts_with: Option<String>,
+    pub genre: Option<String>,
 }
 
 fn normalize_starts_with(raw: Option<&str>) -> Option<String> {
@@ -89,6 +93,7 @@ fn build_movie_pagination(
     total_items: i64,
     page: i64,
     starts_with: Option<&str>,
+    genre: Option<&str>,
 ) -> Result<String, std::fmt::Error> {
     let total_pages = if total_items > 0 {
         (total_items + 29) / 30
@@ -105,15 +110,22 @@ fn build_movie_pagination(
 <ul class="flex items-center gap-1 whitespace-nowrap text-sm">"#,
     );
 
-    let suffix = match starts_with {
-        Some(sw) if !sw.is_empty() => {
-            if sw == "#" {
-                "?starts_with=%23".to_string()
-            } else {
-                format!("?starts_with={sw}")
-            }
+    let mut query_params: Vec<String> = Vec::new();
+    if let Some(sw) = starts_with.filter(|sw| !sw.is_empty()) {
+        if sw == "#" {
+            query_params.push("starts_with=%23".to_string());
+        } else {
+            query_params.push(format!("starts_with={sw}"));
         }
-        _ => String::new(),
+    }
+    if let Some(genre_name) = genre.filter(|genre_name| !genre_name.is_empty()) {
+        query_params.push(format!("genre={}", urlencoding::encode(genre_name)));
+    }
+
+    let suffix = if query_params.is_empty() {
+        String::new()
+    } else {
+        format!("?{}", query_params.join("&"))
     };
 
     if total_pages == 1 {
@@ -195,6 +207,12 @@ pub async fn user_metadata_movie(
     Query(params): Query<FilterQuery>,
 ) -> impl IntoResponse {
     let starts_with = normalize_starts_with(params.starts_with.as_deref());
+    let genre = params
+        .genre
+        .as_deref()
+        .map(str::trim)
+        .filter(|genre| !genre.is_empty())
+        .map(ToOwned::to_owned);
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
         [Method::GET],
@@ -215,17 +233,20 @@ pub async fn user_metadata_movie(
            &state.sqlx_pool_ro,
             String::new(),
             starts_with.clone().unwrap_or_default(),
+            genre.clone().unwrap_or_default(),
         )
         .await
         .unwrap();
         let pagination_html =
-            build_movie_pagination(total_pages, page, starts_with.as_deref()).unwrap();
+            build_movie_pagination(total_pages, page, starts_with.as_deref(), genre.as_deref())
+                .unwrap();
         let movie_list =
         mk_lib_database::database_metadata::mk_lib_database_metadata_movie::mk_lib_database_metadata_movie_read(
             &state.sqlx_pool_ro,
             String::new(),
             current_user.id,
             starts_with.clone().unwrap_or_default(),
+            genre.clone().unwrap_or_default(),
             db_offset,
             30,
         )
@@ -279,6 +300,7 @@ pub async fn user_metadata_movie(
                 .filter_map(|g| {
                     g.get("name").and_then(|n| n.as_str()).map(|name| Genre {
                         name: name.to_string(),
+                        query_value: urlencoding::encode(name).into_owned(),
                     })
                 })
                 .collect();
@@ -316,6 +338,10 @@ pub async fn user_metadata_movie(
             page: &page_usize,
             page_title: Some("MediaKraken Metadata Movies".to_string()),
             current: starts_with.clone(),
+            genre_filter: genre.clone(),
+            genre_filter_query: genre
+                .as_ref()
+                .map(|value| urlencoding::encode(value).into_owned()),
             base_path: "/user/metadata/movie".to_string(),
         };
         let reply_html = template.render().unwrap();

--- a/docker/core/mkwebaxum/templates/cards/movie_card.html
+++ b/docker/core/mkwebaxum/templates/cards/movie_card.html
@@ -78,9 +78,11 @@
 
         <div class="flex flex-wrap gap-1 mt-1">
             {% for genre in row_data.template_metadata_genre %}
-                <span class="px-1.5 py-0.5 text-[10px] rounded bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400">
+                <a href="/user/metadata/movie/1?genre={{ genre.query_value }}"
+                   class="px-1.5 py-0.5 text-[10px] rounded bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors"
+                   aria-label="Filter movies by genre {{ genre.name }}">
                     {{ genre.name }}
-                </span>
+                </a>
             {% endfor %}
         </div>
 

--- a/docker/core/mkwebaxum/templates/filters/pagination_letters.html
+++ b/docker/core/mkwebaxum/templates/filters/pagination_letters.html
@@ -5,7 +5,7 @@
 
     <!-- # Symbols -->
     <li>
-      <a href="{{ base_path }}/1?starts_with=%23"
+      <a href="{{ base_path }}/1?starts_with=%23{% if let Some(genre_name) = genre_filter_query %}&genre={{ genre_name }}{% endif %}"
          class="px-2 py-1.5 rounded-md transition-colors
          {% if current == Some("#".to_string()) %}
             bg-indigo-600 text-white
@@ -19,7 +19,7 @@
     <!-- Numbers -->
     {% for n in 0..10 %}
     <li>
-      <a href="{{ base_path }}/1?starts_with={{ n }}"
+      <a href="{{ base_path }}/1?starts_with={{ n }}{% if let Some(genre_name) = genre_filter_query %}&genre={{ genre_name }}{% endif %}"
          class="px-2 py-1.5 rounded-md transition-colors
          {% if current == Some(n.to_string()) %}
             bg-indigo-600 text-white
@@ -34,7 +34,7 @@
     <!-- Letters -->
     {% for c in 'A'..='Z' %}
     <li>
-      <a href="{{ base_path }}/1?starts_with={{ c }}"
+      <a href="{{ base_path }}/1?starts_with={{ c }}{% if let Some(genre_name) = genre_filter_query %}&genre={{ genre_name }}{% endif %}"
          class="px-2 py-1.5 rounded-md transition-colors
          {% if current == Some(c.to_string()) %}
             bg-indigo-600 text-white
@@ -48,3 +48,13 @@
 
   </ul>
 </nav>
+
+{% if current.is_some() || genre_filter.is_some() %}
+<div class="mt-3 flex justify-center">
+  <a href="{{ base_path }}/1"
+     class="inline-flex items-center rounded-md border border-zinc-300 px-3 py-1.5 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+     aria-label="Clear all movie filters">
+    Clear filters
+  </a>
+</div>
+{% endif %}

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs
@@ -40,6 +40,7 @@ pub async fn mk_lib_database_metadata_movie_read(
     search_value: String,
     user_id: i64,
     starts_with: String,
+    genre_name: String,
     offset: i64,
     limit: i64,
 ) -> Result<Vec<DBMetaMovieList>, sqlx::Error> {
@@ -61,13 +62,24 @@ pub async fn mk_lib_database_metadata_movie_read(
              LEFT JOIN mm_metadata_user_status
              ON mm_metadata_user_status.mm_status_type_movie = mm_metadata_movie.mm_metadata_movie_guid
              and mm_metadata_user_status.mm_status_user_id = $1
-             WHERE mm_metadata_movie_name &@ $2
-             or mm_metadata_movie_name_alt &@ $3
-             offset $4 limit $5"#,
+             WHERE (
+                mm_metadata_movie_name &@ $2
+                OR mm_metadata_movie_name_alt &@ $3
+             )
+             AND (
+                $4 = ''
+                OR EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(mm_metadata_movie_json->'genres') AS genre
+                    WHERE lower(genre->>'name') = lower($4)
+                )
+             )
+             offset $5 limit $6"#,
         )
         .bind(&user_id)
+         .bind(&search_value)
         .bind(&search_value)
-        .bind(&search_value)
+        .bind(&genre_name)
         .bind(offset)
         .bind(limit)
             .fetch_all(sqlx_pool)
@@ -93,11 +105,20 @@ pub async fn mk_lib_database_metadata_movie_read(
                 ($2 = '#' AND left(lower(mm_metadata_movie_name), 1) !~ '^[a-z0-9]$')
                 OR ($2 <> '#' AND lower(mm_metadata_movie_name) LIKE lower($2) || '%')
             )
+            AND (
+                $3 = ''
+                OR EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(mm_metadata_movie_json->'genres') AS genre
+                    WHERE lower(genre->>'name') = lower($3)
+                )
+            )
             order by LOWER(mm_metadata_movie_name), mm_date
-            offset $3 limit $4"#,
+            offset $4 limit $5"#,
         )
         .bind(&user_id)
-        .bind(&starts_with)
+         .bind(&starts_with)
+        .bind(&genre_name)
         .bind(offset)
         .bind(limit)
             .fetch_all(sqlx_pool)
@@ -109,12 +130,23 @@ pub async fn mk_lib_database_metadata_movie_count(
     sqlx_pool: &sqlx::PgPool,
     search_value: String,
     starts_with: String,
+    genre_name: String,
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
         let row: (i64,) = sqlx::query_as(
-            r#"select count(*) from mm_metadata_movie where mm_metadata_movie_name &@ $1"#,
+            r#"select count(*) from mm_metadata_movie
+            where mm_metadata_movie_name &@ $1
+            AND (
+                $2 = ''
+                OR EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(mm_metadata_movie_json->'genres') AS genre
+                    WHERE lower(genre->>'name') = lower($2)
+                )
+            )"#,
         )
         .bind(search_value)
+        .bind(genre_name)
         .fetch_one(sqlx_pool)
         .await?;
         Ok(row.0)
@@ -124,9 +156,18 @@ pub async fn mk_lib_database_metadata_movie_count(
             WHERE (
                 ($1 = '#' AND left(lower(mm_metadata_movie_name), 1) !~ '^[a-z0-9]$')
                 OR ($1 <> '#' AND lower(mm_metadata_movie_name) LIKE lower($1) || '%')
+            )
+            AND (
+                $2 = ''
+                OR EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(mm_metadata_movie_json->'genres') AS genre
+                    WHERE lower(genre->>'name') = lower($2)
+                )
             )"#,
         )
         .bind(starts_with)
+        .bind(genre_name)
         .fetch_one(sqlx_pool)
         .await?;
         Ok(row.0)


### PR DESCRIPTION
### Motivation
- Provide an easy way for users to filter the movie list by genre by clicking genre chips on movie cards and keep filters when paging letters/numbers. 
- Surface a clear UI affordance to remove filters when a `starts_with` or `genre` filter is active.

### Description
- Parse an optional `genre` query parameter in `bp_meta_movie` and thread it into pagination and DB reads by extending `FilterQuery` and template context with `genre_filter` / `genre_filter_query`.
- Make movie-card genre chips clickable by updating `templates/cards/movie_card.html` to link to ` /user/metadata/movie/1?genre=...` and add URL-safe `query_value` generation in `bp_meta_movie` using `urlencoding`.
- Extend DB functions `mk_lib_database_metadata_movie_read` and `mk_lib_database_metadata_movie_count` to accept a `genre_name` parameter and apply parameterized JSONB filtering via `EXISTS (...) FROM jsonb_array_elements(... ) WHERE lower(genre->>'name') = lower($N)` (no string interpolation). 
- Preserve API compatibility at call sites where necessary (`api/bp_api_title_search` updated to pass an empty genre) and add `urlencoding` to `mkwebaxum` Cargo manifest.

### Testing
- `rustfmt` / `rustfmt --edition 2024` and `cargo fmt` were run successfully on modified files.
- `cargo check` was attempted but failed in this environment due to private registry access returning HTTP 403, so full dependency resolution and build could not be completed.
- `cargo clippy -- -D warnings` was attempted but likewise failed due to private registry access (HTTP 403) and could not be completed here.
- A Playwright attempt to capture a UI screenshot against `http://localhost:3000/user/metadata/movie/1` failed with `net::ERR_EMPTY_RESPONSE` because the local app endpoint was not reachable in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac825430308321926f3555192e328a)