### PR TITLE
mkwebaxum: add OpenLibrary browse & detail pages

### DIFF
--- a/docker/core/mkwebaxum/src/main.rs
+++ b/docker/core/mkwebaxum/src/main.rs
@@ -253,7 +253,7 @@ async fn main() {
             get(user_internet::bp_inter_openlibrary::user_inter_openlibrary),
         )
         .route_with_tsr(
-            "/user/internet/openlibrary_detail/{work_id}",
+            "/user/internet/openlibrary_detail/*work_id",
             get(user_internet::bp_inter_openlibrary::user_inter_openlibrary_detail),
         )
         .route_with_tsr(

--- a/docker/core/mkwebaxum/src/main.rs
+++ b/docker/core/mkwebaxum/src/main.rs
@@ -97,6 +97,7 @@ pub mod user {
 pub mod user_internet {
     pub mod bp_inter_flickr;
     pub mod bp_inter_home;
+    pub mod bp_inter_openlibrary;
     pub mod bp_inter_twitchtv;
     pub mod bp_inter_vimeo;
     pub mod bp_inter_youtube;
@@ -246,6 +247,14 @@ async fn main() {
         .route_with_tsr(
             "/user/internet",
             get(user_internet::bp_inter_home::user_inter_home),
+        )
+        .route_with_tsr(
+            "/user/internet/openlibrary/{page}",
+            get(user_internet::bp_inter_openlibrary::user_inter_openlibrary),
+        )
+        .route_with_tsr(
+            "/user/internet/openlibrary_detail/{work_id}",
+            get(user_internet::bp_inter_openlibrary::user_inter_openlibrary_detail),
         )
         .route_with_tsr(
             "/user/internet/twitchtv",

--- a/docker/core/mkwebaxum/src/user/internet/bp_inter_openlibrary.rs
+++ b/docker/core/mkwebaxum/src/user/internet/bp_inter_openlibrary.rs
@@ -31,6 +31,7 @@ struct OpenLibraryWorkRow {
 
 struct OpenLibraryBrowseItem {
     work_id: String,
+    route_work_id: String,
     title: String,
     author_name: String,
     first_publish_year: String,
@@ -152,19 +153,19 @@ pub async fn user_inter_openlibrary_detail(
         return render_401();
     }
 
-    if !is_valid_work_id(&work_id) {
+    let Some(canonical_work_id) = canonicalize_work_id(&work_id) else {
         return (
             StatusCode::BAD_REQUEST,
             Html(String::from("Invalid work id")).into_response(),
         );
-    }
+    };
 
     let row_result = sqlx::query_as::<_, OpenLibraryWorkRow>(
         r#"select mm_openlib_work_id, mm_openlib_work_json
            from mm_openlib_work
            where mm_openlib_work_id = $1"#,
     )
-    .bind(&work_id)
+    .bind(&canonical_work_id)
     .fetch_optional(&state.sqlx_pool_ro)
     .await;
 
@@ -232,8 +233,11 @@ fn map_work_to_browse_item(row: &OpenLibraryWorkRow) -> OpenLibraryBrowseItem {
     let cover_url = read_i64(&row.mm_openlib_work_json, "cover_i")
         .map(|cover| format!("https://covers.openlibrary.org/b/id/{cover}-M.jpg"));
 
+    let route_work_id = row.mm_openlib_work_id.trim_start_matches('/').to_string();
+
     OpenLibraryBrowseItem {
         work_id: row.mm_openlib_work_id.clone(),
+        route_work_id,
         title,
         author_name,
         first_publish_year,
@@ -312,9 +316,21 @@ fn read_string_array(value: &Value, key: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
-fn is_valid_work_id(work_id: &str) -> bool {
-    !work_id.is_empty()
-        && work_id
-            .chars()
-            .all(|char| char.is_ascii_alphanumeric() || char == '_')
+fn canonicalize_work_id(work_id: &str) -> Option<String> {
+    let trimmed = work_id.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let canonical = if trimmed.starts_with('/') {
+        trimmed.to_string()
+    } else {
+        format!("/{trimmed}")
+    };
+
+    if canonical.len() > 255 {
+        return None;
+    }
+
+    Some(canonical)
 }

--- a/docker/core/mkwebaxum/src/user/internet/bp_inter_openlibrary.rs
+++ b/docker/core/mkwebaxum/src/user/internet/bp_inter_openlibrary.rs
@@ -1,0 +1,320 @@
+use crate::mk_lib_database;
+use crate::AppState;
+use askama::Template;
+use axum::{
+    extract::{Path, State},
+    http::{Method, StatusCode},
+    response::{Html, IntoResponse},
+};
+use axum_session_auth::*;
+use axum_session_sqlx::SessionPgPool;
+use serde_json::Value;
+use sqlx::{postgres::PgPool, FromRow};
+
+const PAGE_SIZE: i64 = 24;
+
+#[derive(Template)]
+#[template(path = "bss_error/bss_error_401.html")]
+struct TemplateError401Context {}
+
+#[derive(Template)]
+#[template(path = "bss_error/bss_error_500.html")]
+struct TemplateError500Context {
+    page_title: Option<String>,
+}
+
+#[derive(FromRow)]
+struct OpenLibraryWorkRow {
+    mm_openlib_work_id: String,
+    mm_openlib_work_json: Value,
+}
+
+struct OpenLibraryBrowseItem {
+    work_id: String,
+    title: String,
+    author_name: String,
+    first_publish_year: String,
+    edition_count: String,
+    subject_preview: Vec<String>,
+    subject_more_count: usize,
+    cover_url: Option<String>,
+}
+
+struct OpenLibraryDetailItem {
+    work_id: String,
+    title: String,
+    description: String,
+    authors: Vec<String>,
+    subjects: Vec<String>,
+    first_publish_year: String,
+    cover_url: Option<String>,
+}
+
+#[derive(Template)]
+#[template(path = "bss_user/internet/bss_user_internet_openlibrary.html")]
+struct TemplateOpenLibraryBrowse {
+    items: Vec<OpenLibraryBrowseItem>,
+    has_items: bool,
+    page: i64,
+    pagination_prev: Option<i64>,
+    pagination_next: Option<i64>,
+    page_title: Option<String>,
+}
+
+#[derive(Template)]
+#[template(path = "bss_user/internet/bss_user_internet_openlibrary_detail.html")]
+struct TemplateOpenLibraryDetail {
+    item: OpenLibraryDetailItem,
+    page_title: Option<String>,
+}
+
+pub async fn user_inter_openlibrary(
+    State(state): State<AppState>,
+    method: Method,
+    auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
+    Path(page): Path<i64>,
+) -> impl IntoResponse {
+    let current_user = auth.current_user.clone().unwrap_or_default();
+    if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
+        [Method::GET],
+        false,
+    )
+    .requires(Rights::any([Rights::permission("User::View")]))
+    .validate(&current_user, &method, None)
+    .await
+    {
+        return render_401();
+    }
+
+    if page < 1 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Html(String::from("Invalid page")).into_response(),
+        );
+    }
+
+    let db_offset = (page - 1) * PAGE_SIZE;
+    let rows_result = sqlx::query_as::<_, OpenLibraryWorkRow>(
+        r#"select mm_openlib_work_id, mm_openlib_work_json
+           from mm_openlib_work
+           order by mm_openlib_work_id
+           offset $1 limit $2"#,
+    )
+    .bind(db_offset)
+    .bind(PAGE_SIZE)
+    .fetch_all(&state.sqlx_pool_ro)
+    .await;
+
+    let count_result = sqlx::query_scalar::<_, i64>("select count(*) from mm_openlib_work")
+        .fetch_one(&state.sqlx_pool_ro)
+        .await;
+
+    let (rows, total_count) = match (rows_result, count_result) {
+        (Ok(rows), Ok(total_count)) => (rows, total_count),
+        _ => return render_500(),
+    };
+
+    let items: Vec<OpenLibraryBrowseItem> = rows.iter().map(map_work_to_browse_item).collect();
+    let has_items = !items.is_empty();
+    let has_prev = page > 1;
+    let has_next = db_offset + PAGE_SIZE < total_count;
+
+    let template = TemplateOpenLibraryBrowse {
+        items,
+        has_items,
+        page,
+        pagination_prev: if has_prev { Some(page - 1) } else { None },
+        pagination_next: if has_next { Some(page + 1) } else { None },
+        page_title: Some("MediaKraken OpenLibrary Browse".to_string()),
+    };
+
+    match template.render() {
+        Ok(reply_html) => (StatusCode::OK, Html(reply_html).into_response()),
+        Err(_) => render_500(),
+    }
+}
+
+pub async fn user_inter_openlibrary_detail(
+    State(state): State<AppState>,
+    method: Method,
+    auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
+    Path(work_id): Path<String>,
+) -> impl IntoResponse {
+    let current_user = auth.current_user.clone().unwrap_or_default();
+    if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
+        [Method::GET],
+        false,
+    )
+    .requires(Rights::any([Rights::permission("User::View")]))
+    .validate(&current_user, &method, None)
+    .await
+    {
+        return render_401();
+    }
+
+    if !is_valid_work_id(&work_id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Html(String::from("Invalid work id")).into_response(),
+        );
+    }
+
+    let row_result = sqlx::query_as::<_, OpenLibraryWorkRow>(
+        r#"select mm_openlib_work_id, mm_openlib_work_json
+           from mm_openlib_work
+           where mm_openlib_work_id = $1"#,
+    )
+    .bind(&work_id)
+    .fetch_optional(&state.sqlx_pool_ro)
+    .await;
+
+    let row = match row_result {
+        Ok(Some(row)) => row,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Html(String::from("Not found")).into_response(),
+            )
+        }
+        Err(_) => return render_500(),
+    };
+
+    let template = TemplateOpenLibraryDetail {
+        item: map_work_to_detail_item(&row),
+        page_title: Some("MediaKraken OpenLibrary Detail".to_string()),
+    };
+
+    match template.render() {
+        Ok(reply_html) => (StatusCode::OK, Html(reply_html).into_response()),
+        Err(_) => render_500(),
+    }
+}
+
+fn render_401() -> (StatusCode, axum::response::Response) {
+    let template = TemplateError401Context {};
+    match template.render() {
+        Ok(reply_html) => (StatusCode::UNAUTHORIZED, Html(reply_html).into_response()),
+        Err(_) => (
+            StatusCode::UNAUTHORIZED,
+            Html(String::from("Unauthorized")).into_response(),
+        ),
+    }
+}
+
+fn render_500() -> (StatusCode, axum::response::Response) {
+    let template = TemplateError500Context {
+        page_title: Some("MediaKraken Error".to_string()),
+    };
+    match template.render() {
+        Ok(reply_html) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Html(reply_html).into_response(),
+        ),
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Html(String::from("Internal server error")).into_response(),
+        ),
+    }
+}
+
+fn map_work_to_browse_item(row: &OpenLibraryWorkRow) -> OpenLibraryBrowseItem {
+    let title =
+        read_string(&row.mm_openlib_work_json, "title").unwrap_or_else(|| "Untitled".to_string());
+    let author_name = read_first_string(&row.mm_openlib_work_json, "author_name")
+        .unwrap_or_else(|| "Unknown author".to_string());
+    let first_publish_year = read_i64(&row.mm_openlib_work_json, "first_publish_year")
+        .map_or_else(|| "Unknown".to_string(), |year| year.to_string());
+    let edition_count = read_i64(&row.mm_openlib_work_json, "edition_count")
+        .map_or_else(|| "0".to_string(), |count| count.to_string());
+    let all_subjects = read_string_array(&row.mm_openlib_work_json, "subject");
+    let subject_preview: Vec<String> = all_subjects.iter().take(3).cloned().collect();
+    let subject_more_count = all_subjects.len().saturating_sub(subject_preview.len());
+    let cover_url = read_i64(&row.mm_openlib_work_json, "cover_i")
+        .map(|cover| format!("https://covers.openlibrary.org/b/id/{cover}-M.jpg"));
+
+    OpenLibraryBrowseItem {
+        work_id: row.mm_openlib_work_id.clone(),
+        title,
+        author_name,
+        first_publish_year,
+        edition_count,
+        subject_preview,
+        subject_more_count,
+        cover_url,
+    }
+}
+
+fn map_work_to_detail_item(row: &OpenLibraryWorkRow) -> OpenLibraryDetailItem {
+    let title =
+        read_string(&row.mm_openlib_work_json, "title").unwrap_or_else(|| "Untitled".to_string());
+    let authors = read_string_array(&row.mm_openlib_work_json, "author_name");
+    let subjects = read_string_array(&row.mm_openlib_work_json, "subject");
+    let description = read_description(&row.mm_openlib_work_json)
+        .unwrap_or_else(|| "No description available for this work.".to_string());
+    let first_publish_year = read_i64(&row.mm_openlib_work_json, "first_publish_year")
+        .map_or_else(|| "Unknown".to_string(), |year| year.to_string());
+    let cover_url = read_i64(&row.mm_openlib_work_json, "cover_i")
+        .map(|cover| format!("https://covers.openlibrary.org/b/id/{cover}-L.jpg"));
+
+    OpenLibraryDetailItem {
+        work_id: row.mm_openlib_work_id.clone(),
+        title,
+        description,
+        authors,
+        subjects,
+        first_publish_year,
+        cover_url,
+    }
+}
+
+fn read_description(value: &Value) -> Option<String> {
+    match value.get("description") {
+        Some(Value::String(text)) => Some(text.clone()),
+        Some(Value::Object(map)) => map
+            .get("value")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        _ => None,
+    }
+}
+
+fn read_string(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn read_first_string(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_array)
+        .and_then(|arr| arr.first())
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn read_i64(value: &Value, key: &str) -> Option<i64> {
+    value.get(key).and_then(Value::as_i64)
+}
+
+fn read_string_array(value: &Value, key: &str) -> Vec<String> {
+    value
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|array| {
+            array
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn is_valid_work_id(work_id: &str) -> bool {
+    !work_id.is_empty()
+        && work_id
+            .chars()
+            .all(|char| char.is_ascii_alphanumeric() || char == '_')
+}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet.html
@@ -14,6 +14,9 @@
                 loading="lazy" decoding="async"></a>
         <a href="/user/internet/twitchtv"><img src="/static/image/internet/twitch.png" width="200" height="200"
                 loading="lazy" decoding="async"></a>
+        <a href="/user/internet/openlibrary/1" class="inline-flex h-[200px] w-[200px] items-center justify-center rounded-lg bg-slate-800 text-center text-lg font-semibold text-slate-100" aria-label="OpenLibrary browse">
+            OpenLibrary
+        </a>
     </div>
     {% include "bss_public/bss_public_footer.html" %}
  </body>

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_openlibrary.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_openlibrary.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+{% include "bss_include_header.html" %}
+
+<body class="bg-slate-950 text-slate-100">
+    {% include "bss_user/bss_user_include_menu.html" %}
+    {% include "bss_user/bss_user_include_side_menu.html" %}
+
+    <main class="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8" x-data="{ onlyWithCovers: false }">
+        <section class="mb-6 flex flex-col gap-4 rounded-xl border border-slate-800 bg-slate-900/60 p-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+                <h1 class="text-2xl font-semibold">OpenLibrary Browse</h1>
+                <p class="text-sm text-slate-300">Browse preloaded OpenLibrary works from the local database.</p>
+            </div>
+            <button
+                type="button"
+                class="rounded-lg border border-slate-600 px-4 py-2 text-sm font-medium hover:border-slate-400 hover:bg-slate-800"
+                aria-label="Toggle only records with covers"
+                @click="onlyWithCovers = !onlyWithCovers"
+                :class="onlyWithCovers ? 'border-teal-400 bg-teal-950/40 text-teal-200' : ''"
+            >
+                <span x-text="onlyWithCovers ? 'Showing: With cover' : 'Showing: All works'"></span>
+            </button>
+        </section>
+
+        {% if has_items %}
+        <section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {% for item in items %}
+            <article
+                class="flex flex-col gap-3 rounded-xl border border-slate-800 bg-slate-900 p-4"
+                x-show="!onlyWithCovers || {{ item.cover_url.is_some() }}"
+                x-cloak
+            >
+                <div class="flex gap-3">
+                    {% if let Some(url) = item.cover_url %}
+                    <img src="{{ url }}" alt="{{ item.title }} cover" class="h-28 w-20 rounded object-cover" loading="lazy" decoding="async" />
+                    {% else %}
+                    <div class="flex h-28 w-20 items-center justify-center rounded bg-slate-800 text-xs text-slate-400">No cover</div>
+                    {% endif %}
+
+                    <div class="min-w-0 flex-1">
+                        <h2 class="truncate text-base font-semibold">{{ item.title }}</h2>
+                        <p class="mt-1 text-sm text-slate-300">{{ item.author_name }}</p>
+                        <dl class="mt-2 grid grid-cols-2 gap-2 text-xs text-slate-400">
+                            <div>
+                                <dt>First Published</dt>
+                                <dd class="text-slate-200">{{ item.first_publish_year }}</dd>
+                            </div>
+                            <div>
+                                <dt>Editions</dt>
+                                <dd class="text-slate-200">{{ item.edition_count }}</dd>
+                            </div>
+                        </dl>
+                    </div>
+                </div>
+
+                <div class="flex flex-wrap gap-2">
+                    {% for subject in item.subject_preview %}
+                    <span class="rounded-full bg-slate-800 px-2 py-1 text-xs text-slate-300">{{ subject }}</span>
+                    {% endfor %}
+                    {% if item.subject_more_count > 0 %}
+                    <span class="rounded-full bg-slate-800 px-2 py-1 text-xs text-slate-400">+{{ item.subject_more_count }} more</span>
+                    {% endif %}
+                </div>
+
+                <a
+                    href="/user/internet/openlibrary_detail/{{ item.work_id }}"
+                    class="mt-1 inline-flex items-center justify-center rounded-lg bg-teal-700 px-3 py-2 text-sm font-medium hover:bg-teal-600"
+                    aria-label="View OpenLibrary details for {{ item.title }}"
+                >
+                    View details
+                </a>
+            </article>
+            {% endfor %}
+        </section>
+        {% else %}
+        <section class="rounded-xl border border-slate-800 bg-slate-900 p-6 text-center text-slate-300">
+            No OpenLibrary works were found in the database.
+        </section>
+        {% endif %}
+
+        <nav class="mt-6 flex items-center justify-between" aria-label="OpenLibrary pagination">
+            <div>
+                {% if let Some(previous_page) = pagination_prev %}
+                <a href="/user/internet/openlibrary/{{ previous_page }}" class="rounded-lg border border-slate-600 px-4 py-2 text-sm hover:border-slate-400 hover:bg-slate-800" aria-label="Go to previous page">Previous</a>
+                {% endif %}
+            </div>
+            <p class="text-sm text-slate-300">Page {{ page }}</p>
+            <div>
+                {% if let Some(next_page) = pagination_next %}
+                <a href="/user/internet/openlibrary/{{ next_page }}" class="rounded-lg border border-slate-600 px-4 py-2 text-sm hover:border-slate-400 hover:bg-slate-800" aria-label="Go to next page">Next</a>
+                {% endif %}
+            </div>
+        </nav>
+    </main>
+
+    {% include "bss_public/bss_public_footer.html" %}
+</body>
+
+</html>

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_openlibrary.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_openlibrary.html
@@ -64,7 +64,7 @@
                 </div>
 
                 <a
-                    href="/user/internet/openlibrary_detail/{{ item.work_id }}"
+                    href="/user/internet/openlibrary_detail/{{ item.route_work_id }}"
                     class="mt-1 inline-flex items-center justify-center rounded-lg bg-teal-700 px-3 py-2 text-sm font-medium hover:bg-teal-600"
                     aria-label="View OpenLibrary details for {{ item.title }}"
                 >

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_openlibrary_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_openlibrary_detail.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+{% include "bss_include_header.html" %}
+
+<body class="bg-slate-950 text-slate-100">
+    {% include "bss_user/bss_user_include_menu.html" %}
+    {% include "bss_user/bss_user_include_side_menu.html" %}
+
+    <main class="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
+        <a href="/user/internet/openlibrary/1" class="mb-4 inline-flex rounded-lg border border-slate-600 px-3 py-2 text-sm hover:border-slate-400 hover:bg-slate-800" aria-label="Back to OpenLibrary browse">← Back to browse</a>
+
+        <article class="rounded-xl border border-slate-800 bg-slate-900 p-5" x-data="{ showSubjects: true }">
+            <header class="flex flex-col gap-4 sm:flex-row">
+                {% if let Some(url) = item.cover_url %}
+                <img src="{{ url }}" alt="{{ item.title }} cover" class="h-64 w-44 rounded object-cover" loading="lazy" decoding="async" />
+                {% else %}
+                <div class="flex h-64 w-44 items-center justify-center rounded bg-slate-800 text-sm text-slate-400">No cover image</div>
+                {% endif %}
+
+                <div class="min-w-0">
+                    <p class="text-xs uppercase tracking-wide text-slate-400">OpenLibrary Work ID: {{ item.work_id }}</p>
+                    <h1 class="mt-1 text-3xl font-semibold">{{ item.title }}</h1>
+                    <p class="mt-2 text-slate-300">First published: {{ item.first_publish_year }}</p>
+
+                    {% if item.authors.len() > 0 %}
+                    <div class="mt-3 flex flex-wrap gap-2">
+                        {% for author in item.authors %}
+                        <span class="rounded-full bg-slate-800 px-3 py-1 text-sm text-slate-200">{{ author }}</span>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+                </div>
+            </header>
+
+            <section class="mt-5">
+                <h2 class="text-lg font-medium">Description</h2>
+                <p class="mt-2 whitespace-pre-wrap text-slate-200">{{ item.description }}</p>
+            </section>
+
+            <section class="mt-5">
+                <div class="flex items-center justify-between">
+                    <h2 class="text-lg font-medium">Subjects</h2>
+                    <button type="button" class="rounded-md border border-slate-600 px-3 py-1 text-sm hover:border-slate-400 hover:bg-slate-800" @click="showSubjects = !showSubjects" :aria-label="showSubjects ? 'Hide subjects' : 'Show subjects'">
+                        <span x-text="showSubjects ? 'Hide' : 'Show'"></span>
+                    </button>
+                </div>
+
+                <div class="mt-3 flex flex-wrap gap-2" x-show="showSubjects" x-cloak>
+                    {% if item.subjects.len() > 0 %}
+                    {% for subject in item.subjects %}
+                    <span class="rounded-full bg-teal-900/30 px-3 py-1 text-sm text-teal-100">{{ subject }}</span>
+                    {% endfor %}
+                    {% else %}
+                    <p class="text-slate-400">No subjects available.</p>
+                    {% endif %}
+                </div>
+            </section>
+        </article>
+    </main>
+
+    {% include "bss_public/bss_public_footer.html" %}
+</body>
+
+</html>


### PR DESCRIPTION
### Motivation

- Provide a user-facing browse and detail UI for preloaded OpenLibrary data so users can explore works stored in the local `mm_openlib_work` tables.

### Description

- Added a new Axum handler module `user/internet/bp_inter_openlibrary.rs` that implements a paginated browse handler `user_inter_openlibrary` and a detail handler `user_inter_openlibrary_detail` using parameterized `sqlx` queries against `mm_openlib_work` and maps JSON to view models.
- Registered routes `/user/internet/openlibrary/{page}` and `/user/internet/openlibrary_detail/{work_id}` in `docker/core/mkwebaxum/src/main.rs` and added an OpenLibrary launcher tile to the internet hub template `bss_user/internet/bss_user_internet.html`.
- Added Askama templates `bss_user/internet/bss_user_internet_openlibrary.html` and `bss_user/internet/bss_user_internet_openlibrary_detail.html` that use Tailwind utility classes and Alpine.js for a cover toggle and subject show/hide behaviour, and follow accessibility rules for interactive elements.
- Error handling returns existing 401/500 templates for unauthorized/internal failures and explicit 400/404 responses for invalid input or missing records, and SQL is parameterized to avoid interpolation.

### Testing

- Ran `rustfmt --edition 2021` on the new handler and updated `main.rs` files to ensure formatting, which completed successfully.
- Attempted `cargo fmt --manifest-path docker/core/mkwebaxum/Cargo.toml`, `cargo check --manifest-path docker/core/mkwebaxum/Cargo.toml`, and `cargo clippy --manifest-path docker/core/mkwebaxum/Cargo.toml -- -D warnings`, but these were blocked in this environment due to a private registry index (`kellnr`) referenced by the crate manifest.
- Attempted a headless template render verification via a Playwright screenshot script, however the run failed to load `file://` template paths in the browser environment, so no screenshots were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af6ce1ae788321b86b806859a2b48e)