### PR TITLE
Add TiVo SSDP discovery helper (mk_lib_hardware_tivo_discover)

### DIFF
--- a/src/mk_lib_hardware/src/mk_lib_hardware_tivo.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_tivo.rs
@@ -1,0 +1,29 @@
+use ssdp::header::{HeaderMut, MX, Man, ST};
+use ssdp::message::SearchRequest;
+use url::Url;
+
+const TIVO_SSDP_SEARCH_TARGET: &str = "TiVoMediaServer:1";
+
+pub async fn mk_lib_hardware_tivo_discover() -> Vec<Url> {
+    let mut request = SearchRequest::new();
+    request.set(Man);
+    request.set(MX(5));
+
+    let Ok(st_field) = ssdp::FieldMap::new(TIVO_SSDP_SEARCH_TARGET) else {
+        return Vec::new();
+    };
+    request.set(ST::Target(st_field));
+
+    let Ok(responses) = request.multicast() else {
+        return Vec::new();
+    };
+
+    responses
+        .into_iter()
+        .filter_map(|(res, _)| {
+            let location_header = res.get_raw("Location")?;
+            let first_value = location_header.first()?;
+            Url::parse(&String::from_utf8_lossy(first_value)).ok()
+        })
+        .collect()
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal helper to discover TiVo devices on the local network via SSDP so other hardware modules can locate TiVo device URLs programmatically.

### Description
- Add `src/mk_lib_hardware/src/mk_lib_hardware_tivo.rs` with `mk_lib_hardware_tivo_discover` that issues an SSDP `M-SEARCH` using the search target `TiVoMediaServer:1`.
- Parse the SSDP `Location` header into `url::Url` values and return a `Vec<Url>`, ignoring malformed or missing `Location` entries instead of panicking.
- Fail gracefully by returning an empty vector if building the `ST` field or performing the multicast search fails.

### Testing
- Ran `rustfmt --edition 2024 src/mk_lib_hardware/src/mk_lib_hardware_tivo.rs`, which succeeded.
- Attempted `cargo check --manifest-path src/mk_lib_hardware/Cargo.toml`, which failed in this environment due to a missing private registry configuration (`kellnr`).
- Attempted `cargo clippy --manifest-path src/mk_lib_hardware/Cargo.toml -- -D warnings`, which also failed for the same private registry reason.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ba1b60ec8321a77ea39888270be0)