### PR TITLE
Add Apple TV discovery function to hardware library

### DIFF
--- a/src/mk_lib_hardware/src/mk_lib_hardware_appletv.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_appletv.rs
@@ -1,1 +1,21 @@
+use futures_util::{pin_mut, stream::StreamExt};
+use std::time::Duration;
 
+const APPLETV_SERVICE_NAME: &str = "_appletv-v2._tcp.local";
+
+pub async fn mk_lib_hardware_appletv_discover() -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let stream = mdns::discover::all(APPLETV_SERVICE_NAME, Duration::from_secs(5))?.listen();
+    pin_mut!(stream);
+
+    let mut devices = Vec::new();
+    while let Some(Ok(response)) = stream.next().await {
+        if let Some(hostname) = response.hostname() {
+            let hostname = hostname.to_string();
+            if !devices.iter().any(|existing| existing == &hostname) {
+                devices.push(hostname);
+            }
+        }
+    }
+
+    Ok(devices)
+}


### PR DESCRIPTION
### Motivation
- Provide a small helper to discover Apple TV devices on the local network via mDNS so higher-level code can enumerate devices. 
- Keep the change minimal and self-contained inside the hardware library without altering public interfaces beyond adding the helper.

### Description
- Add `mk_lib_hardware_appletv_discover` in `src/mk_lib_hardware/src/mk_lib_hardware_appletv.rs` which performs mDNS discovery for the service `_appletv-v2._tcp.local`.
- The function listens for responses for 5 seconds, collects hostnames into a `Vec<String>`, and deduplicates entries before returning `Result<Vec<String>, Box<dyn std::error::Error>>`.
- Uses `mdns::discover::all`, `futures_util::stream::StreamExt`, and `std::time::Duration` and keeps the implementation minimal and synchronous to the rest of the crate.

### Testing
- Ran `rustfmt --edition 2024 src/mk_lib_hardware/src/mk_lib_hardware_appletv.rs`, which succeeded.
- Attempted `cargo check` in the crate, which failed in this environment due to a private registry HTTP 403 and not due to the change itself.
- Attempted `cargo clippy -- -D warnings`, which also failed in this environment for the same private registry access issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ad303f048321a80cfc7f9991c837)