### PR TITLE
Fix movie metadata pages offset beside sidenav

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-<section class="max-w-7xl mx-auto p-4
+<section class="max-w-7xl mx-auto p-4 md:ml-64
                 text-zinc-900
                 dark:text-zinc-100">  <h1 id="movie-grid-heading" class="sr-only">Movie list</h1>
   {% include "filters/pagination_letters.html" %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail.html
@@ -1,7 +1,7 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<section class="max-w-6xl mx-auto px-4 py-6 sm:px-6" x-data="moviePage()">
+<section class="max-w-6xl mx-auto px-4 py-6 sm:px-6 md:ml-64" x-data="moviePage()">
 
     <!-- HEADER -->
     <div class="grid gap-6 lg:grid-cols-[260px_1fr]">


### PR DESCRIPTION
### Motivation
- On medium+ layouts the fixed/translated sidenav was overlapping the movie metadata list and detail pages, causing content to render beneath the sidebar instead of to its right.

### Description
- Add `md:ml-64` to the main section containers of the movie metadata list and movie metadata detail templates to apply a desktop left offset so content is positioned beside the sidenav (`docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html` and `docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail.html`).

### Testing
- Ran `cargo fmt --all -- --check` in `docker/core/mkwebaxum` which failed due to existing workspace-wide formatting drift unrelated to this change. 
- Ran `cargo check` in `docker/core/mkwebaxum` which failed because the private registry returned HTTP 403 while fetching dependencies. 
- Attempted a Playwright screenshot of the movie list page but the local app was not serving (navigation failed with `ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b72170bc188321b0e3f2746b73a236)