### PR TITLE
Convert iRadio DB helper module from Python stubs to Rust

### DIFF
--- a/src/mk_lib_database/src/media/mk_lib_database_media_iradio.rs
+++ b/src/mk_lib_database/src/media/mk_lib_database_media_iradio.rs
@@ -1,82 +1,142 @@
-/*
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
 
-// TODO port query
-pub async fn db_iradio_insert(self, radio_channel):
-    """
-    Insert iradio channel
-    """
-    // TODO exists upsert!
-    if await db_conn.fetchval('select count(*) from mm_radio'
-                              ' where mm_radio_address = $1',
-                              radio_channel) == 0:
-        new_guid = uuid.uuid4()
-        self.db_cursor.execute('insert into mm_radio (mm_radio_guid,'
-                               ' mm_radio_address,'
-                               ' mm_radio_active)'
-                               ' values ($1, $2, true)',
-                               new_guid, radio_channel)
-        return new_guid
+#[derive(Debug, FromRow, Deserialize, Serialize)]
+pub struct DBMediaIradioList {
+    pub mm_radio_guid: uuid::Uuid,
+    pub mm_radio_name: Option<String>,
+    pub mm_radio_address: String,
+}
 
-// TODO port query
-pub async fn db_iradio_list(self, offset=0, records=None, active_station=True,
-                         search_value=None):
-    """
-    Iradio list
-    """
-    if search_value != None:
-        return await db_conn.fetch('select mm_radio_guid,'
-                                   ' mm_radio_name,'
-                                   ' mm_radio_address'
-                                   ' from mm_radio where mm_radio_guid'
-                                   ' in (select mm_radio_guid from mm_radio'
-                                   ' where mm_radio_active = $1 and mm_radio_name % $2'
-                                   ' order by LOWER(mm_radio_name) offset $3 limit $4)'
-                                   ' order by LOWER(mm_radio_name)',
-                                   active_station, search_value, offset, records)
-    else:
-        return await db_conn.fetch('select mm_radio_guid,'
-                                   ' mm_radio_name,'
-                                   ' mm_radio_address'
-                                   ' from mm_radio where mm_radio_guid'
-                                   ' in (select mm_radio_guid'
-                                   ' from mm_radio'
-                                   ' where mm_radio_active = $1'
-                                   ' order by LOWER(mm_radio_name)'
-                                   ' offset $2 limit $3)'
-                                   ' order by LOWER(mm_radio_name)',
-                                   active_station, offset, records)
+pub async fn mk_lib_database_media_iradio_insert(
+    sqlx_pool: &sqlx::PgPool,
+    radio_channel: &str,
+) -> Result<Option<uuid::Uuid>, sqlx::Error> {
+    let row: (i64,) = sqlx::query_as(
+        r#"select count(*) from mm_radio
+        where mm_radio_address = $1"#,
+    )
+    .bind(radio_channel)
+    .fetch_one(sqlx_pool)
+    .await?;
 
-// TODO port query
-pub async fn mk_lib_database_media_iradio_count(sqlx_pool: &sqlx::PgPool,
-                                                  search_value: String)
-                                                  -> Result<i32, sqlx::Error> {
-    if !search_value.is_empty() {
-        let row: (i32, ) = sqlx::query(r#""#)
-            .bind(search_value)
-            .fetch_one(sqlx_pool)
-            .await?;
-        Ok(row.0)
+    if row.0 == 0 {
+        let new_guid = uuid::Uuid::new_v4();
+        sqlx::query(
+            r#"insert into mm_radio (
+                mm_radio_guid,
+                mm_radio_address,
+                mm_radio_active
+            ) values ($1, $2, true)"#,
+        )
+        .bind(new_guid)
+        .bind(radio_channel)
+        .execute(sqlx_pool)
+        .await?;
+        Ok(Some(new_guid))
     } else {
-        let row: (i32, ) = sqlx::query(r#""#)
-            .fetch_one(sqlx_pool)
-            .await?;
-        Ok(row.0)
+        Ok(None)
     }
 }
 
-// TODO port query
-pub async fn db_iradio_list_count(self, active_station=True, search_value=None):
-    """
-    Iradio count
-    """
-    if search_value != None:
-        return await db_conn.fetchval('select count(*) from mm_radio '
-                                      'where mm_radio_active = $1'
-                                      ' and mm_radio_name = $2',
-                                      active_station)
-    else:
-        return await db_conn.fetchval('select count(*) from mm_radio'
-                                      ' where mm_radio_active = $1',
-                                      active_station)
+pub async fn mk_lib_database_media_iradio_read(
+    sqlx_pool: &sqlx::PgPool,
+    offset: i64,
+    records: Option<i64>,
+    active_station: bool,
+    search_value: Option<String>,
+) -> Result<Vec<DBMediaIradioList>, sqlx::Error> {
+    match (search_value, records) {
+        (Some(search), Some(limit)) => {
+            sqlx::query_as(
+                r#"select mm_radio_guid, mm_radio_name, mm_radio_address
+                from mm_radio where mm_radio_guid
+                in (select mm_radio_guid from mm_radio
+                where mm_radio_active = $1 and mm_radio_name % $2
+                order by LOWER(mm_radio_name) offset $3 limit $4)
+                order by LOWER(mm_radio_name)"#,
+            )
+            .bind(active_station)
+            .bind(search)
+            .bind(offset)
+            .bind(limit)
+            .fetch_all(sqlx_pool)
+            .await
+        }
+        (Some(search), None) => {
+            sqlx::query_as(
+                r#"select mm_radio_guid, mm_radio_name, mm_radio_address
+                from mm_radio where mm_radio_guid
+                in (select mm_radio_guid from mm_radio
+                where mm_radio_active = $1 and mm_radio_name % $2
+                order by LOWER(mm_radio_name) offset $3)
+                order by LOWER(mm_radio_name)"#,
+            )
+            .bind(active_station)
+            .bind(search)
+            .bind(offset)
+            .fetch_all(sqlx_pool)
+            .await
+        }
+        (None, Some(limit)) => {
+            sqlx::query_as(
+                r#"select mm_radio_guid, mm_radio_name, mm_radio_address
+                from mm_radio where mm_radio_guid
+                in (select mm_radio_guid
+                from mm_radio
+                where mm_radio_active = $1
+                order by LOWER(mm_radio_name)
+                offset $2 limit $3)
+                order by LOWER(mm_radio_name)"#,
+            )
+            .bind(active_station)
+            .bind(offset)
+            .bind(limit)
+            .fetch_all(sqlx_pool)
+            .await
+        }
+        (None, None) => {
+            sqlx::query_as(
+                r#"select mm_radio_guid, mm_radio_name, mm_radio_address
+                from mm_radio where mm_radio_guid
+                in (select mm_radio_guid
+                from mm_radio
+                where mm_radio_active = $1
+                order by LOWER(mm_radio_name)
+                offset $2)
+                order by LOWER(mm_radio_name)"#,
+            )
+            .bind(active_station)
+            .bind(offset)
+            .fetch_all(sqlx_pool)
+            .await
+        }
+    }
+}
 
- */
+pub async fn mk_lib_database_media_iradio_count(
+    sqlx_pool: &sqlx::PgPool,
+    active_station: bool,
+    search_value: Option<String>,
+) -> Result<i64, sqlx::Error> {
+    if let Some(search) = search_value {
+        let row: (i64,) = sqlx::query_as(
+            r#"select count(*) from mm_radio
+            where mm_radio_active = $1 and mm_radio_name = $2"#,
+        )
+        .bind(active_station)
+        .bind(search)
+        .fetch_one(sqlx_pool)
+        .await?;
+        Ok(row.0)
+    } else {
+        let row: (i64,) = sqlx::query_as(
+            r#"select count(*) from mm_radio
+            where mm_radio_active = $1"#,
+        )
+        .bind(active_station)
+        .fetch_one(sqlx_pool)
+        .await?;
+        Ok(row.0)
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace the commented Python placeholder implementations in the iRadio DB helper with concrete, typed Rust functions so the database helpers are implemented and usable from Rust code. 
- Preserve the original SQL semantics (deduplicated insert by address, list with optional search/limit/offset, and count with optional search/active filter) while moving to `sqlx`-style parameterized queries.

### Description
- Replaced the Python-stub block in `src/mk_lib_database/src/media/mk_lib_database_media_iradio.rs` with a `DBMediaIradioList` row struct and three `sqlx` functions: `mk_lib_database_media_iradio_insert`, `mk_lib_database_media_iradio_read`, and `mk_lib_database_media_iradio_count`.
- `mk_lib_database_media_iradio_insert` checks if `mm_radio_address` exists and inserts a new GUIDed row when absent, returning `Some(guid)` or `None` if already present.
- `mk_lib_database_media_iradio_read` implements the list query with support for `offset`, optional `records` (limit), `active_station` filtering, and optional `search_value` behavior mapped to the original SQL structure.
- `mk_lib_database_media_iradio_count` returns the active-station filtered count and optionally filters by `mm_radio_name` when `search_value` is provided, using parameterized queries and typed result tuples.

### Testing
- Ran `cargo fmt` (in `src/mk_lib_database`) and it completed successfully.
- Ran `cargo check` (in `src/mk_lib_database`) and it failed due to inability to fetch dependencies from the private registry (HTTP 403), so compilation could not be fully validated.
- Ran `cargo clippy -- -D warnings` (in `src/mk_lib_database`) and it also failed for the same private registry access error, so linting was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5f16096d08321a88a20d9efdd5879)