### PR TITLE
Add Amazon UPC lookup parsing helpers in mk_lib_metadata

### DIFF
--- a/src/mk_lib_metadata/src/provider/amazon.rs
+++ b/src/mk_lib_metadata/src/provider/amazon.rs
@@ -1,0 +1,142 @@
+use reqwest::Url;
+use select::document::Document;
+use select::predicate::{Attr, Name};
+
+const AMAZON_SEARCH_URL: &str = "https://www.amazon.com/s";
+const MEDIA_FORMAT_KEYWORDS: [&str; 12] = [
+    "4k",
+    "blu-ray",
+    "dvd",
+    "vhs",
+    "prime video",
+    "audio cd",
+    "mp3 cd",
+    "vinyl",
+    "kindle",
+    "hardcover",
+    "paperback",
+    "digital",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AmazonUpcResult {
+    pub title: String,
+    pub year: Option<u16>,
+    pub media_format: Option<String>,
+}
+
+pub async fn provider_amazon_search_by_upc(
+    upc_code: &str,
+) -> Result<Option<AmazonUpcResult>, Box<dyn std::error::Error>> {
+    let results = provider_amazon_search_results_by_upc(upc_code).await?;
+    Ok(results.into_iter().next())
+}
+
+pub async fn provider_amazon_search_results_by_upc(
+    upc_code: &str,
+) -> Result<Vec<AmazonUpcResult>, Box<dyn std::error::Error>> {
+    let trimmed_upc = upc_code.trim();
+    if trimmed_upc.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut url = Url::parse(AMAZON_SEARCH_URL)?;
+    url.query_pairs_mut().append_pair("k", trimmed_upc);
+
+    let html = reqwest::Client::new()
+        .get(url)
+        .header(
+            reqwest::header::USER_AGENT,
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+        )
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+
+    Ok(parse_amazon_search_results(&html))
+}
+
+fn parse_amazon_search_results(html: &str) -> Vec<AmazonUpcResult> {
+    let document = Document::from(html);
+
+    document
+        .find(Name("div").and(Attr("data-component-type", "s-search-result")))
+        .filter_map(|search_result_node| {
+            let title = search_result_node
+                .find(Name("h2"))
+                .next()
+                .map(|title_node| title_node.text().trim().to_string())
+                .filter(|value| !value.is_empty())?;
+
+            let result_text = search_result_node.text();
+            let year = extract_year(&result_text);
+            let media_format = extract_media_format(&result_text);
+
+            Some(AmazonUpcResult {
+                title,
+                year,
+                media_format,
+            })
+        })
+        .collect()
+}
+
+fn extract_year(input: &str) -> Option<u16> {
+    input
+        .split(|c: char| !c.is_ascii_digit())
+        .filter(|part| part.len() == 4)
+        .filter_map(|part| part.parse::<u16>().ok())
+        .find(|value| (1900..=2100).contains(value))
+}
+
+fn extract_media_format(input: &str) -> Option<String> {
+    let lowercase = input.to_ascii_lowercase();
+
+    MEDIA_FORMAT_KEYWORDS.iter().find_map(|keyword| {
+        if lowercase.contains(keyword) {
+            Some(format_keyword(keyword))
+        } else {
+            None
+        }
+    })
+}
+
+fn format_keyword(keyword: &str) -> String {
+    keyword
+        .split(' ')
+        .map(|word| {
+            if word.eq_ignore_ascii_case("mp3") || word.eq_ignore_ascii_case("4k") {
+                word.to_ascii_uppercase()
+            } else {
+                let mut chars = word.chars();
+                match chars.next() {
+                    Some(first) => format!("{}{}", first.to_ascii_uppercase(), chars.as_str()),
+                    None => String::new(),
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_amazon_result_text() {
+        let html = r#"
+        <div data-component-type="s-search-result">
+            <h2>The Matrix [Blu-ray] (1999)</h2>
+        </div>
+        "#;
+
+        let parsed = parse_amazon_search_results(html);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].title, "The Matrix [Blu-ray] (1999)");
+        assert_eq!(parsed[0].year, Some(1999));
+        assert_eq!(parsed[0].media_format.as_deref(), Some("Blu-ray"));
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight Amazon UPC lookup to extract title, year and media format from Amazon search results for metadata resolution.
- Add a focused, non-invasive provider helper in `mk_lib_metadata` to be used by other metadata lookup flows without touching existing public interfaces.
- Keep the change minimal and localized to a new `provider/amazon.rs` module implementing UPC-based parsing only.

### Description
- Added `src/mk_lib_metadata/src/provider/amazon.rs` with `AmazonUpcResult` and the helper functions `provider_amazon_search_results_by_upc` and `provider_amazon_search_by_upc` to query Amazon search and return parsed results.
- Implemented HTML fetching with `reqwest` and parsing with `select` and a search query to `https://www.amazon.com/s` using the UPC as the `k` parameter.
- Implemented parsing helpers `parse_amazon_search_results`, `extract_year`, `extract_media_format`, and `format_keyword` to extract a cleaned `title`, approximate `year`, and a normalized `media_format` from `data-component-type="s-search-result"` result cards.
- Added a unit test that exercises parsing of a representative Amazon-like snippet to validate title/year/format extraction.

### Testing
- Ran `rustfmt --edition 2024 src/mk_lib_metadata/src/provider/amazon.rs`, which completed successfully.
- Attempted `cargo check --manifest-path src/mk_lib_metadata/Cargo.toml`, which failed in this environment due to a missing `kellnr` registry configuration.
- Attempted `cargo clippy --manifest-path src/mk_lib_metadata/Cargo.toml -- -D warnings`, which likewise failed due to the same registry configuration issue; the new unit test was added but not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b88eec813483218fe7ad856c8c64e0)