### PR TITLE
Add HDHomeRun channel discovery helper

### DIFF
--- a/src/mk_lib_hardware/src/mk_lib_hardware_hdhomerun.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_hdhomerun.rs
@@ -1,8 +1,20 @@
+use mk_lib_network;
+use serde::Deserialize;
 use ssdp::header::{HeaderMut, HeaderRef, MX, Man, ST};
 use ssdp::message::{Multicast, SearchRequest};
 use url::Url;
 
 const HDHOMERUN_DISCOVERY_TARGET: &str = "upnp:rootdevice";
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HDHomeRunChannel {
+    #[serde(rename = "GuideNumber")]
+    pub guide_number: String,
+    #[serde(rename = "GuideName")]
+    pub guide_name: String,
+    #[serde(rename = "URL")]
+    pub stream_url: String,
+}
 
 pub async fn mk_lib_hardware_hdhomerun_discover() -> Vec<Url> {
     let mut request = SearchRequest::new();
@@ -42,4 +54,30 @@ pub async fn mk_lib_hardware_hdhomerun_discover() -> Vec<Url> {
             Url::parse(&String::from_utf8_lossy(location)).ok()
         })
         .collect()
+}
+
+pub async fn mk_lib_hardware_hdhomerun_channel_discover() -> Vec<HDHomeRunChannel> {
+    let mut channels = Vec::new();
+
+    for device_location in mk_lib_hardware_hdhomerun_discover().await {
+        let mut lineup_url = device_location;
+        lineup_url.set_path("/lineup.json");
+        lineup_url.set_query(None);
+        lineup_url.set_fragment(None);
+
+        let Ok(lineup_json) =
+            mk_lib_network::mk_lib_network::mk_data_from_url_to_json(lineup_url.to_string()).await
+        else {
+            continue;
+        };
+
+        let Ok(mut device_channels) = serde_json::from_value::<Vec<HDHomeRunChannel>>(lineup_json)
+        else {
+            continue;
+        };
+
+        channels.append(&mut device_channels);
+    }
+
+    channels
 }


### PR DESCRIPTION
### Motivation
- Provide channel discovery for HDHomeRun tuners by fetching the device `lineup.json` and exposing a typed model to consume channel entries.
- Implement the feature as a small, non-breaking helper that is resilient to individual device failures and does not alter existing public interfaces.

### Description
- Add `HDHomeRunChannel` (`GuideNumber`, `GuideName`, `URL`) and derive `Deserialize` to model `lineup.json` entries.
- Add `mk_lib_hardware_hdhomerun_channel_discover()` which reuses `mk_lib_hardware_hdhomerun_discover()`, normalizes each device URL to `/lineup.json`, fetches JSON via `mk_lib_network::mk_data_from_url_to_json`, deserializes into `Vec<HDHomeRunChannel>`, and aggregates results across devices.
- Add imports for `mk_lib_network` and `serde::Deserialize` and keep behavior tolerant by skipping devices that fail HTTP fetch or JSON parsing.
- No changes to existing APIs beyond adding the helper function and the new typed struct.

### Testing
- Ran `cargo fmt` in `src/mk_lib_hardware` and it completed successfully.
- Ran `cargo check` in `src/mk_lib_hardware`, which failed to complete in this environment due to the private Kellnr registry returning HTTP 403 when resolving dependencies.
- Ran `cargo clippy -- -D warnings` in `src/mk_lib_hardware`, which also failed for the same private-registry access issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5bc3580088321a185ee76f4a023df)