### PR TITLE
Add URL-encoded `query_value` for genres in movie detail

### DIFF
--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
@@ -398,6 +398,7 @@ pub async fn user_metadata_movie_detail(
             .filter_map(|g| {
                 g.get("name").and_then(|n| n.as_str()).map(|name| Genre {
                     name: name.to_string(),
+                    query_value: urlencoding::encode(name).into_owned(),
                 })
             })
             .collect();


### PR DESCRIPTION
### Motivation
- Provide URL-safe genre strings for building links and queries in the movie metadata template by storing an encoded value alongside the genre name.

### Description
- When constructing `genres` for `TemplateMetaMovieDetailContext`, populate `Genre.query_value` with `urlencoding::encode(name).into_owned()` so a URL-encoded version of the genre is available.

### Testing
- Ran `cargo build` and `cargo test` and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac825430308321926f3555192e328a)