### PR TITLE
Add Alexa device discovery helper

### DIFF
--- a/src/mk_lib_hardware/src/mk_lib_hardware_alexa.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_alexa.rs
@@ -1,1 +1,44 @@
+use ssdp::header::{HeaderMut, HeaderRef, Man, MX, ST};
+use ssdp::message::{Multicast, SearchRequest};
+use url::Url;
 
+const ALEXA_DISCOVERY_TARGET: &str = "urn:schemas-upnp-org:device:MediaRenderer:1";
+
+pub async fn mk_lib_hardware_alexa_discover() -> Vec<Url> {
+    let mut request = SearchRequest::new();
+    request.set(Man);
+    request.set(MX(5));
+
+    let Ok(target) = ssdp::FieldMap::new(ALEXA_DISCOVERY_TARGET) else {
+        return Vec::new();
+    };
+
+    request.set(ST::Target(target));
+
+    let Ok(responses) = request.multicast() else {
+        return Vec::new();
+    };
+
+    responses
+        .into_iter()
+        .filter_map(|(response, _)| {
+            let looks_like_alexa = response
+                .get_raw("SERVER")
+                .into_iter()
+                .flatten()
+                .chain(response.get_raw("USN").into_iter().flatten())
+                .any(|value| {
+                    let value = String::from_utf8_lossy(value);
+                    let lowercase_value = value.to_ascii_lowercase();
+                    lowercase_value.contains("amazon") || lowercase_value.contains("alexa")
+                });
+
+            if !looks_like_alexa {
+                return None;
+            }
+
+            let location = response.get_raw("Location")?.first()?;
+            Url::parse(&String::from_utf8_lossy(location)).ok()
+        })
+        .collect()
+}


### PR DESCRIPTION
### Motivation
- Provide an Alexa device discovery helper so the hardware library can locate Amazon/Alexa media renderer devices on the local network via SSDP.

### Description
- Add `mk_lib_hardware_alexa_discover()` in `src/mk_lib_hardware/src/mk_lib_hardware_alexa.rs` which sends an SSDP M-SEARCH using `urn:schemas-upnp-org:device:MediaRenderer:1` and returns a `Vec<Url>` of discovered `Location` URLs.
- Filter SSDP responses for Alexa-like devices by inspecting `SERVER` and `USN` headers for the substrings `amazon` or `alexa` and skip non-matching or malformed responses instead of panicking.
- Use a constant `ALEXA_DISCOVERY_TARGET` and perform graceful early returns when request setup or multicast fails.

### Testing
- Ran `rustfmt --edition 2021 src/mk_lib_hardware/src/mk_lib_hardware_alexa.rs` which completed successfully.
- Ran `cargo check` in the `mk_lib_hardware` crate which failed in this environment due to the private registry endpoint returning HTTP 403 and prevented full compilation.
- Ran `cargo clippy -- -D warnings` in the `mk_lib_hardware` crate which also failed due to the same private registry HTTP 403 issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5acf675d883218e48b6f94a668e49)