### PR TITLE
Make libretro core fetcher use latest stable Linux x86_64 and only download zips

### DIFF
--- a/docker/core/mklibretrocorefetchupdate/src/main.rs
+++ b/docker/core/mklibretrocorefetchupdate/src/main.rs
@@ -1,4 +1,3 @@
-use mk_lib_compression;
 use mk_lib_hash;
 use mk_lib_network;
 use mk_lib_rabbitmq;
@@ -16,6 +15,30 @@ fn is_hidden(entry: &DirEntry) -> bool {
         .to_str()
         .map(|s| s.starts_with("."))
         .unwrap_or(false)
+}
+
+fn parse_version_components(version: &str) -> Option<Vec<u32>> {
+    let parsed = version
+        .split('.')
+        .map(str::parse::<u32>)
+        .collect::<Result<Vec<_>, _>>()
+        .ok()?;
+    if parsed.is_empty() {
+        return None;
+    }
+    Some(parsed)
+}
+
+fn latest_stable_version(index_html: &str) -> Option<String> {
+    index_html
+        .split("href=\"")
+        .skip(1)
+        .filter_map(|segment| segment.split('\"').next())
+        .filter_map(|href| href.strip_suffix('/'))
+        .filter(|version| version.chars().all(|c| c.is_ascii_digit() || c == '.'))
+        .filter_map(|version| parse_version_components(version).map(|parts| (parts, version)))
+        .max_by(|(left, _), (right, _)| left.cmp(right))
+        .map(|(_, version)| version.to_string())
 }
 
 #[tokio::main]
@@ -65,10 +88,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 println!("hash: {:?}", emulation_cores);
 
                 // date crc32 core_filename.zip
-                let libtro_url = "http://buildbot.libretro.com/nightly/linux/x86_64/latest/";
+                let stable_root = "http://buildbot.libretro.com/stable/";
+                let stable_index =
+                    mk_lib_network::mk_lib_network::mk_data_from_url(stable_root.to_string())
+                        .await
+                        .unwrap();
+                let latest_version = latest_stable_version(&stable_index).unwrap();
+                let libtro_url = format!("{}{}/linux/x86_64/", stable_root, latest_version);
                 let fetch_result = mk_lib_network::mk_lib_network::mk_data_from_url(format!(
                     "{}{}",
-                    libtro_url, ".index-extended"
+                    &libtro_url, ".index-extended"
                 ))
                 .await
                 .unwrap();
@@ -98,16 +127,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         if download_core {
                             // download the missing or newer core
                             mk_lib_network::mk_lib_network::mk_download_file_from_url(
-                                format!("{}{}", libtro_url, core_name),
+                                format!("{}{}", &libtro_url, core_name),
                                 &format!("/mediakraken/emulation/cores/{}", core_name),
-                            )
-                            .await
-                            .unwrap();
-                            // unzip the core for use
-                            mk_lib_compression::mk_lib_compression::mk_decompress_zip(
-                                &format!("/mediakraken/emulation/cores/{}", core_name),
-                                false,
-                                "/mediakraken/emulation/cores/",
                             )
                             .await
                             .unwrap();


### PR DESCRIPTION
### Motivation

- Replace the previous nightly `latest` endpoint with the stable release tree so cores come from official stable builds. 
- Dynamically discover the newest numeric stable release directory instead of hardcoding a path. 
- Avoid extracting archives on fetch to keep the job focused on downloading core zip files only.

### Description

- Added `parse_version_components` and `latest_stable_version` helper functions to parse the HTML index at `http://buildbot.libretro.com/stable/` and pick the highest numeric version directory. 
- Changed the core index source from the nightly `latest` URL to the computed stable URL for `linux/x86_64/.index-extended`. 
- Adjusted download logic to only download core `.zip` files and removed the unzip/decompression step. 
- Modified file: `docker/core/mklibretrocorefetchupdate/src/main.rs`.

### Testing

- Ran `cargo fmt` in `docker/core/mklibretrocorefetchupdate` which completed successfully. 
- Ran `cargo check` and `cargo clippy -- -D warnings` but both were blocked by an external registry error (HTTP 403 from the configured Kellnr/crates endpoint), so compile/lint checks could not be completed in this environment. 
- Basic local review of the modified `main.rs` logic and formatting was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b36a031f788321a5f9f16ec66d9945)