### PR TITLE
Refactor user sidebar markup to group primary media links

### DIFF
--- a/docker/core/mkwebaxum/templates/partials/sidebar_user.html
+++ b/docker/core/mkwebaxum/templates/partials/sidebar_user.html
@@ -17,11 +17,8 @@ dark:border-zinc-800 dark:text-zinc-400">
         </span>
     </div>
 
-    <!-- Nav -->
-    <nav class="flex-1 space-y-1 px-4 py-4 overflow-y-auto">
-
-        <!-- Primary -->
-        <div class="pb-4">
+    <div class="border-b border-zinc-200 px-4 py-4 dark:border-zinc-800">
+        <div class="space-y-1">
             <a href="/user/media/new" class="flex items-center rounded-lg px-3 py-2 text-sm font-medium
        text-zinc-700 hover:bg-zinc-200
        dark:text-zinc-200 dark:hover:bg-zinc-800
@@ -51,7 +48,13 @@ dark:border-zinc-800 dark:text-zinc-400">
                 </span>
                 <span class="ml-3">My Physical Media</span>
             </a>
+
         </div>
+
+    </div>
+
+    <!-- Nav -->
+    <nav class="flex-1 space-y-1 px-4 py-4 overflow-y-auto">
 
         <hr class="my-2 border-gray-200 dark:border-zinc-800">
 


### PR DESCRIPTION
### Motivation
- Improve visual grouping of top-level user media actions in the sidebar by separating them from the rest of the navigation with a bordered container.

### Description
- Reorganized `docker/core/mkwebaxum/templates/partials/sidebar_user.html` so the primary links (New Releases, My Queue, My Physical Media) are wrapped in a bordered `div` and placed before the main navigation.
- Added/adjusted container and spacing markup (bordered `div`, moved `nav`, inserted `hr`) to preserve scrolling and styling while creating a clear separation between primary and secondary items.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba14a4bd4c8321923ce94178b44e20)