### PR TITLE
Add Internet Archive trailer downloader (IATrailer handler) with state and backoff

### DIFF
--- a/docker/core/mkdownload/Cargo.toml
+++ b/docker/core/mkdownload/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1.0.149"
 stdext = "0.3.3"
 sys-info = "0.9.1"
 tokio = { version = "1.49.0", features = ["full"] }
+urlencoding = "2.1.3"
 uuid = { version = "1.19.0", features = ["serde", "v4", "v7"] }
 validator = { version = "0.20.0", features = ["derive"] }
 

--- a/docker/core/mkdownload/src/main.rs
+++ b/docker/core/mkdownload/src/main.rs
@@ -1,13 +1,58 @@
 use mk_lib_database;
 use mk_lib_network;
 use mk_lib_rabbitmq;
-use serde_json::{json, Value};
+use reqwest::{Client, StatusCode};
+use serde_json::{Value, json};
+use std::collections::{HashMap, HashSet};
+use std::env;
 use std::error::Error;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use tokio::io::AsyncWriteExt;
 use tokio::sync::Notify;
-use std::env;
+use tokio::time::{Duration, sleep};
+
+const IA_SEARCH_ROWS: usize = 25;
+const IA_SEARCH_DELAY: Duration = Duration::from_secs(2);
+const IA_DOWNLOAD_DELAY: Duration = Duration::from_secs(1);
+const IA_MAX_RETRIES: usize = 3;
+const IA_DEFAULT_OUTPUT_DIR: &str = "/mediakraken/metadata/meta/trailer/internet_archive";
+const IA_DEFAULT_STATE_FILE: &str =
+    "/mediakraken/metadata/meta/trailer/internet_archive_state.json";
+const IA_DEFAULT_MAX_PAGES: usize = 1;
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Default)]
+struct IATrailerState {
+    downloaded_ids: HashSet<String>,
+    downloaded_files: HashMap<String, String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct IASearchResponse {
+    response: IASearchDocs,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct IASearchDocs {
+    docs: Vec<IASearchDoc>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct IASearchDoc {
+    identifier: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct IAMetadataResponse {
+    files: Vec<IAArchiveFile>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct IAArchiveFile {
+    name: Option<String>,
+    format: Option<String>,
+}
 
 // #[derive(Debug, serde::Deserialize)]
 // struct DigitalUPCNetRecord {
@@ -39,9 +84,10 @@ use std::env;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // connect to db and do a version check
-    let (sqlx_pool_rw, sqlx_pool_ro) = mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120)
-        .await
-        .unwrap();
+    let (sqlx_pool_rw, sqlx_pool_ro) =
+        mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120)
+            .await
+            .unwrap();
     mk_lib_database::mk_lib_database_version::mk_lib_database_version_check(&sqlx_pool_ro, false)
         .await
         .unwrap();
@@ -179,6 +225,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             }
                         }
                     }
+                } else if json_message["Type"].to_string() == "IATrailer" {
+                    if let Err(error) = process_ia_trailer_request(&json_message).await {
+                        eprintln!("IATrailer request failed: {error}");
+                    }
                 }
                 let _result = mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_ack(
                     &rabbit_channel,
@@ -191,5 +241,211 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let guard = Notify::new();
     guard.notified().await;
+    Ok(())
+}
+
+async fn process_ia_trailer_request(json_message: &Value) -> Result<(), Box<dyn Error>> {
+    let output_dir = json_message
+        .get("OutputDir")
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(IA_DEFAULT_OUTPUT_DIR));
+    let state_file = json_message
+        .get("StateFile")
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(IA_DEFAULT_STATE_FILE));
+    let max_pages = json_message
+        .get("MaxPages")
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .unwrap_or(IA_DEFAULT_MAX_PAGES);
+
+    tokio::fs::create_dir_all(&output_dir).await?;
+
+    let mut state = ia_load_state(&state_file).await?;
+    let client = Client::builder()
+        .user_agent("mediakraken-mkdownload-ia-trailer/0.1 (+https://archive.org)")
+        .build()?;
+
+    for page in 1..=max_pages {
+        let docs = ia_search_trailer_items(&client, page).await?;
+        if docs.is_empty() {
+            break;
+        }
+
+        for doc in docs {
+            if state.downloaded_ids.contains(&doc.identifier) {
+                continue;
+            }
+
+            if let Some(filename) = ia_fetch_best_trailer_file(&client, &doc.identifier).await? {
+                let saved_path =
+                    ia_download_file(&client, &doc.identifier, &filename, &output_dir).await?;
+                state.downloaded_ids.insert(doc.identifier.clone());
+                state.downloaded_files.insert(
+                    doc.identifier.clone(),
+                    saved_path.to_string_lossy().to_string(),
+                );
+                ia_save_state(&state_file, &state).await?;
+                sleep(IA_DOWNLOAD_DELAY).await;
+            }
+        }
+
+        sleep(IA_SEARCH_DELAY).await;
+    }
+
+    Ok(())
+}
+
+async fn ia_search_trailer_items(
+    client: &Client,
+    page: usize,
+) -> Result<Vec<IASearchDoc>, Box<dyn Error>> {
+    let query = "mediatype:movies AND subject:trailer";
+    let url = format!(
+        "https://archive.org/advancedsearch.php?q={}&fl[]=identifier&sort[]=downloads+desc&rows={}&page={}&output=json",
+        urlencoding::encode(query),
+        IA_SEARCH_ROWS,
+        page
+    );
+    let response: IASearchResponse = ia_fetch_json_with_backoff(client, &url).await?;
+    Ok(response.response.docs)
+}
+
+async fn ia_fetch_best_trailer_file(
+    client: &Client,
+    identifier: &str,
+) -> Result<Option<String>, Box<dyn Error>> {
+    let metadata_url = format!(
+        "https://archive.org/metadata/{}",
+        urlencoding::encode(identifier)
+    );
+    let metadata: IAMetadataResponse = ia_fetch_json_with_backoff(client, &metadata_url).await?;
+
+    let preferred_extensions = [".mp4", ".m4v", ".mkv", ".webm"];
+    let mut best: Option<String> = None;
+
+    for file in metadata.files {
+        let Some(name) = file.name else {
+            continue;
+        };
+
+        let name_lower = name.to_ascii_lowercase();
+        let format_lower = file.format.unwrap_or_default().to_ascii_lowercase();
+        let likely_trailer = name_lower.contains("trailer") || format_lower.contains("trailer");
+        let video_format = preferred_extensions
+            .iter()
+            .any(|ext| name_lower.ends_with(ext))
+            || format_lower.contains("mpeg4")
+            || format_lower.contains("h.264")
+            || format_lower.contains("matroska")
+            || format_lower.contains("webm");
+
+        if likely_trailer && video_format {
+            return Ok(Some(name));
+        }
+
+        if best.is_none() && video_format {
+            best = Some(name);
+        }
+    }
+
+    Ok(best)
+}
+
+async fn ia_download_file(
+    client: &Client,
+    identifier: &str,
+    filename: &str,
+    output_dir: &Path,
+) -> Result<PathBuf, Box<dyn Error>> {
+    let url = format!(
+        "https://archive.org/download/{}/{}",
+        urlencoding::encode(identifier),
+        urlencoding::encode(filename)
+    );
+
+    let mut response = ia_get_with_backoff(client, &url).await?;
+    let output_name = ia_sanitize_filename(identifier, filename);
+    let output_path = output_dir.join(output_name);
+    let mut file = tokio::fs::File::create(&output_path).await?;
+
+    while let Some(chunk) = response.chunk().await? {
+        file.write_all(&chunk).await?;
+    }
+    file.flush().await?;
+
+    Ok(output_path)
+}
+
+async fn ia_fetch_json_with_backoff<T>(client: &Client, url: &str) -> Result<T, Box<dyn Error>>
+where
+    T: for<'de> serde::Deserialize<'de>,
+{
+    let response = ia_get_with_backoff(client, url).await?;
+    Ok(response.json::<T>().await?)
+}
+
+async fn ia_get_with_backoff(
+    client: &Client,
+    url: &str,
+) -> Result<reqwest::Response, Box<dyn Error>> {
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+        let response = client.get(url).send().await?;
+
+        if response.status() == StatusCode::TOO_MANY_REQUESTS {
+            let retry_after = response
+                .headers()
+                .get("retry-after")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.parse::<u64>().ok())
+                .unwrap_or(5);
+
+            if attempt > IA_MAX_RETRIES {
+                return Err(
+                    format!("rate limited after {IA_MAX_RETRIES} retries for {url}").into(),
+                );
+            }
+
+            sleep(Duration::from_secs(retry_after)).await;
+            continue;
+        }
+
+        if !response.status().is_success() {
+            return Err(format!("request failed ({}): {url}", response.status()).into());
+        }
+
+        return Ok(response);
+    }
+}
+
+fn ia_sanitize_filename(identifier: &str, filename: &str) -> String {
+    let source = format!("{identifier}_{filename}");
+    source
+        .chars()
+        .map(|value| {
+            if value.is_ascii_alphanumeric() || value == '.' || value == '-' || value == '_' {
+                value
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+async fn ia_load_state(path: &Path) -> Result<IATrailerState, Box<dyn Error>> {
+    match tokio::fs::read(path).await {
+        Ok(bytes) => Ok(serde_json::from_slice(&bytes)?),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(IATrailerState::default()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+async fn ia_save_state(path: &Path, state: &IATrailerState) -> Result<(), Box<dyn Error>> {
+    let data = serde_json::to_vec_pretty(state)?;
+    tokio::fs::write(path, data).await?;
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- Add automated retrieval of trailer files from Internet Archive and avoid re-downloading the same items by persisting state.
- Provide configurable output directory, state file location, and page limits while respecting rate limits and retries.
- Integrate IA trailer downloads into the existing RabbitMQ-driven `mkdownload` service as a new message `Type` handler.

### Description
- Added `urlencoding` dependency and implemented a new `IATrailer` workflow in `main.rs` that watches for `"Type":"IATrailer"` RabbitMQ messages and calls `process_ia_trailer_request`.
- Implemented IA-specific types and helpers including `IASearchResponse`, `IAMetadataResponse`, `IAArchiveFile`, and an `IATrailerState` struct to track `downloaded_ids` and `downloaded_files` with `ia_load_state`/`ia_save_state` functions.
- Added network logic using `reqwest::Client` with `ia_get_with_backoff` and `ia_fetch_json_with_backoff` to handle `429` rate limiting, retry delays, and max retries, plus search/metadata parsing functions `ia_search_trailer_items` and `ia_fetch_best_trailer_file` to pick best video files.
- Implemented `ia_download_file` with async streaming writes, filename sanitization via `ia_sanitize_filename`, directory creation, and configurable constants like `IA_SEARCH_ROWS`, `IA_SEARCH_DELAY`, and default output/state paths.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07e8e26e483218142010a61d02535)