### PR TITLE
Implement BarcodeLookup UPC API request

### DIFF
--- a/src/mk_lib_metadata/src/provider/barcodelookup.rs
+++ b/src/mk_lib_metadata/src/provider/barcodelookup.rs
@@ -1,21 +1,17 @@
 // https://www.barcodelookup.com/api
 
-use mk_lib_database;
 use mk_lib_network::mk_lib_network;
-use serde_json::json;
-use sqlx::types::Uuid;
 
 pub async fn provider_barcodelookup_fetch(
-    sqlx_pool: &sqlx::PgPool,
+    _sqlx_pool: &sqlx::PgPool,
     upc_code: &i32,
     api_token: &str,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
     let url_result = mk_lib_network::mk_data_from_url_to_json(format!(
-        "TODO fake {} {}",
-        api_token,
-        upc_code
+        "https://api.barcodelookup.com/v3/products?barcode={}&formatted=y&key={}",
+        upc_code, api_token
     ))
-    .await
-    .unwrap();
+    .await?;
+
     Ok(url_result)
 }


### PR DESCRIPTION
### Motivation
- Enable the BarcodeLookup provider to perform real UPC lookups by replacing the placeholder URL and improving error handling.

### Description
- Replace the `TODO` placeholder with the BarcodeLookup v3 products endpoint using `barcode`, `formatted`, and `key` query parameters in `provider_barcodelookup_fetch`.
- Propagate network/parsing errors by replacing `.unwrap()` with `?` and mark the unused DB pool parameter as `_sqlx_pool` to avoid warnings while preserving the function signature.
- Remove unused imports from `barcodelookup.rs`.

### Testing
- Ran `rustfmt --edition 2024 src/mk_lib_metadata/src/provider/barcodelookup.rs`, which succeeded.
- Attempted `cargo fmt --manifest-path src/mk_lib_metadata/Cargo.toml`, which failed in this environment because the custom `kellnr` Cargo registry is not configured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b767cda5d88321b6719d9325f7d631)