### PR TITLE
Fix metadata movie sidebar spacing

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-<section class="max-w-7xl mx-auto p-4 md:ml-64
+<section class="max-w-7xl mx-auto p-4
                 text-zinc-900
                 dark:text-zinc-100">  <h1 id="movie-grid-heading" class="sr-only">Movie list</h1>
   {% include "filters/pagination_letters.html" %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail.html
@@ -1,7 +1,7 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<section class="max-w-6xl mx-auto px-4 py-6 sm:px-6 md:ml-64" x-data="moviePage()">
+<section class="max-w-6xl mx-auto px-4 py-6 sm:px-6" x-data="moviePage()">
 
     <!-- HEADER -->
     <div class="grid gap-6 lg:grid-cols-[260px_1fr]">


### PR DESCRIPTION
### Motivation
- The movie metadata list and detail templates each added a `md:ml-64` offset in addition to the shared layout, which caused the main content to be pushed too far from the user sidenav on desktop.

### Description
- Remove the duplicate `md:ml-64` class from `docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html` and `docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail.html` so the shared `layouts/base_user.html` single margin controls sidebar spacing.

### Testing
- Ran `rg -n "md:ml-64|<section class=\"max-w-7xl mx-auto p-4|<section class=\"max-w-6xl mx-auto px-4 py-6 sm:px-6"` to verify the templates were updated and the layout only contains the single sidebar offset (succeeded).
- Ran `cargo fmt --all --check` which reported pre-existing unrelated formatting diffs in the workspace, so formatting failures are not caused by this template-only change.
- Ran `cargo check` and `cargo clippy -- -D warnings` which failed due to the configured Kellnr registry returning HTTP 403 in this environment, so those failures are environmental and unrelated to the templates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb507b0c808321bb0560c25ec1427c)