### PR TITLE
Fix mkwebaxum music metadata query aliases

### DIFF
--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_music_brainz.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_music_brainz.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use sqlx::postgres::PgRow;
 use sqlx::FromRow;
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
@@ -37,7 +36,7 @@ pub async fn mk_lib_database_metadata_music_album_read(
     // TODO order by release year
     if search_value != String::new() {
         sqlx::query_as(
-            r#"select release.id as brainz_id, release.name as brainz_name, artist.name as brainz_artist from release, artist where artist.id = artist_credit and mm_metadata_album_name % $1 order by LOWER(name) offset $2 limit $3"#,
+            r#"select release.id as mm_metadata_album_id, release.name as mm_metadata_album_name, artist.name as mm_metadata_album_artist from release, artist where artist.id = artist_credit and release.name % $1 order by LOWER(release.name), LOWER(artist.name) offset $2 limit $3"#,
         )
         .bind(search_value)
         .bind(offset)
@@ -46,7 +45,7 @@ pub async fn mk_lib_database_metadata_music_album_read(
             .await
     } else {
         sqlx::query_as(
-            r#"select release.id as brainz_id, release.name as brainz_name, artist.name as brainz_artist from release, artist where artist.id = artist_credit order by LOWER(release.name), LOWER(artist.name) offset $1 limit $2"#,
+            r#"select release.id as mm_metadata_album_id, release.name as mm_metadata_album_name, artist.name as mm_metadata_album_artist from release, artist where artist.id = artist_credit order by LOWER(release.name), LOWER(artist.name) offset $1 limit $2"#,
         )
         .bind(offset)
         .bind(limit)


### PR DESCRIPTION
### Motivation
- The music album list query returned columns that did not match the `DBMetaMusicList` struct and used a non-existent legacy column in the search branch, causing sqlx row-mapping failures that surfaced as 500 errors on the music metadata pages.

### Description
- Update the MusicBrainz album list SQL to alias selected columns as `mm_metadata_album_id`, `mm_metadata_album_name`, and `mm_metadata_album_artist` so they map to `DBMetaMusicList` correctly in `src/mk_lib_database/src/metadata/mk_lib_database_metadata_music_brainz.rs`.
- Fix the search branch to filter on `release.name` (previously referenced `mm_metadata_album_name`) and make the ordering consistent, and remove the unused `PgRow` import.

### Testing
- Ran `rustfmt --edition 2024 /workspace/MediaKraken/src/mk_lib_database/src/metadata/mk_lib_database_metadata_music_brainz.rs` which completed successfully.
- Attempted `cargo check -p mkwebaxum` and `cargo clippy -p mkwebaxum -- -D warnings` but dependency resolution is blocked in this environment by the configured registry returning HTTP 403, so those checks could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c061b1a3888321ac024345750caec4)