### PR TITLE
Fix sports metadata page failures

### DIFF
--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_sports.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_sports.rs
@@ -1,24 +1,24 @@
+use crate::AppState;
 use crate::mk_lib_database;
 use askama::Template;
-use axum::response::Redirect;
 use axum::{
-    extract::Path,
+    extract::{Path, State},
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
-use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use serde_json::json;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
 struct TemplateError401Context {}
+
+#[derive(Template)]
+#[template(path = "bss_error/bss_error_500.html")]
+struct TemplateError500Context {}
 
 #[derive(Template)]
 #[template(path = "bss_user/metadata/bss_user_metadata_sports.html")]
@@ -52,34 +52,56 @@ pub async fn user_metadata_sports(
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
         let db_offset: i64 = (page * 30) - 30;
-        let total_pages: i64 =
-        mk_lib_database::database_metadata::mk_lib_database_metadata_sports::mk_lib_database_metadata_sports_count(
+        let total_pages = match mk_lib_database::database_metadata::mk_lib_database_metadata_sports::mk_lib_database_metadata_sports_count(
             &state.sqlx_pool_ro,
             String::new(),
         )
         .await
-        .unwrap();
-        let pagination_html = mk_lib_common_pagination::mk_lib_common_paginate(
+        {
+            Ok(total_pages) => total_pages,
+            Err(err) => {
+                eprintln!("sports metadata count failed: {err}");
+                let template = TemplateError500Context {};
+                let reply_html = template.render().unwrap_or_default();
+                return (StatusCode::INTERNAL_SERVER_ERROR, Html(reply_html).into_response());
+            }
+        };
+        let pagination_html = match mk_lib_common_pagination::mk_lib_common_paginate(
             total_pages,
             page,
             "/user/metadata/sports".to_string(),
             None,
         )
         .await
-        .unwrap();
-        let sports_list =
-        mk_lib_database::database_metadata::mk_lib_database_metadata_sports::mk_lib_database_metadata_sports_read(
-           &state.sqlx_pool_ro,
+        {
+            Ok(pagination_html) => pagination_html,
+            Err(err) => {
+                eprintln!("sports metadata pagination failed: {err}");
+                let template = TemplateError500Context {};
+                let reply_html = template.render().unwrap_or_default();
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Html(reply_html).into_response(),
+                );
+            }
+        };
+        let sports_list = match mk_lib_database::database_metadata::mk_lib_database_metadata_sports::mk_lib_database_metadata_sports_read(
+            &state.sqlx_pool_ro,
             String::new(),
             db_offset,
             30,
         )
         .await
-        .unwrap();
-        let mut template_data_exists = false;
-        if sports_list.len() > 0 {
-            template_data_exists = true;
-        }
+        {
+            Ok(sports_list) => sports_list,
+            Err(err) => {
+                eprintln!("sports metadata read failed: {err}");
+                let template = TemplateError500Context {};
+                let reply_html = template.render().unwrap_or_default();
+                return (StatusCode::INTERNAL_SERVER_ERROR, Html(reply_html).into_response());
+            }
+        };
+        let template_data_exists = !sports_list.is_empty();
         let page_usize = page as usize;
         let template = TemplateMetaSportsContext {
             template_data: &sports_list,
@@ -88,8 +110,18 @@ pub async fn user_metadata_sports(
             page: &page_usize,
             page_title: Some("MediaKraken Metadata Sports".to_string()),
         };
-        let reply_html = template.render().unwrap();
-        (StatusCode::OK, Html(reply_html).into_response())
+        match template.render() {
+            Ok(reply_html) => (StatusCode::OK, Html(reply_html).into_response()),
+            Err(err) => {
+                eprintln!("sports metadata template render failed: {err}");
+                let template = TemplateError500Context {};
+                let reply_html = template.render().unwrap_or_default();
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Html(reply_html).into_response(),
+                )
+            }
+        }
     }
 }
 

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_sports.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_sports.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::postgres::PgRow;
 use sqlx::FromRow;
+use sqlx::postgres::PgRow;
 
 pub async fn mk_lib_database_metadata_sports_count(
     sqlx_pool: &sqlx::PgPool,
@@ -34,10 +34,15 @@ pub async fn mk_lib_database_metadata_sports_read(
     offset: i64,
     limit: i64,
 ) -> Result<Vec<DBMetaSportsList>, sqlx::Error> {
-    // TODO order by year
     if !search_value.is_empty() {
         sqlx::query_as(
-            r#"select mm_metadata_sports_guid, mm_metadata_sports_name from mm_metadata_sports where mm_metadata_sports_guid where mm_metadata_sports_name &@ $1 offset $2 limit $3"#,
+            r#"select
+                mm_metadata_sports_guid,
+                coalesce(mm_metadata_sports_name, 'Unknown Event') as mm_metadata_sports_name
+            from mm_metadata_sports
+            where mm_metadata_sports_name &@ $1
+            order by lower(coalesce(mm_metadata_sports_name, 'Unknown Event'))
+            offset $2 limit $3"#,
         )
         .bind(search_value)
         .bind(offset)
@@ -46,8 +51,12 @@ pub async fn mk_lib_database_metadata_sports_read(
         .await
     } else {
         sqlx::query_as(
-            r#"select mm_metadata_sports_guid, mm_metadata_sports_name from mm_metadata_sports
-            order by LOWER(mm_metadata_sports_name) offset $1 limit $2"#,
+            r#"select
+                mm_metadata_sports_guid,
+                coalesce(mm_metadata_sports_name, 'Unknown Event') as mm_metadata_sports_name
+            from mm_metadata_sports
+            order by lower(coalesce(mm_metadata_sports_name, 'Unknown Event'))
+            offset $1 limit $2"#,
         )
         .bind(offset)
         .bind(limit)


### PR DESCRIPTION
### Motivation
- The mkwebaxum sports metadata page was returning 500s due to an invalid SQL filter and cases where database rows contained NULL event names that caused row decoding / template rendering to panic.
- The handler also used unchecked `.unwrap()`/`fetch` paths that caused the whole request to crash instead of rendering the existing 500 page, so explicit error handling was required.

### Description
- Fix SQL in `mk_lib_database_metadata_sports_read` in `src/mk_lib_database/src/metadata/mk_lib_database_metadata_sports.rs` by removing the malformed `where` clause, adding `coalesce(mm_metadata_sports_name, 'Unknown Event')` to tolerate `NULL` names, and applying a stable `order by lower(...)` so filtered and unfiltered queries return rows that match the `DBMetaSportsList` struct.
- Harden the web handler `user_metadata_sports` in `docker/core/mkwebaxum/src/user/metadata/bp_meta_sports.rs` to explicitly handle errors from the count, pagination, read, and template render steps by logging the error and returning the existing 500 template instead of panicking, and add a `TemplateError500Context` for that purpose.
- Adjusted imports to use `State` extractor and simplified boolean presence checks; replaced manual `len` checks with `!sports_list.is_empty()` for clarity.
- Committed the changes (files modified: `src/mk_lib_database/src/metadata/mk_lib_database_metadata_sports.rs`, `docker/core/mkwebaxum/src/user/metadata/bp_meta_sports.rs`).

### Testing
- Ran formatting checks with `rustfmt` / `cargo fmt` on the modified files and confirmed formatting succeeded.
- Attempted `cargo check` in the local environment but it could not complete because the configured Kellnr registry returned HTTP 403 for dependency index access, so full compilation checks are blocked in this environment.
- Attempted `cargo clippy -- -D warnings` but it also could not run for the same private registry 403 reason, so lints were not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c05133322c832187221986d23a3ee5)