### PR TITLE
Fix UPC lookup type inference in physical media import

### DIFF
--- a/docker/core/mkwebaxum/src/user/media/bp_media_physical.rs
+++ b/docker/core/mkwebaxum/src/user/media/bp_media_physical.rs
@@ -145,7 +145,10 @@ fn optional_string(value: &str) -> Option<String> {
 }
 
 async fn lookup_media_by_upc(upc_code: &str) -> Result<Option<PhysicalMediaMatch>, String> {
-    match mk_lib_metadata::provider::ebay::provider_ebay_fetch_by_upc(upc_code).await {
+    let ebay_results: Result<Vec<mk_lib_metadata::provider::ebay::EbayMediaResult>, _> =
+        mk_lib_metadata::provider::ebay::provider_ebay_fetch_by_upc(upc_code).await;
+
+    match ebay_results {
         Ok(results) => {
             if let Some(result) = results.into_iter().next() {
                 return Ok(Some(PhysicalMediaMatch {
@@ -162,7 +165,10 @@ async fn lookup_media_by_upc(upc_code: &str) -> Result<Option<PhysicalMediaMatch
         }
     }
 
-    match mk_lib_metadata::provider::amazon::provider_amazon_search_by_upc(upc_code).await {
+    let amazon_result: Result<Option<mk_lib_metadata::provider::amazon::AmazonUpcResult>, _> =
+        mk_lib_metadata::provider::amazon::provider_amazon_search_by_upc(upc_code).await;
+
+    match amazon_result {
         Ok(Some(result)) => Ok(Some(PhysicalMediaMatch {
             upc_code: upc_code.to_string(),
             title: result.title,


### PR DESCRIPTION
### Motivation
- The UPC lookup path in `user/media/bp_media_physical.rs` produced `E0282` type-inference errors when matching provider results and mapping `year` to a `String`, so a minimal change was needed to make the provider call return types explicit while preserving existing lookup behavior.

### Description
- Add explicit result type annotations for the eBay and Amazon provider calls in `docker/core/mkwebaxum/src/user/media/bp_media_physical.rs`, keeping the eBay-first then Amazon-fallback logic unchanged and allowing `result.year.map(|year| year.to_string())` to type-check.

### Testing
- Ran `rustfmt --edition 2024` on `docker/core/mkwebaxum/src/user/media/bp_media_physical.rs`, which succeeded; automated workspace `cargo check` and `cargo clippy` were attempted for `mkwebaxum` but were blocked by the repository's custom registry configuration returning HTTP 403 for dependency/index access in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9f542a3708321867d35a9797ff5aa)