### PR TITLE
Add profile photo uploads on the user profile page

### DIFF
--- a/docker/core/mkwebaxum/Cargo.toml
+++ b/docker/core/mkwebaxum/Cargo.toml
@@ -27,7 +27,7 @@ mk_lib_rabbitmq = { version = "0.0.174", registry = "kellnr" }
 askama = "0.15.4"
 askama_axum = "0.4.0"
 async-trait = "0.1.89"
-axum = { version = "0.8.8", features = ["form", "http2", "json", "ws", "macros"] }
+axum = { version = "0.8.8", features = ["form", "http2", "json", "multipart", "ws", "macros"] }
 axum-client-ip = "1.3.1"
 axum_csrf = "0.11.0"
 axum-extra = { version = "0.12.5", features = ["routing"]}

--- a/docker/core/mkwebaxum/src/main.rs
+++ b/docker/core/mkwebaxum/src/main.rs
@@ -445,6 +445,10 @@ async fn main() {
         .route_with_tsr("/user/hardware", get(user::bp_hardware::user_hardware))
         .route_with_tsr("/user/home", get(user::bp_home::user_home))
         .route_with_tsr("/user/profile", get(user::bp_profile::user_profile))
+        .route(
+            "/user/profile/photo",
+            post(user::bp_profile::user_profile_photo_post),
+        )
         .route_with_tsr("/user/queue", get(user::bp_queue::user_queue))
         //.route_with_tsr("/user/search", get(user::bp_search::user_search))
         .route("/user/search", get(user::bp_search::search_handler))

--- a/docker/core/mkwebaxum/src/user/bp_profile.rs
+++ b/docker/core/mkwebaxum/src/user/bp_profile.rs
@@ -1,16 +1,20 @@
+use crate::AppState;
 use crate::mk_lib_database;
 use askama::Template;
 use axum::{
+    extract::{Multipart, Query, State},
     http::{Method, StatusCode},
-    response::{Html, IntoResponse},
-    Extension,
+    response::{Html, IntoResponse, Redirect},
 };
-use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
-use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use sqlx::{FromRow, postgres::PgPool};
+
+const DEFAULT_PROFILE_IMAGE_URL: &str = "/static/image/K3.png";
+const PROFILE_IMAGE_DIR: &str = "static/image/user_profile";
+const MAX_PROFILE_IMAGE_BYTES: usize = 5 * 1024 * 1024;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -20,10 +24,27 @@ struct TemplateError401Context {}
 #[template(path = "bss_user/bss_user_profile.html")]
 struct UserProfileTemplate {
     page_title: Option<String>,
+    username: String,
+    profile_image_url: String,
+    success_message: Option<String>,
+    error_message: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct UserProfileQuery {
+    status: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(FromRow)]
+struct UserProfileRow {
+    mm_user_profile_guid: uuid::Uuid,
+    mm_user_profile_json: Option<Value>,
 }
 
 pub async fn user_profile(
     State(state): State<AppState>,
+    Query(query): Query<UserProfileQuery>,
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
 ) -> impl IntoResponse {
@@ -42,8 +63,242 @@ pub async fn user_profile(
     } else {
         let template = UserProfileTemplate {
             page_title: Some("MediaKraken User Profile".to_string()),
+            username: current_user.username,
+            profile_image_url: load_profile_image_url(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or_else(|_| DEFAULT_PROFILE_IMAGE_URL.to_string()),
+            success_message: match query.status.as_deref() {
+                Some("updated") => Some("Profile picture updated.".to_string()),
+                _ => None,
+            },
+            error_message: match query.error.as_deref() {
+                Some("missing-file") => {
+                    Some("Choose an image before submitting the form.".to_string())
+                }
+                Some("invalid-type") => {
+                    Some("Profile pictures must be a PNG, JPEG, GIF, or WebP image.".to_string())
+                }
+                Some("too-large") => Some("Profile pictures must be 5 MB or smaller.".to_string()),
+                Some("save-failed") => {
+                    Some("MediaKraken could not save that profile picture right now.".to_string())
+                }
+                _ => None,
+            },
         };
         let reply_html = template.render().unwrap();
         (StatusCode::OK, Html(reply_html).into_response())
     }
+}
+
+pub async fn user_profile_photo_post(
+    State(state): State<AppState>,
+    method: Method,
+    auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
+    mut multipart: Multipart,
+) -> Redirect {
+    let current_user = auth.current_user.clone().unwrap_or_default();
+    if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
+        [Method::POST],
+        false,
+    )
+    .requires(Rights::any([Rights::permission("User::View")]))
+    .validate(&current_user, &method, None)
+    .await
+    {
+        return Redirect::to("/error/401");
+    }
+
+    let mut image_bytes = None;
+    let mut image_extension = None;
+
+    loop {
+        let next_field = match multipart.next_field().await {
+            Ok(field) => field,
+            Err(_) => return Redirect::to("/user/profile?error=save-failed"),
+        };
+
+        let Some(field) = next_field else {
+            break;
+        };
+
+        if field.name() != Some("profile_image") {
+            continue;
+        }
+
+        let Some(extension) = content_type_to_extension(field.content_type()) else {
+            return Redirect::to("/user/profile?error=invalid-type");
+        };
+
+        let bytes = match field.bytes().await {
+            Ok(bytes) => bytes,
+            Err(_) => return Redirect::to("/user/profile?error=save-failed"),
+        };
+
+        if bytes.is_empty() {
+            return Redirect::to("/user/profile?error=missing-file");
+        }
+
+        if bytes.len() > MAX_PROFILE_IMAGE_BYTES {
+            return Redirect::to("/user/profile?error=too-large");
+        }
+
+        image_bytes = Some(bytes);
+        image_extension = Some(extension.to_string());
+        break;
+    }
+
+    let Some(image_bytes) = image_bytes else {
+        return Redirect::to("/user/profile?error=missing-file");
+    };
+    let Some(image_extension) = image_extension else {
+        return Redirect::to("/user/profile?error=invalid-type");
+    };
+
+    let public_image_url = format!(
+        "/static/image/user_profile/user-{}.{}",
+        current_user.id, image_extension
+    );
+
+    if save_profile_image(current_user.id, &image_extension, &image_bytes)
+        .await
+        .is_err()
+    {
+        return Redirect::to("/user/profile?error=save-failed");
+    }
+
+    if upsert_profile_image_url(&state.sqlx_pool_rw, current_user.id, &public_image_url)
+        .await
+        .is_err()
+    {
+        return Redirect::to("/user/profile?error=save-failed");
+    }
+
+    Redirect::to("/user/profile?status=updated")
+}
+
+async fn load_profile_image_url(sqlx_pool: &PgPool, user_id: i64) -> Result<String, sqlx::Error> {
+    let profile_name = profile_name_for_user(user_id);
+    let row = sqlx::query_scalar::<_, Option<String>>(
+        r#"
+        select mm_user_profile_json ->> 'profile_image_url'
+        from mm_user_profile
+        where mm_user_profile_name = $1
+        order by mm_user_profile_guid
+        limit 1
+        "#,
+    )
+    .bind(profile_name)
+    .fetch_optional(sqlx_pool)
+    .await?;
+
+    Ok(row
+        .flatten()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_PROFILE_IMAGE_URL.to_string()))
+}
+
+async fn upsert_profile_image_url(
+    sqlx_pool: &PgPool,
+    user_id: i64,
+    profile_image_url: &str,
+) -> Result<(), sqlx::Error> {
+    let profile_name = profile_name_for_user(user_id);
+    let existing_profile = sqlx::query_as::<_, UserProfileRow>(
+        r#"
+        select mm_user_profile_guid, mm_user_profile_json
+        from mm_user_profile
+        where mm_user_profile_name = $1
+        order by mm_user_profile_guid
+        limit 1
+        "#,
+    )
+    .bind(&profile_name)
+    .fetch_optional(sqlx_pool)
+    .await?;
+
+    let mut transaction = sqlx_pool.begin().await?;
+
+    if let Some(existing_profile) = existing_profile {
+        let mut profile_json = existing_profile
+            .mm_user_profile_json
+            .unwrap_or_else(|| json!({}));
+
+        if !profile_json.is_object() {
+            profile_json = json!({});
+        }
+
+        if let Some(profile_object) = profile_json.as_object_mut() {
+            profile_object.insert(
+                "profile_image_url".to_string(),
+                Value::String(profile_image_url.to_string()),
+            );
+        }
+
+        sqlx::query(
+            r#"
+            update mm_user_profile
+            set mm_user_profile_json = $2
+            where mm_user_profile_guid = $1
+            "#,
+        )
+        .bind(existing_profile.mm_user_profile_guid)
+        .bind(profile_json)
+        .execute(&mut *transaction)
+        .await?;
+    } else {
+        sqlx::query(
+            r#"
+            insert into mm_user_profile (
+                mm_user_profile_guid,
+                mm_user_profile_name,
+                mm_user_profile_json
+            )
+            values ($1, $2, $3)
+            "#,
+        )
+        .bind(uuid::Uuid::now_v7())
+        .bind(profile_name)
+        .bind(json!({ "profile_image_url": profile_image_url }))
+        .execute(&mut *transaction)
+        .await?;
+    }
+
+    transaction.commit().await?;
+    Ok(())
+}
+
+async fn save_profile_image(
+    user_id: i64,
+    image_extension: &str,
+    image_bytes: &[u8],
+) -> Result<(), std::io::Error> {
+    tokio::fs::create_dir_all(PROFILE_IMAGE_DIR).await?;
+
+    for extension in ["png", "jpg", "jpeg", "gif", "webp"] {
+        let existing_path = format!("{}/user-{}.{}", PROFILE_IMAGE_DIR, user_id, extension);
+        if extension != image_extension {
+            match tokio::fs::remove_file(&existing_path).await {
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    let disk_path = format!("{}/user-{}.{}", PROFILE_IMAGE_DIR, user_id, image_extension);
+    tokio::fs::write(disk_path, image_bytes).await
+}
+
+fn content_type_to_extension(content_type: Option<&str>) -> Option<&'static str> {
+    match content_type {
+        Some("image/png") => Some("png"),
+        Some("image/jpeg") | Some("image/jpg") => Some("jpg"),
+        Some("image/gif") => Some("gif"),
+        Some("image/webp") => Some("webp"),
+        _ => None,
+    }
+}
+
+fn profile_name_for_user(user_id: i64) -> String {
+    format!("axum_user_{}", user_id)
 }

--- a/docker/core/mkwebaxum/templates/bss_user/bss_user_profile.html
+++ b/docker/core/mkwebaxum/templates/bss_user/bss_user_profile.html
@@ -1,81 +1,73 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <h3 class="text-dark mb-4">Profile</h3>
-    <div class="row mb-3">
-        <div class="col-lg-4">
-            <div class="card mb-3">
-                <div class="card-body text-center shadow"><img class="rounded-circle mb-3 mt-4"
-                        src="/static/image/K3.png" width="160" height="160">
-                    <div class="mb-3"><button class="btn btn-primary btn-sm" type="button">Change
-                            Photo</button></div>
-                </div>
+<div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+    <div class="mb-8">
+        <h1 class="text-3xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">Profile</h1>
+        <p class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+            Update the profile photo shown for your MediaKraken account.
+        </p>
+    </div>
+
+    {% if let Some(message) = success_message %}
+    <div class="mb-6 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/50 dark:text-emerald-300">
+        {{ message }}
+    </div>
+    {% endif %}
+
+    {% if let Some(message) = error_message %}
+    <div class="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/50 dark:text-red-300">
+        {{ message }}
+    </div>
+    {% endif %}
+
+    <div class="grid gap-6 lg:grid-cols-[280px_minmax(0,1fr)]">
+        <section class="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+            <div x-data="{ previewUrl: '{{ profile_image_url }}' }" class="flex flex-col items-center text-center">
+                <img x-bind:src="previewUrl"
+                     src="{{ profile_image_url }}"
+                     alt="Current profile picture for {{ username }}"
+                     class="h-40 w-40 rounded-full border border-zinc-200 object-cover shadow-sm dark:border-zinc-700">
+                <p class="mt-4 text-lg font-medium text-zinc-900 dark:text-zinc-100">{{ username }}</p>
+                <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">Recommended formats: PNG, JPEG, GIF, or WebP up to 5 MB.</p>
+
+                <form class="mt-6 flex w-full flex-col gap-4" action="/user/profile/photo" method="post" enctype="multipart/form-data">
+                    <label for="profile_image" class="text-left text-sm font-medium text-zinc-700 dark:text-zinc-200">
+                        Choose a new profile picture
+                    </label>
+                    <input id="profile_image"
+                           name="profile_image"
+                           type="file"
+                           accept="image/png,image/jpeg,image/gif,image/webp"
+                           aria-label="Choose a new profile picture"
+                           class="block w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 file:mr-4 file:rounded-md file:border-0 file:bg-indigo-600 file:px-3 file:py-2 file:text-sm file:font-medium file:text-white hover:file:bg-indigo-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-100 dark:file:bg-indigo-500 dark:hover:file:bg-indigo-400"
+                           x-on:change="const [file] = $event.target.files; if (file) { previewUrl = URL.createObjectURL(file); }">
+                    <button type="submit"
+                            aria-label="Upload new profile picture"
+                            class="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:focus:ring-offset-zinc-900">
+                        Save profile picture
+                    </button>
+                </form>
             </div>
-            <div class="card shadow mb-4"></div>
-        </div>
-        <div class="col-lg-8">
-            <div class="row mb-3 d-none">
-                <div class="col">
-                    <div class="card text-white bg-primary shadow">
-                        <div class="card-body">
-                            <div class="row mb-2">
-                                <div class="col">
-                                    <p class="m-0">Peformance</p>
-                                    <p class="m-0"><strong>65.2%</strong></p>
-                                </div>
-                                <div class="col-auto"><i class="fas fa-rocket fa-2x"></i></div>
-                            </div>
-                            <p class="text-white-50 small m-0"><i class="fas fa-arrow-up"></i>&nbsp;5%
-                                since last month</p>
-                        </div>
-                    </div>
+        </section>
+
+        <section class="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+            <h2 class="text-lg font-semibold text-zinc-900 dark:text-zinc-100">Photo settings</h2>
+            <dl class="mt-6 space-y-4 text-sm text-zinc-600 dark:text-zinc-300">
+                <div>
+                    <dt class="font-medium text-zinc-900 dark:text-zinc-100">Username</dt>
+                    <dd class="mt-1">{{ username }}</dd>
                 </div>
-                <div class="col">
-                    <div class="card text-white bg-success shadow">
-                        <div class="card-body">
-                            <div class="row mb-2">
-                                <div class="col">
-                                    <p class="m-0">Peformance</p>
-                                    <p class="m-0"><strong>65.2%</strong></p>
-                                </div>
-                                <div class="col-auto"><i class="fas fa-rocket fa-2x"></i></div>
-                            </div>
-                            <p class="text-white-50 small m-0"><i class="fas fa-arrow-up"></i>&nbsp;5%
-                                since last month</p>
-                        </div>
-                    </div>
+                <div>
+                    <dt class="font-medium text-zinc-900 dark:text-zinc-100">Current image path</dt>
+                    <dd class="mt-1 break-all">{{ profile_image_url }}</dd>
                 </div>
-            </div>
-            <div class="row">
-                <div class="col">
-                    <div class="card shadow mb-3">
-                        <div class="card-header py-3">
-                            <p class="text-primary m-0 font-weight-bold">User Settings</p>
-                        </div>
-                        <div class="card-body">
-                            <form>
-                                <div class="form-row">
-                                    <div class="col">
-                                        <div class="form-group"><label
-                                                for="username"><strong>Username</strong></label><input
-                                                class="form-control" type="text" placeholder="Username"
-                                                name="username"></div>
-                                        <div class="form-group"><label for="email"><strong>Email
-                                                    Address</strong></label><input class="form-control"
-                                                type="email" placeholder="user@example.com"
-                                                name="email"></div>
-                                    </div>
-                                </div>
-                                <div class="form-group"><button class="btn btn-primary btn-sm"
-                                        type="submit">Save Settings</button></div>
-                            </form>
-                        </div>
-                    </div>
-                    <div class="card shadow"></div>
+                <div>
+                    <dt class="font-medium text-zinc-900 dark:text-zinc-100">How this works</dt>
+                    <dd class="mt-1">Uploading a new image replaces your existing saved profile picture and updates the profile page immediately.</dd>
                 </div>
-            </div>
-        </div>
+            </dl>
+        </section>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Let users change their account avatar directly from the profile page with a minimal, non-destructive server+template change.
- Keep behavior simple: validate file type/size, save image to disk under `static/image/user_profile`, and persist a public image URL in `mm_user_profile` JSON so the UI can load it.

### Description
- Added a POST upload route at `/user/profile/photo` and handler `user_profile_photo_post` in `docker/core/mkwebaxum/src/user/bp_profile.rs` that accepts axum `Multipart`, validates image MIME, enforces a 5 MB limit, writes the file as `static/image/user_profile/user-{id}.{ext}`, and upserts the saved URL into `mm_user_profile` JSON (profile key `axum_user_{id}`).
- Updated the GET handler in `bp_profile.rs` to load the saved `profile_image_url` from `mm_user_profile` and pass `username`, `profile_image_url`, and optional `status`/`error` messages into the Askama template context.
- Replaced the placeholder profile card template with an upload UI in `docker/core/mkwebaxum/templates/bss_user/bss_user_profile.html` that includes a file input (accepting PNG/JPEG/GIF/WebP), client-side preview via Alpine, and inline success/error display.
- Enabled Axum multipart support by adding the `multipart` feature to the `axum` dependency in `docker/core/mkwebaxum/Cargo.toml` and registered the new route in `src/main.rs`.

### Testing
- Ran formatter: `source "$HOME/.cargo/env" 2>/dev/null && cargo fmt` — succeeded. 
- Ran style/check: `git diff --check` — succeeded.
- Attempted `cargo check` but validation is blocked by the repository cargo registry configuration returning HTTP 403 for crates.io replacement (network/registry limitation). 
- Attempted `cargo check -p mkwebapp --offline` and `cargo clippy -p mkwebapp --offline -- -D warnings` but both were blocked because the environment is offline for the git dependency `axum-flash` (required by the workspace) so dependencies could not be fetched offline.
- Changes have been committed: `Add profile photo uploads on user profile page`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c05109f7088321b704a6f440f55502)