### PR TITLE
Fix mkdownload IAMovies/IATrailer handler wiring and restore IA types/constants

### DIFF
--- a/docker/core/mkdownload/src/main.rs
+++ b/docker/core/mkdownload/src/main.rs
@@ -1,17 +1,60 @@
 use mk_lib_database;
 use mk_lib_network;
 use mk_lib_rabbitmq;
+use reqwest::{Client, StatusCode};
 use serde_json::{Value, json};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
+use tokio::io::AsyncWriteExt;
 use tokio::sync::{Notify, Semaphore};
+use tokio::time::{Duration, sleep};
 
 const DEFAULT_MAX_CONCURRENT_DOWNLOADS: usize = 4;
+const IA_SEARCH_ROWS: usize = 25;
+const IA_SEARCH_DELAY: Duration = Duration::from_secs(2);
+const IA_DOWNLOAD_DELAY: Duration = Duration::from_secs(1);
+const IA_MAX_RETRIES: usize = 3;
+const IA_DEFAULT_OUTPUT_DIR: &str = "/mediakraken/metadata/meta/trailer/internet_archive";
+const IA_DEFAULT_STATE_FILE: &str =
+    "/mediakraken/metadata/meta/trailer/internet_archive_state.json";
+const IA_DEFAULT_MAX_PAGES: usize = 1;
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Default)]
+struct IATrailerState {
+    downloaded_ids: HashSet<String>,
+    downloaded_files: HashMap<String, String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct IASearchResponse {
+    response: IASearchDocs,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct IASearchDocs {
+    docs: Vec<IASearchDoc>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct IASearchDoc {
+    identifier: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct IAMetadataResponse {
+    files: Vec<IAArchiveFile>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct IAArchiveFile {
+    name: Option<String>,
+    format: Option<String>,
+}
 
 async fn process_message(json_message: Value, option_config_json: &Value) {
     if json_message["Type"].to_string() == "File" {
@@ -67,6 +110,12 @@ async fn process_message(json_message: Value, option_config_json: &Value) {
                     }
                 }
             }
+        }
+    } else if json_message["Type"].to_string() == "IATrailer"
+        || json_message["Type"].to_string() == "IAMovies"
+    {
+        if let Err(error) = process_ia_trailer_request(&json_message).await {
+            eprintln!("{} request failed: {error}", json_message["Type"]);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- A previous merge removed Internet Archive (IA) trailer-related imports, constants, and types and detached the IA message path, causing `IATrailer`/`IAMovies` messages to be unhandled.
- Restore the minimal IA support surface so existing IA helper functions and `process_ia_trailer_request` can compile and be invoked.

### Description
- Restored missing imports: `reqwest::{Client, StatusCode}`, `HashMap`, `tokio::io::AsyncWriteExt`, and `tokio::time::{Duration, sleep}` in `docker/core/mkdownload/src/main.rs`.
- Reintroduced IA constants used by the IA logic: `IA_SEARCH_ROWS`, `IA_SEARCH_DELAY`, `IA_DOWNLOAD_DELAY`, `IA_MAX_RETRIES`, `IA_DEFAULT_OUTPUT_DIR`, `IA_DEFAULT_STATE_FILE`, and `IA_DEFAULT_MAX_PAGES`.
- Recreated IA state/response data structures required by IA functions: `IATrailerState`, `IASearchResponse`, `IASearchDocs`, `IASearchDoc`, `IAMetadataResponse`, and `IAArchiveFile`.
- Re-wired the message dispatch in `process_message` so both `Type == "IATrailer"` and `Type == "IAMovies"` call `process_ia_trailer_request` and log failures (kept change minimal and localized to mkdownload).

### Testing
- Ran `cargo fmt` in `docker/core/mkdownload` to format the file and it completed successfully.
- Ran `cargo check` in `docker/core/mkdownload` and it failed due to external registry access (configured Kellnr mirror returned `403 Forbidden`), preventing a full compile verification.
- Ran `cargo clippy -- -D warnings` in `docker/core/mkdownload` and it also failed for the same external registry access issue, so lints could not be fully validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0da0cea248321ba72a27afcfe9c3a)