### PR TITLE
mkwebaxum: show signed-in status and Logout in top navbar for authenticated layouts

### DIFF
--- a/docker/core/mkwebaxum/templates/partials/topnavbar.html
+++ b/docker/core/mkwebaxum/templates/partials/topnavbar.html
@@ -196,15 +196,16 @@
                         </svg>
                     </button>
 
-                    <a href="/public/login" class="px-3 py-2 text-sm font-medium
-              text-gray-700 dark:text-zinc-300
-              hover:text-indigo-600 dark:hover:text-indigo-400">
-                        Login
-                    </a>
+                    <span class="hidden rounded-full bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300 sm:inline-flex"
+                        aria-label="Signed in status">
+                        Signed in
+                    </span>
 
-                    <a href="#" class="bg-indigo-600 text-white px-4 py-2 rounded-lg
-              text-sm font-semibold hover:bg-indigo-700 transition shadow-sm">
-                        Sign Up
+                    <a href="/public/logout" class="px-3 py-2 text-sm font-medium
+              text-gray-700 dark:text-zinc-300
+              hover:text-indigo-600 dark:hover:text-indigo-400"
+                        aria-label="Log out">
+                        Logout
                     </a>
                 </div>
 


### PR DESCRIPTION
### Motivation
- The authenticated top navbar should not display public `Login` / `Sign Up` actions; it must show the user is signed in and provide a `Logout` action so authenticated layouts reflect the correct auth state.

### Description
- Replace the public `Login` / `Sign Up` links in the shared top navbar partial with a `Signed in` status badge and a `Logout` link pointing to `/public/logout` in `docker/core/mkwebaxum/templates/partials/topnavbar.html`, keeping the change minimal and isolated to the shared partial used by authenticated layouts.

### Testing
- Ran `git diff` and committed the change successfully; attempted `cargo fmt --all --check` which flagged unrelated workspace formatting differences so it did not complete; attempted `cargo check` and `cargo clippy -- -D warnings` but both could not complete in this environment because the configured custom registry returned HTTP 403 while resolving workspace dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0519685d8832181021489e64d24cd)