### PR TITLE
Add eBay UPC search provider to mk_lib_metadata

### DIFF
--- a/src/mk_lib_metadata/src/lib.rs
+++ b/src/mk_lib_metadata/src/lib.rs
@@ -25,6 +25,7 @@ pub mod metadata_provider {
     pub mod coverartarchive;
     #[cfg(feature = "discid")]
     pub mod discid;
+    pub mod ebay;
     pub mod flickr;
     pub mod giant_bomb;
     pub mod goupc;

--- a/src/mk_lib_metadata/src/provider/ebay.rs
+++ b/src/mk_lib_metadata/src/provider/ebay.rs
@@ -1,0 +1,115 @@
+use reqwest::Url;
+use select::document::Document;
+use select::predicate::Class;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EbayMediaResult {
+    pub title: String,
+    pub year: Option<i32>,
+    pub media_format: Option<String>,
+}
+
+/// Search eBay listings by UPC and return parsed title/year/media-format details.
+pub async fn provider_ebay_fetch_by_upc(
+    upc_code: &str,
+) -> Result<Vec<EbayMediaResult>, Box<dyn std::error::Error>> {
+    let mut search_url = Url::parse("https://www.ebay.com/sch/i.html")?;
+    search_url
+        .query_pairs_mut()
+        .append_pair("_nkw", upc_code.trim())
+        .append_pair("_sop", "12");
+
+    let html = reqwest::Client::new()
+        .get(search_url)
+        .header(reqwest::header::USER_AGENT, "MediaKraken/1.0")
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+
+    let mut results = Vec::new();
+    let document = Document::from(html.as_str());
+
+    for node in document.find(Class("s-item__title")) {
+        let title = node.text().trim().to_string();
+        if title.is_empty() || title == "Shop on eBay" {
+            continue;
+        }
+
+        let (year, media_format) = extract_year_and_media_format(&title);
+        results.push(EbayMediaResult {
+            title,
+            year,
+            media_format,
+        });
+    }
+
+    Ok(results)
+}
+
+fn extract_year_and_media_format(title: &str) -> (Option<i32>, Option<String>) {
+    let year = extract_year(title);
+    let media_format = detect_media_format(title);
+    (year, media_format)
+}
+
+fn extract_year(title: &str) -> Option<i32> {
+    title
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter_map(|token| token.parse::<i32>().ok())
+        .find(|value| (1900..=2100).contains(value))
+}
+
+fn detect_media_format(title: &str) -> Option<String> {
+    let lowered = title.to_ascii_lowercase();
+
+    const MEDIA_FORMAT_KEYWORDS: [(&str, &str); 10] = [
+        ("4k ultra hd", "4K Ultra HD"),
+        ("blu-ray", "Blu-ray"),
+        ("bluray", "Blu-ray"),
+        ("dvd", "DVD"),
+        ("vhs", "VHS"),
+        ("laserdisc", "LaserDisc"),
+        ("cd", "CD"),
+        ("cassette", "Cassette"),
+        ("vinyl", "Vinyl"),
+        ("digital", "Digital"),
+    ];
+
+    MEDIA_FORMAT_KEYWORDS
+        .iter()
+        .find_map(|(keyword, label)| lowered.contains(keyword).then(|| (*label).to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{detect_media_format, extract_year, extract_year_and_media_format};
+
+    #[test]
+    fn extracts_year_from_title() {
+        assert_eq!(extract_year("The Matrix 1999 Blu-ray"), Some(1999));
+        assert_eq!(extract_year("Classic Film DVD"), None);
+    }
+
+    #[test]
+    fn detects_media_formats() {
+        assert_eq!(
+            detect_media_format("Movie Blu-ray + DVD Combo"),
+            Some("Blu-ray".to_string())
+        );
+        assert_eq!(
+            detect_media_format("Brand New Vinyl LP"),
+            Some("Vinyl".to_string())
+        );
+        assert_eq!(detect_media_format("Book Hardcover"), None);
+    }
+
+    #[test]
+    fn extracts_both_values() {
+        assert_eq!(
+            extract_year_and_media_format("Alien 1979 4K Ultra HD"),
+            (Some(1979), Some("4K Ultra HD".to_string()))
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a metadata source that can look up a UPC on eBay and return structured listing information (title, release year, and media format). 
- Support downstream metadata enrichment flows that can fall back to marketplace listings when other UPC providers have limited coverage.

### Description
- Exported a new `metadata_provider::ebay` module in `src/mk_lib_metadata/src/lib.rs` so the provider is available from the crate surface. 
- Added `provider_ebay_fetch_by_upc(upc_code: &str)` in `src/mk_lib_metadata/src/provider/ebay.rs` that performs an eBay search request and parses listing titles into a typed `EbayMediaResult { title, year, media_format }` result vector. 
- Implemented helper parsers `extract_year`, `detect_media_format`, and `extract_year_and_media_format`, and included focused unit tests that verify parsing behavior.

### Testing
- Formatted the new files with `rustfmt --edition 2024 src/mk_lib_metadata/src/provider/ebay.rs src/mk_lib_metadata/src/lib.rs` which completed successfully. 
- Attempts to run `cargo check --manifest-path src/mk_lib_metadata/Cargo.toml`, `cargo clippy --manifest-path src/mk_lib_metadata/Cargo.toml -- -D warnings`, and `cargo fmt --manifest-path src/mk_lib_metadata/Cargo.toml` failed in this environment due to the private `kellnr` registry not being available. 
- Unit tests are included in the new provider file but were not executed in this environment due to the above `cargo` manifest/registry constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b88efd4bd48321986e6eb774122c95)