### PR TITLE
Implement Barcodespider UPC API response handling

### DIFF
--- a/src/mk_lib_metadata/src/provider/barcodespider.rs
+++ b/src/mk_lib_metadata/src/provider/barcodespider.rs
@@ -1,21 +1,31 @@
 // https://devapi.barcodespider.com/
 
-use mk_lib_database;
 use mk_lib_network::mk_lib_network;
-use serde_json::json;
-use sqlx::types::Uuid;
+
+const BASE_API_URL: &str = "https://api.barcodespider.com/v1/lookup";
 
 pub async fn provider_barcodespider_fetch_by_upc(
-    sqlx_pool: &sqlx::PgPool,
+    _sqlx_pool: &sqlx::PgPool,
     upc_code: &i32,
     api_token: &str,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let url_result = mk_lib_network::mk_data_from_url_to_json(format!(
-        "https://api.barcodespider.com/v1/lookup?token={}&upc={}",
-        api_token,
-        upc_code
+    let api_response = mk_lib_network::mk_data_from_url_to_json(format!(
+        "{}?token={}&upc={}",
+        BASE_API_URL, api_token, upc_code
     ))
-    .await
-    .unwrap();
-    Ok(url_result)
+    .await?;
+
+    // Keep API semantics explicit for callers: Barcodespider returns
+    // `item_response.code` + `status` in JSON even for non-success cases.
+    if api_response["item_response"]["code"] != 200 {
+        return Err(format!(
+            "barcodespider lookup failed: {}",
+            api_response["item_response"]["message"]
+                .as_str()
+                .unwrap_or("unknown error")
+        )
+        .into());
+    }
+
+    Ok(api_response)
 }


### PR DESCRIPTION
### Motivation

- Implement the Barcodespider UPC lookup API in `src/mk_lib_metadata/src/provider/barcodespider.rs` to provide a proper provider integration and avoid panics on network or API errors.
- Centralize the request endpoint so callers and future edits use a single source for the API URL.
- Surface provider-level errors to callers instead of allowing an internal `.unwrap()` to abort the process.

### Description

- Add a `BASE_API_URL` constant and construct the request URL with `format!` so the endpoint is defined in one place.
- Replace the previous `.unwrap()` call on `mk_lib_network::mk_data_from_url_to_json` with `?` to propagate network/JSON errors to callers.
- Validate the Barcodespider response by checking `item_response.code` and return a descriptive `Err(...)` when it is not `200` using the provider `message` field.
- Keep the original function signature but rename the unused SQL pool argument to `_sqlx_pool` to avoid unused-variable warnings without changing the public API.

### Testing

- Ran `cargo fmt` for the `src/mk_lib_metadata` crate and it completed successfully.
- Ran `cargo check` for the `src/mk_lib_metadata` crate but it failed due to a private registry returning `403 Forbidden` while resolving dependencies, blocking full compilation verification.
- Ran `cargo clippy -- -D warnings` for the `src/mk_lib_metadata` crate but it was also blocked by the same private registry `403 Forbidden` issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b767e774c88321b9b2dc0ea5fce74b)