### PR TITLE
Fix UPC media lookup type inference

### DIFF
--- a/docker/core/mkwebaxum/src/user/media/bp_media_physical.rs
+++ b/docker/core/mkwebaxum/src/user/media/bp_media_physical.rs
@@ -150,12 +150,14 @@ async fn lookup_media_by_upc(upc_code: &str) -> Result<Option<PhysicalMediaMatch
 
     match ebay_results {
         Ok(results) => {
-            if let Some(result) = results.into_iter().next() {
+            let first_result: Option<mk_lib_metadata::provider::ebay::EbayMediaResult> =
+                results.into_iter().next();
+            if let Some(result) = first_result {
                 return Ok(Some(PhysicalMediaMatch {
                     upc_code: upc_code.to_string(),
                     title: result.title,
                     source: "eBay".to_string(),
-                    year: result.year.map(|year| year.to_string()),
+                    year: result.year.map(|year: i32| year.to_string()),
                     media_format: result.media_format,
                 }));
             }
@@ -173,7 +175,7 @@ async fn lookup_media_by_upc(upc_code: &str) -> Result<Option<PhysicalMediaMatch
             upc_code: upc_code.to_string(),
             title: result.title,
             source: "Amazon".to_string(),
-            year: result.year.map(|year| year.to_string()),
+            year: result.year.map(|year: u16| year.to_string()),
             media_format: result.media_format,
         })),
         Ok(None) => Ok(None),


### PR DESCRIPTION
### Motivation
- Resolve compiler error `E0282` caused by ambiguous iterator item and closure parameter types during UPC metadata lookups in `lookup_media_by_upc`.

### Description
- Add an explicit typed binding `first_result: Option<mk_lib_metadata::provider::ebay::EbayMediaResult> = results.into_iter().next();` and use `if let Some(result) = first_result` to make the iterator item type unambiguous in `lookup_media_by_upc`.
- Annotate the `year` mapping closures with concrete types (`|year: i32|` for eBay and `|year: u16|` for Amazon) so `year.to_string()` can be inferred and compiled without changing runtime behavior.

### Testing
- Ran `rustfmt --edition 2024` on `docker/core/mkwebaxum/src/user/media/bp_media_physical.rs` successfully.
- Attempted `cargo check` and `cargo clippy` for the `mkwebaxum` crate, but both were blocked by the environment's configured `kellnr` registry returning HTTP 403 when fetching registry metadata, so full workspace validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9f7c018588321951c9dd0c575455d)