### PR TITLE
Preserve and display auth flash errors on public login/register

### DIFF
--- a/docker/core/mkwebaxum/src/public/bp_login.rs
+++ b/docker/core/mkwebaxum/src/public/bp_login.rs
@@ -1,29 +1,32 @@
+use crate::AppState;
 use crate::mk_lib_database;
 use askama::Template;
 use axum::{
-    extract::Form,
+    extract::{Form, State},
     http::StatusCode,
     response::{Html, IntoResponse, Redirect},
-    Extension,
 };
-use axum_flash::{Flash, IncomingFlashes, Key};
-use axum_session::{SessionConfig, SessionLayer};
+use axum_flash::{Flash, IncomingFlashes};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use serde::Deserialize;
-use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
-use validator::Validate;
-use axum::extract::State;
-use crate::AppState;
+use sqlx::postgres::PgPool;
 
 #[derive(Template)]
 #[template(path = "bss_public/bss_public_login.html")]
-struct LoginTemplate;
+struct LoginTemplate {
+    flash_messages: Vec<String>,
+}
 
-pub async fn public_login() -> impl IntoResponse {
-    let template = LoginTemplate {};
+pub async fn public_login(flashes: IncomingFlashes) -> impl IntoResponse {
+    let template = LoginTemplate {
+        flash_messages: flashes
+            .iter()
+            .map(|(_, message)| message.to_string())
+            .collect(),
+    };
     let reply_html = template.render().unwrap();
-    (StatusCode::OK, Html(reply_html).into_response())
+    (flashes, StatusCode::OK, Html(reply_html).into_response())
 }
 
 #[derive(Deserialize)]
@@ -33,11 +36,11 @@ pub struct LoginInput {
 }
 
 pub async fn public_login_post(
-     State(state): State<AppState>,
+    State(state): State<AppState>,
     mut auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
-    mut flash: Flash,
+    flash: Flash,
     Form(input_data): Form<LoginInput>,
-) -> Redirect {
+) -> (Flash, Redirect) {
     let user_id: i64 =
         mk_lib_database::mk_lib_database_user::mk_lib_database_user_login_verification(
             &state.sqlx_pool_rw,
@@ -55,8 +58,11 @@ pub async fn public_login_post(
         .await;
         auth.login_user(user_id);
         auth.remember_user(true);
+        (flash, Redirect::to("/user/home"))
     } else {
-        flash.error("Unknown user or password incorrect!");
+        (
+            flash.error("Unknown user or password incorrect!"),
+            Redirect::to("/public/login"),
+        )
     }
-    Redirect::to("/user/home")
 }

--- a/docker/core/mkwebaxum/src/public/bp_register.rs
+++ b/docker/core/mkwebaxum/src/public/bp_register.rs
@@ -1,33 +1,29 @@
+use crate::AppState;
+use crate::mk_lib_database;
 use askama::Template;
 use axum::{
-    extract::Form,
-    http::{Method, StatusCode},
+    extract::{Form, State},
+    http::StatusCode,
     response::{Html, IntoResponse, Redirect},
-    routing::{get, post},
-    Extension,
 };
-use axum_flash::{Flash, IncomingFlashes, Key};
-use axum_session::{SessionConfig, SessionLayer};
-use axum_session_sqlx::{SessionPgPool};
-use axum_session_auth::*;
-use crate::mk_lib_database;
-use serde::{Deserialize, Serialize};
-use sqlx::{
-    postgres::{PgConnectOptions, PgPoolOptions},
-    ConnectOptions, PgPool,
-};
-use validator::Validate;
-use axum::extract::State;
-use crate::AppState;
+use axum_flash::{Flash, IncomingFlashes};
+use serde::Deserialize;
 
 #[derive(Template)]
 #[template(path = "bss_public/bss_public_register.html")]
-struct RegisterTemplate;
+struct RegisterTemplate {
+    flash_messages: Vec<String>,
+}
 
-pub async fn public_register() -> impl IntoResponse {
-    let template = RegisterTemplate {};
+pub async fn public_register(flashes: IncomingFlashes) -> impl IntoResponse {
+    let template = RegisterTemplate {
+        flash_messages: flashes
+            .iter()
+            .map(|(_, message)| message.to_string())
+            .collect(),
+    };
     let reply_html = template.render().unwrap();
-    (StatusCode::OK, Html(reply_html).into_response())
+    (flashes, StatusCode::OK, Html(reply_html).into_response())
 }
 
 #[derive(Deserialize)]
@@ -38,17 +34,20 @@ pub struct RegisterInput {
 
 pub async fn public_register_post(
     State(state): State<AppState>,
-    mut flash: Flash,
+    flash: Flash,
     Form(input_data): Form<RegisterInput>,
-) -> Redirect {
+) -> (Flash, Redirect) {
     let user_found = mk_lib_database::mk_lib_database_user::mk_lib_database_user_exists(
-       &state.sqlx_pool_ro,
+        &state.sqlx_pool_ro,
         &input_data.username,
     )
     .await
     .unwrap();
-    if user_found == true {
-        flash.error("User already exists!");
+    if user_found {
+        (
+            flash.error("User already exists!"),
+            Redirect::to("/public/register"),
+        )
     } else {
         let user_id: i64 = mk_lib_database::mk_lib_database_user::mk_lib_database_user_insert(
             &state.sqlx_pool_rw,
@@ -57,7 +56,7 @@ pub async fn public_register_post(
         )
         .await
         .unwrap();
-    // using rw here as I need to see the insert immediately
+        // using rw here as I need to see the insert immediately
         if mk_lib_database::mk_lib_database_user::mk_lib_database_user_count(
             &state.sqlx_pool_rw,
             String::new(),
@@ -68,10 +67,12 @@ pub async fn public_register_post(
         // Use 2 as 1 is guest
         {
             let _result = mk_lib_database::mk_lib_database_user::mk_lib_database_user_set_admin(
-                &state.sqlx_pool_rw, user_id,
+                &state.sqlx_pool_rw,
+                user_id,
             )
             .await;
         }
+
+        (flash, Redirect::to("/public/login"))
     }
-    Redirect::to("/public/login")
 }

--- a/docker/core/mkwebaxum/templates/bss_public/bss_public_login.html
+++ b/docker/core/mkwebaxum/templates/bss_public/bss_public_login.html
@@ -31,6 +31,16 @@
             </h4>
           </div>
 
+          {% if !flash_messages.is_empty() %}
+          <div class="space-y-2" role="alert" aria-live="polite">
+            {% for message in flash_messages %}
+            <div class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {{ message }}
+            </div>
+            {% endfor %}
+          </div>
+          {% endif %}
+
           <form action="/public/login" method="post" class="space-y-4">
 
             <input

--- a/docker/core/mkwebaxum/templates/bss_public/bss_public_register.html
+++ b/docker/core/mkwebaxum/templates/bss_public/bss_public_register.html
@@ -30,6 +30,16 @@
             </h4>
           </div>
 
+          {% if !flash_messages.is_empty() %}
+          <div class="space-y-2" role="alert" aria-live="polite">
+            {% for message in flash_messages %}
+            <div class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {{ message }}
+            </div>
+            {% endfor %}
+          </div>
+          {% endif %}
+
           <form action="/public/register" method="post" class="space-y-4">
 
             <input


### PR DESCRIPTION
### Motivation
- Users were not seeing authentication or registration errors because the login POST always redirected to `/user/home` and the public templates never rendered `axum_flash` messages.
- The change aims to preserve flash state across redirects and show user-facing validation/auth errors on the public pages.

### Description
- `docker/core/mkwebaxum/src/public/bp_login.rs` now accepts `IncomingFlashes`, passes collected `flash_messages` into the Askama template, and returns `(Flash, Redirect)` from the POST handler so flash state is preserved; failed logins now redirect back to `/public/login` with an error flash instead of unconditionally redirecting to `/user/home`.
- `docker/core/mkwebaxum/src/public/bp_register.rs` was updated with the same flash-preservation pattern so duplicate-user errors survive the redirect and are visible to the user.
- `docker/core/mkwebaxum/templates/bss_public/bss_public_login.html` and `.../bss_public_register.html` now render a simple, accessible flash-error block (role="alert", `aria-live="polite"`) that lists flash messages returned by the handlers.
- Minor import adjustments were made (added `State`, `AppState`, `PgPool` usages) to support the handler changes with minimal scope.

### Testing
- Ran formatting with `rustfmt --edition 2024 docker/core/mkwebaxum/src/public/bp_login.rs docker/core/mkwebaxum/src/public/bp_register.rs` which succeeded.
- Attempted `cargo check -p mkwebapp` and `cargo clippy -p mkwebapp -- -D warnings`, but both are blocked in this environment because the repository is configured to use a private `kellnr` registry that returned HTTP 403 for its `config.json` during dependency resolution.
- Manual inspection of the modified templates and handler signatures was performed to ensure the flash messages are collected, returned, and rendered by the templates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c05161ccf08321b242dd53d17cfa9f)