### PR TITLE
Add Synology SSDP discovery helper

### DIFF
--- a/src/mk_lib_hardware/src/mk_lib_hardware_synology.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_synology.rs
@@ -1,0 +1,45 @@
+use ssdp::header::{HeaderMut, HeaderRef, MX, Man, ST};
+use ssdp::message::{Multicast, SearchRequest};
+use url::Url;
+
+const SYNOLOGY_DISCOVERY_TARGET: &str = "ssdp:all";
+
+pub async fn mk_lib_hardware_synology_discover() -> Vec<Url> {
+    let mut request = SearchRequest::new();
+    request.set(Man);
+    request.set(MX(5));
+
+    let Ok(target) = ssdp::FieldMap::new(SYNOLOGY_DISCOVERY_TARGET) else {
+        return Vec::new();
+    };
+
+    request.set(ST::Target(target));
+
+    let Ok(responses) = request.multicast() else {
+        return Vec::new();
+    };
+
+    responses
+        .into_iter()
+        .filter_map(|(response, _)| {
+            let looks_like_synology = response
+                .get_raw("SERVER")
+                .into_iter()
+                .flatten()
+                .chain(response.get_raw("USN").into_iter().flatten())
+                .chain(response.get_raw("Location").into_iter().flatten())
+                .any(|value| {
+                    String::from_utf8_lossy(value)
+                        .to_ascii_lowercase()
+                        .contains("synology")
+                });
+
+            if !looks_like_synology {
+                return None;
+            }
+
+            let location = response.get_raw("Location")?.first()?;
+            Url::parse(&String::from_utf8_lossy(location)).ok()
+        })
+        .collect()
+}


### PR DESCRIPTION
### Motivation
- Provide a small, focused helper to discover Synology NAS devices on the local network using the project's existing SSDP discovery pattern.
- Match the existing discovery helpers (e.g. Alexa, Sonos, Roku) so higher-level code can enumerate Synology devices uniformly.

### Description
- Added `src/mk_lib_hardware/src/mk_lib_hardware_synology.rs` with an async `mk_lib_hardware_synology_discover()` function that returns `Vec<Url>`.
- The function sends an SSDP `M-SEARCH` using target `ssdp:all`, filters responses for entries containing the string `synology` in `SERVER`, `USN`, or `Location`, and returns parsed `Location` URLs.
- The implementation safely handles SSDP setup/send failures by returning an empty vector and skips malformed or unparsable Location headers.

### Testing
- Ran `cargo fmt` in `src/mk_lib_hardware` and it completed successfully.
- Ran `cargo check` in `src/mk_lib_hardware`, which failed due to the environment's configured registry returning HTTP 403 and blocking dependency resolution.
- Ran `cargo clippy -- -D warnings` in `src/mk_lib_hardware`, which also failed for the same registry access limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b7079e3c8321bdd5a8bb04c96d0f)