### PR TITLE
Render user profile inside shared user layout (beside side navbar)

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_user/bss_user_profile.html
+++ b/docker/core/mkwebaxum/templates/bss_user/bss_user_profile.html
@@ -1,92 +1,81 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body id="page-top">
-            {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "bss_user/bss_user_include_side_menu.html" %}
-    <div id="wrapper">
-        <div class="d-flex flex-column" id="content-wrapper">
-            <div id="content">
-                <div class="container-fluid">
-                    {% include "bss_user/bss_user_include_menu.html" %}
-                    <h3 class="text-dark mb-4">Profile</h3>
-                    <div class="row mb-3">
-                        <div class="col-lg-4">
-                            <div class="card mb-3">
-                                <div class="card-body text-center shadow"><img class="rounded-circle mb-3 mt-4"
-                                        src="/static/image/K3.png" width="160" height="160">
-                                    <div class="mb-3"><button class="btn btn-primary btn-sm" type="button">Change
-                                            Photo</button></div>
+{% block content %}
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <h3 class="text-dark mb-4">Profile</h3>
+    <div class="row mb-3">
+        <div class="col-lg-4">
+            <div class="card mb-3">
+                <div class="card-body text-center shadow"><img class="rounded-circle mb-3 mt-4"
+                        src="/static/image/K3.png" width="160" height="160">
+                    <div class="mb-3"><button class="btn btn-primary btn-sm" type="button">Change
+                            Photo</button></div>
+                </div>
+            </div>
+            <div class="card shadow mb-4"></div>
+        </div>
+        <div class="col-lg-8">
+            <div class="row mb-3 d-none">
+                <div class="col">
+                    <div class="card text-white bg-primary shadow">
+                        <div class="card-body">
+                            <div class="row mb-2">
+                                <div class="col">
+                                    <p class="m-0">Peformance</p>
+                                    <p class="m-0"><strong>65.2%</strong></p>
                                 </div>
+                                <div class="col-auto"><i class="fas fa-rocket fa-2x"></i></div>
                             </div>
-                            <div class="card shadow mb-4"></div>
+                            <p class="text-white-50 small m-0"><i class="fas fa-arrow-up"></i>&nbsp;5%
+                                since last month</p>
                         </div>
-                        <div class="col-lg-8">
-                            <div class="row mb-3 d-none">
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="card text-white bg-success shadow">
+                        <div class="card-body">
+                            <div class="row mb-2">
                                 <div class="col">
-                                    <div class="card text-white bg-primary shadow">
-                                        <div class="card-body">
-                                            <div class="row mb-2">
-                                                <div class="col">
-                                                    <p class="m-0">Peformance</p>
-                                                    <p class="m-0"><strong>65.2%</strong></p>
-                                                </div>
-                                                <div class="col-auto"><i class="fas fa-rocket fa-2x"></i></div>
-                                            </div>
-                                            <p class="text-white-50 small m-0"><i class="fas fa-arrow-up"></i>&nbsp;5%
-                                                since last month</p>
-                                        </div>
-                                    </div>
+                                    <p class="m-0">Peformance</p>
+                                    <p class="m-0"><strong>65.2%</strong></p>
                                 </div>
-                                <div class="col">
-                                    <div class="card text-white bg-success shadow">
-                                        <div class="card-body">
-                                            <div class="row mb-2">
-                                                <div class="col">
-                                                    <p class="m-0">Peformance</p>
-                                                    <p class="m-0"><strong>65.2%</strong></p>
-                                                </div>
-                                                <div class="col-auto"><i class="fas fa-rocket fa-2x"></i></div>
-                                            </div>
-                                            <p class="text-white-50 small m-0"><i class="fas fa-arrow-up"></i>&nbsp;5%
-                                                since last month</p>
-                                        </div>
-                                    </div>
-                                </div>
+                                <div class="col-auto"><i class="fas fa-rocket fa-2x"></i></div>
                             </div>
-                            <div class="row">
-                                <div class="col">
-                                    <div class="card shadow mb-3">
-                                        <div class="card-header py-3">
-                                            <p class="text-primary m-0 font-weight-bold">User Settings</p>
-                                        </div>
-                                        <div class="card-body">
-                                            <form>
-                                                <div class="form-row">
-                                                    <div class="col">
-                                                        <div class="form-group"><label
-                                                                for="username"><strong>Username</strong></label><input
-                                                                class="form-control" type="text" placeholder="Username"
-                                                                name="username"></div>
-                                                        <div class="form-group"><label for="email"><strong>Email
-                                                                    Address</strong></label><input class="form-control"
-                                                                type="email" placeholder="user@example.com"
-                                                                name="email"></div>
-                                                    </div>
-                                                </div>
-                                                <div class="form-group"><button class="btn btn-primary btn-sm"
-                                                        type="submit">Save Settings</button></div>
-                                            </form>
-                                        </div>
-                                    </div>
-                                    <div class="card shadow"></div>
-                                </div>
-                            </div>
+                            <p class="text-white-50 small m-0"><i class="fas fa-arrow-up"></i>&nbsp;5%
+                                since last month</p>
                         </div>
                     </div>
                 </div>
             </div>
-            {% include "bss_public/bss_public_footer.html" %}
-               </body>
-</html>
+            <div class="row">
+                <div class="col">
+                    <div class="card shadow mb-3">
+                        <div class="card-header py-3">
+                            <p class="text-primary m-0 font-weight-bold">User Settings</p>
+                        </div>
+                        <div class="card-body">
+                            <form>
+                                <div class="form-row">
+                                    <div class="col">
+                                        <div class="form-group"><label
+                                                for="username"><strong>Username</strong></label><input
+                                                class="form-control" type="text" placeholder="Username"
+                                                name="username"></div>
+                                        <div class="form-group"><label for="email"><strong>Email
+                                                    Address</strong></label><input class="form-control"
+                                                type="email" placeholder="user@example.com"
+                                                name="email"></div>
+                                    </div>
+                                </div>
+                                <div class="form-group"><button class="btn btn-primary btn-sm"
+                                        type="submit">Save Settings</button></div>
+                            </form>
+                        </div>
+                    </div>
+                    <div class="card shadow"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
### Motivation
- Ensure the user profile page is displayed inside the shared user shell so the profile content appears in the main content area beside the side navbar instead of as a standalone page.

### Description
- Replace the standalone HTML shell in `docker/core/mkwebaxum/templates/bss_user/bss_user_profile.html` with `extends "layouts/base_user.html"` and wrap the profile markup in `{% block content %}` so it uses the shared layout.
- Remove duplicated top menu / side menu includes and page wrapper markup while preserving the existing profile form and avatar UI so layout responsibilities stay centralized in `layouts/base_user.html`.

### Testing
- Ran `cargo check` in `docker/core/mkwebaxum`, which failed due to a private registry endpoint returning HTTP 403 and not due to template syntax issues. 
- Ran `cargo fmt --all -- --check` in `docker/core/mkwebaxum`, which reported unrelated formatting diffs across workspace crates and did not indicate a template-specific error. 
- Attempted an automated Playwright page load of `http://127.0.0.1:3000/user/profile`, which failed because no local web server was reachable (network error `ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d861596483219b092e89a616e77b)