### PR TITLE
mkiradio: fetch all radio stations (remove name filter and limit)

### DIFF
--- a/docker/core/mkiradio/src/main.rs
+++ b/docker/core/mkiradio/src/main.rs
@@ -6,13 +6,13 @@ use mk_lib_database;
 use mk_lib_file;
 use mk_lib_rabbitmq;
 use num_format::{Locale, ToFormattedString};
-use serde_json::{json, Value};
+use radiobrowser::{RadioBrowserAPI, StationOrder};
+use serde_json::{Value, json};
 use std::error::Error;
-use std::ffi::OsStr;g
+use std::ffi::OsStr;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
-use radiobrowser::{RadioBrowserAPI, StationOrder};
 
 lazy_static! {
     static ref epoch: DateTime<Utc> = DateTime::<Utc>::from(UNIX_EPOCH);
@@ -21,12 +21,15 @@ lazy_static! {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // connect to db and do a version check
-    let (sqlx_pool_rw, sqlx_pool_ro) = mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120)
-        .await
-        .unwrap();
-    let _result =
-        mk_lib_database::mk_lib_database_version::mk_lib_database_version_check(&sqlx_pool_ro, false)
-            .await;
+    let (sqlx_pool_rw, sqlx_pool_ro) =
+        mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120)
+            .await
+            .unwrap();
+    let _result = mk_lib_database::mk_lib_database_version::mk_lib_database_version_check(
+        &sqlx_pool_ro,
+        false,
+    )
+    .await;
 
     let (_rabbit_connection, rabbit_channel) =
         mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_connect("mkiradio")
@@ -40,49 +43,46 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     while let Some(msg) = rabbit_consumer.recv().await {
         if let Some(payload) = msg.content {
-                let json_message: Value =
-                    serde_json::from_str(&String::from_utf8_lossy(&payload)).unwrap();
-                println!(" [x] Received {:?}", json_message);
-                if json_message["Type"] == "radiobrowser" {
-                   let mut api = RadioBrowserAPI::new().await?;
+            let json_message: Value =
+                serde_json::from_str(&String::from_utf8_lossy(&payload)).unwrap();
+            println!(" [x] Received {:?}", json_message);
+            if json_message["Type"] == "radiobrowser" {
+                let mut api = RadioBrowserAPI::new().await?;
 
-    // Search for stations by name.
-    // Change "jazz" to whatever you want.
-    let stations = api
-        .get_stations()
-        .name("jazz")
-        .order(StationOrder::Clickcount)
-        .reverse(true)
-        .limit(10)
-        .send()
-        .await?;
+                // Fetch all stations instead of filtering by a specific genre/name.
+                let stations = api
+                    .get_stations()
+                    .order(StationOrder::Clickcount)
+                    .reverse(true)
+                    .send()
+                    .await?;
 
-    if stations.is_empty() {
-        println!("No stations found.");
-        return Ok(());
-    }
+                if stations.is_empty() {
+                    println!("No stations found.");
+                    return Ok(());
+                }
 
-    for (idx, station) in stations.iter().enumerate() {
-        println!("{}. {}", idx + 1, station.name);
-        println!("   Station UUID: {}", station.stationuuid);
+                for (idx, station) in stations.iter().enumerate() {
+                    println!("{}. {}", idx + 1, station.name);
+                    println!("   Station UUID: {}", station.stationuuid);
 
-        if let Some(country) = &station.country {
-            println!("   Country: {}", country);
-        }
+                    if let Some(country) = &station.country {
+                        println!("   Country: {}", country);
+                    }
 
-        if let Some(language) = &station.language {
-            println!("   Language: {}", language);
-        }
+                    if let Some(language) = &station.language {
+                        println!("   Language: {}", language);
+                    }
 
-        if let Some(tags) = &station.tags {
-            println!("   Tags: {}", tags);
-        }
+                    if let Some(tags) = &station.tags {
+                        println!("   Tags: {}", tags);
+                    }
 
-        println!("   Stream URL: {}", station.url_resolved);
-        println!();
-    }
-}
-                 let _result = mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_ack(
+                    println!("   Stream URL: {}", station.url_resolved);
+                    println!();
+                }
+            }
+            let _result = mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_ack(
                 &rabbit_channel,
                 msg.deliver.unwrap().delivery_tag(),
             )


### PR DESCRIPTION
### Motivation
- The radio worker should discover all stations from Radio Browser rather than only those matching a hard-coded genre/name and a small fixed result set.

### Description
- Removed the hard-coded `.name("jazz")` filter from the `get_stations()` call so queries are not restricted to a single genre/name.
- Removed the hard-coded `.limit(10)` so results are no longer artificially capped by the worker.
- Kept ordering by `StationOrder::Clickcount` (descending) unchanged to preserve sort behavior.
- Fixed a stray character typo in the `OsStr` import (`;g` → `;`) and ran formatting for the changed file (`docker/core/mkiradio/src/main.rs`).

### Testing
- Ran `cargo fmt` in `docker/core/mkiradio` and it completed successfully.
- Attempted `cargo check` in `docker/core/mkiradio`, but it failed due to the project's private crate registry returning HTTP 403; this prevented a full compile validation.
- Attempted `cargo clippy -- -D warnings` in `docker/core/mkiradio`, but it also failed for the same private registry HTTP 403 reason.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b621bd0b888321b585b84859d46a56)