### PR TITLE
Fix admin page layout to stack below top navbar

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_backup.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_backup.html
@@ -4,9 +4,11 @@
 
 <body class="bg-gray-100 text-gray-900">
 
-<div class="flex min-h-screen">
+<div class="flex min-h-screen flex-col">
   {% include "bss_user/bss_user_include_menu.html" %}
-  {% include "bss_admin/bss_admin_include_menu.html" %}
+
+  <div class="flex flex-1">
+    {% include "bss_admin/bss_admin_include_menu.html" %}
 
   <main class="flex-1 p-6" x-data="backupPage()">
 
@@ -142,9 +144,8 @@
     </div>
 
   </main>
+  </div>
 </div>
-
-
 
 {% include "bss_public/bss_public_footer.html" %}
    <script>

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_cloud.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_cloud.html
@@ -4,9 +4,11 @@
 
 <body class="bg-gray-100 text-gray-900">
 
-<div class="flex min-h-screen">
+<div class="flex min-h-screen flex-col">
   {% include "bss_user/bss_user_include_menu.html" %}
-  {% include "bss_admin/bss_admin_include_menu.html" %}
+
+  <div class="flex flex-1">
+    {% include "bss_admin/bss_admin_include_menu.html" %}
 
   <main class="flex-1 p-6" x-data="cloudConfig()">
 
@@ -89,6 +91,7 @@
     </div>
 
   </main>
+  </div>
 </div>
 
 {% include "bss_public/bss_public_footer.html" %}

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_cron.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_cron.html
@@ -4,9 +4,11 @@
 
 <body class="bg-gray-100 text-gray-900">
 
-<div class="flex min-h-screen">
+<div class="flex min-h-screen flex-col">
   {% include "bss_user/bss_user_include_menu.html" %}
-  {% include "bss_admin/bss_admin_include_menu.html" %}
+
+  <div class="flex flex-1">
+    {% include "bss_admin/bss_admin_include_menu.html" %}
 
   <main class="flex-1 p-6" x-data="cronPage()">
 
@@ -164,6 +166,7 @@
     </div>
 
   </main>
+  </div>
 </div>
 
 {% include "bss_public/bss_public_footer.html" %}

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_db_statistics.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_db_statistics.html
@@ -4,9 +4,11 @@
 
 <body class="bg-gray-100 text-gray-900">
 
-<div class="flex min-h-screen">
+<div class="flex min-h-screen flex-col">
   {% include "bss_user/bss_user_include_menu.html" %}
-  {% include "bss_admin/bss_admin_include_menu.html" %}
+
+  <div class="flex flex-1">
+    {% include "bss_admin/bss_admin_include_menu.html" %}
 
   <main class="flex-1 p-6">
 
@@ -155,6 +157,7 @@
     </section>
 
   </main>
+  </div>
 </div>
 
 {% include "bss_public/bss_public_footer.html" %}

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_game_servers.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_game_servers.html
@@ -5,9 +5,11 @@
 
 <body class="bg-gray-100 text-gray-900">
 
-<div class="flex min-h-screen">
+<div class="flex min-h-screen flex-col">
   {% include "bss_user/bss_user_include_menu.html" %}
-  {% include "bss_admin/bss_admin_include_menu.html" %}
+
+  <div class="flex flex-1">
+    {% include "bss_admin/bss_admin_include_menu.html" %}
 
   <main class="flex-1 p-6">
 
@@ -70,6 +72,7 @@
     </section>
 
   </main>
+  </div>
 </div>
 
 {% include "bss_public/bss_public_footer.html" %}

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_hardware.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_hardware.html
@@ -4,9 +4,11 @@
 
 <body class="bg-gray-100 text-gray-900">
 
-<div class="flex min-h-screen">
+<div class="flex min-h-screen flex-col">
   {% include "bss_user/bss_user_include_menu.html" %}
-  {% include "bss_admin/bss_admin_include_menu.html" %}
+
+  <div class="flex flex-1">
+    {% include "bss_admin/bss_admin_include_menu.html" %}
 
   <main class="flex-1 p-6" x-data="hardwarePage()">
 
@@ -105,6 +107,7 @@
     </div>
 
   </main>
+  </div>
 </div>
 
 {% include "bss_public/bss_public_footer.html" %}

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_home.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_home.html
@@ -4,11 +4,13 @@
 {% include "bss_include_header.html" %}
 
 <body id="page-top" class="bg-gray-100">
-  <div class="flex min-h-screen">
+  <div class="flex min-h-screen flex-col">
     {% include "bss_user/bss_user_include_menu.html" %}
-    {% include "bss_admin/bss_admin_include_menu.html" %}
 
-    <div id="content-wrapper" class="flex flex-col flex-1">
+    <div class="flex flex-1">
+      {% include "bss_admin/bss_admin_include_menu.html" %}
+
+      <div id="content-wrapper" class="flex flex-col flex-1">
 
       <main id="content" class="flex-1 px-4 py-6">
 
@@ -95,6 +97,7 @@
       </main>
 
       {% include "bss_public/bss_public_footer.html" %}
+      </div>
     </div>
   </div>
  </body>

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
@@ -4,9 +4,11 @@
 
 <body class="bg-gray-100 text-gray-900">
 
-<div class="flex min-h-screen">
+<div class="flex min-h-screen flex-col">
   {% include "bss_user/bss_user_include_menu.html" %}
-  {% include "bss_admin/bss_admin_include_menu.html" %}
+
+  <div class="flex flex-1">
+    {% include "bss_admin/bss_admin_include_menu.html" %}
 
   <main class="flex-1 p-6" x-data="libraryPage()">
 
@@ -166,6 +168,7 @@
     </div>
 
   </main>
+  </div>
 </div>
 
 {% include "bss_public/bss_public_footer.html" %}

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_logging.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_logging.html
@@ -3,9 +3,11 @@
 {% include "bss_include_header.html" %}
 <body class="bg-gray-100 text-gray-900">
 
-<div class="flex min-h-screen">
+<div class="flex min-h-screen flex-col">
   {% include "bss_user/bss_user_include_menu.html" %}
-  {% include "bss_admin/bss_admin_include_menu.html" %}
+
+  <div class="flex flex-1">
+    {% include "bss_admin/bss_admin_include_menu.html" %}
 
   <main class="flex-1 p-6" x-data>
 
@@ -54,8 +56,9 @@
     </section>
 
   </main>
+  </div>
 </div>
 
 {% include "bss_public/bss_public_footer.html" %}
- -</body>
+</body>
 </html>

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_report_known_media.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_report_known_media.html
@@ -4,9 +4,11 @@
 
 <body class="bg-gray-100 text-gray-900">
 
-<div class="flex min-h-screen">
+<div class="flex min-h-screen flex-col">
   {% include "bss_user/bss_user_include_menu.html" %}
-  {% include "bss_admin/bss_admin_include_menu.html" %}
+
+  <div class="flex flex-1">
+    {% include "bss_admin/bss_admin_include_menu.html" %}
 
   <main class="flex-1 p-6">
 
@@ -51,6 +53,7 @@
     </section>
 
   </main>
+  </div>
 </div>
 
 {% include "bss_public/bss_public_footer.html" %}

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_settings.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_settings.html
@@ -4,9 +4,11 @@
 
 <body class="bg-gray-100 text-gray-900">
 
-<div class="flex min-h-screen">
+<div class="flex min-h-screen flex-col">
   {% include "bss_user/bss_user_include_menu.html" %}
-  {% include "bss_admin/bss_admin_include_menu.html" %}
+
+  <div class="flex flex-1">
+    {% include "bss_admin/bss_admin_include_menu.html" %}
 
   <main class="flex-1 p-6 space-y-6">
 
@@ -83,6 +85,7 @@
     </section>
 
   </main>
+  </div>
 </div>
 
 {% include "bss_public/bss_public_footer.html" %}

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_torrent proxy.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_torrent proxy.html
@@ -4,12 +4,15 @@
 {% include "bss_include_header.html" %}
 
 <body id="page-top">
-    <div class="flex min-h-screen">
+    <div class="flex min-h-screen flex-col">
         {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "bss_admin/bss_admin_include_menu.html" %}
+
+        <div class="flex flex-1">
+            {% include "bss_admin/bss_admin_include_menu.html" %}
         <iframe src="https://{{template_data_host}}:8900/admin/transmission/web/" title="MediaKraken Transmission"
             class="w-full h-screen border-0" style="min-height: 80vh;">
         </iframe>
+        </div>
         {% include "bss_public/bss_public_footer.html" %}
     </div>
  </body>


### PR DESCRIPTION
### Motivation
- Admin pages rendered the admin sidebar as a horizontal sibling of the top navbar which pushed admin content to the right instead of placing it below the top navbar.
- The change makes admin pages consistently render the shared top navbar above the admin sidebar + content without changing visual components or behavior.

### Description
- Updated admin templates to change the outer wrapper from `flex min-h-screen` to `flex min-h-screen flex-col` and introduced an inner `div` with `flex flex-1` that contains the admin sidebar and page content so the top navbar sits above the admin row.
- Fixed missing/misaligned closing containers in a few templates so the DOM structure is balanced after the restructure.
- Files modified: `docker/core/mkwebaxum/templates/bss_admin/{bss_admin_home.html,bss_admin_backup.html,bss_admin_cloud.html,bss_admin_cron.html,bss_admin_db_statistics.html,bss_admin_game_servers.html,bss_admin_hardware.html,bss_admin_library.html,bss_admin_logging.html,bss_admin_report_known_media.html,bss_admin_settings.html,bss_admin_torrent proxy.html}`.
- Change is intentionally minimal and only touches layout containers in the listed templates (no CSS, JS, or Rust code changes beyond template structure).

### Testing
- Ran `cargo fmt --check` in `docker/core/mkwebaxum` which reported repository formatting/structural diffs outside this change and warnings from workspace config; this check did not conclusively validate template edits.
- Ran `cargo check` and `cargo clippy -- -D warnings` in the environment but both failed to fetch dependencies due to a `403` from the configured internal registry (`mkdevkellnrapi`), so build/lint could not complete here.
- Attempted an automated browser capture of `/admin/home` but the local app was not running (`ERR_EMPTY_RESPONSE`), so no runtime screenshot verification was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b20fbf148883218661088df65e3272)