### PR TITLE
Add Fire TV mDNS discovery helper

### DIFF
--- a/src/mk_lib_hardware/src/mk_lib_hardware_firetv.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_firetv.rs
@@ -1,0 +1,27 @@
+use futures_util::{pin_mut, stream::StreamExt};
+use std::time::Duration;
+
+const FIRETV_SERVICE_NAMES: [&str; 2] = [
+    "_adb-tls-connect._tcp.local",
+    "_androidtvremote2._tcp.local",
+];
+
+pub async fn mk_lib_hardware_firetv_discover() -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let mut devices = Vec::new();
+
+    for service_name in FIRETV_SERVICE_NAMES {
+        let stream = mdns::discover::all(service_name, Duration::from_secs(5))?.listen();
+        pin_mut!(stream);
+
+        while let Some(Ok(response)) = stream.next().await {
+            if let Some(hostname) = response.hostname() {
+                let hostname = hostname.to_string();
+                if !devices.iter().any(|existing| existing == &hostname) {
+                    devices.push(hostname);
+                }
+            }
+        }
+    }
+
+    Ok(devices)
+}


### PR DESCRIPTION
### Motivation
- Provide a simple helper to locate Fire TV / Android TV devices via mDNS so the hardware library can enumerate devices similarly to other discovery helpers (AppleTV, Roku, etc.).

### Description
- Add `mk_lib_hardware_firetv_discover` in `src/mk_lib_hardware/src/mk_lib_hardware_firetv.rs` which queries `_adb-tls-connect._tcp.local` and `_androidtvremote2._tcp.local` via `mdns`, collects hostnames, deduplicates them, and returns `Result<Vec<String>, Box<dyn std::error::Error>>`.

### Testing
- Ran `cargo fmt` in the `src/mk_lib_hardware` crate (succeeded).
- Attempted `cargo check` and `cargo clippy -- -D warnings` in the crate but both failed in this environment due to the private registry returning HTTP 403 while fetching dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b65574908321a42ef841b3431eb0)