### PR TITLE
Add HDHomeRun device discovery function

### DIFF
--- a/src/mk_lib_hardware/src/mk_lib_hardware_hdhomerun.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_hdhomerun.rs
@@ -1,0 +1,45 @@
+use ssdp::header::{HeaderMut, HeaderRef, MX, Man, ST};
+use ssdp::message::{Multicast, SearchRequest};
+use url::Url;
+
+const HDHOMERUN_DISCOVERY_TARGET: &str = "upnp:rootdevice";
+
+pub async fn mk_lib_hardware_hdhomerun_discover() -> Vec<Url> {
+    let mut request = SearchRequest::new();
+    request.set(Man);
+    request.set(MX(5));
+
+    let Ok(target) = ssdp::FieldMap::new(HDHOMERUN_DISCOVERY_TARGET) else {
+        return Vec::new();
+    };
+
+    request.set(ST::Target(target));
+
+    let Ok(responses) = request.multicast() else {
+        return Vec::new();
+    };
+
+    responses
+        .into_iter()
+        .filter_map(|(response, _)| {
+            let looks_like_hdhomerun = response
+                .get_raw("SERVER")
+                .into_iter()
+                .flatten()
+                .chain(response.get_raw("USN").into_iter().flatten())
+                .chain(response.get_raw("ST").into_iter().flatten())
+                .any(|value| {
+                    String::from_utf8_lossy(value)
+                        .to_ascii_lowercase()
+                        .contains("hdhomerun")
+                });
+
+            if !looks_like_hdhomerun {
+                return None;
+            }
+
+            let location = response.get_raw("Location")?.first()?;
+            Url::parse(&String::from_utf8_lossy(location)).ok()
+        })
+        .collect()
+}


### PR DESCRIPTION
### Motivation
- Provide a small helper to discover HDHomeRun tuners on the local network via SSDP so other code can locate and interact with HDHomeRun devices.

### Description
- Add `mk_lib_hardware_hdhomerun_discover` in `src/mk_lib_hardware/src/mk_lib_hardware_hdhomerun.rs` that performs an SSDP M-SEARCH using `upnp:rootdevice` and returns matching device `Location` URLs as `Vec<Url>`.
- Filter SSDP responses by checking `SERVER`, `USN`, and `ST` headers for the substring `hdhomerun` (case-insensitive) before parsing the `Location` header.
- Gracefully handle missing or malformed responses by skipping non-matching entries and returning an empty `Vec` on errors.

### Testing
- Formatted the new file with `rustfmt --edition 2024 src/mk_lib_hardware/src/mk_lib_hardware_hdhomerun.rs`, which succeeded.
- `cargo fmt --manifest-path src/mk_lib_hardware/Cargo.toml` failed in this environment due to a missing `kellnr` registry configuration.
- `cargo check --manifest-path src/mk_lib_hardware/Cargo.toml` failed in this environment due to the same missing `kellnr` registry configuration.
- `cargo clippy --manifest-path src/mk_lib_hardware/Cargo.toml -- -D warnings` failed in this environment due to the same missing `kellnr` registry configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b67b9e5883218cdb76d59c31a561)