### PR TITLE
Fix person metadata image query

### DIFF
--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_person.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_person.rs
@@ -1,31 +1,34 @@
-use crate::mk_lib_database;
+use crate::AppState;
 use askama::Template;
-use axum::response::Redirect;
 use axum::{
-    extract::Path,
+    extract::{Path, State},
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
-use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
-use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
+use sqlx::{FromRow, postgres::PgPool};
+
+use crate::mk_lib_database;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
 struct TemplateError401Context {}
 
+#[derive(Debug, Deserialize, Serialize, FromRow)]
+struct TemplateMetaPersonList {
+    mm_metadata_person_guid: uuid::Uuid,
+    mm_metadata_person_name: String,
+    mm_metadata_person_image: String,
+}
+
 #[derive(Template)]
 #[template(path = "bss_user/metadata/bss_user_metadata_person.html")]
 struct TemplateMetaPersonContext<'a> {
-    template_data: &'a Vec<
-        mk_lib_database::database_metadata::mk_lib_database_metadata_person::DBMetaPersonList,
-    >,
+    template_data: &'a Vec<TemplateMetaPersonList>,
     template_data_exists: &'a bool,
     pagination_bar: &'a String,
     page: &'a usize,
@@ -52,9 +55,8 @@ pub async fn user_metadata_person(
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
         let db_offset: i64 = (page * 30) - 30;
-        let total_pages: i64 =
-        mk_lib_database::database_metadata::mk_lib_database_metadata_person::mk_lib_database_metadata_person_count(
-           &state.sqlx_pool_ro,
+        let total_pages: i64 = mk_lib_database::database_metadata::mk_lib_database_metadata_person::mk_lib_database_metadata_person_count(
+            &state.sqlx_pool_ro,
             String::new(),
         )
         .await
@@ -67,19 +69,20 @@ pub async fn user_metadata_person(
         )
         .await
         .unwrap();
-        let person_list =
-        mk_lib_database::database_metadata::mk_lib_database_metadata_person::mk_lib_database_metadata_person_read(
-           &state.sqlx_pool_ro,
-            String::new(),
-            db_offset,
-            30,
+        let person_list: Vec<TemplateMetaPersonList> = sqlx::query_as(
+            r#"select mm_metadata_person_guid,
+            mm_metadata_person_name,
+            COALESCE(mm_metadata_person_image->>'Poster', '') as mm_metadata_person_image
+            from mm_metadata_person
+            order by LOWER(mm_metadata_person_name)
+            offset $1 limit $2"#,
         )
+        .bind(db_offset)
+        .bind(30_i64)
+        .fetch_all(&state.sqlx_pool_ro)
         .await
         .unwrap();
-        let mut template_data_exists = false;
-        if person_list.len() > 0 {
-            template_data_exists = true;
-        }
+        let template_data_exists = !person_list.is_empty();
         let page_usize = page as usize;
         let template = TemplateMetaPersonContext {
             template_data: &person_list,
@@ -101,10 +104,10 @@ struct TemplateMetaPersonDetailContext {
 }
 
 pub async fn user_metadata_person_detail(
-    State(state): State<AppState>,
+    State(_state): State<AppState>,
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
-    Path(guid): Path<uuid::Uuid>,
+    Path(_guid): Path<uuid::Uuid>,
 ) -> impl IntoResponse {
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_person.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_person.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
 use sqlx::postgres::PgRow;
 use sqlx::types::Uuid;
-use sqlx::FromRow;
 
 pub async fn mk_lib_database_metadata_exists_person(
     sqlx_pool: &sqlx::PgPool,
@@ -53,7 +53,11 @@ pub async fn mk_lib_database_metadata_person_read(
     // TODO order by birth date
     if !search_value.is_empty() {
         sqlx::query_as(
-            r#"select mm_metadata_person_guid, mm_metadata_person_name, mm_metadata_person_image, mm_metadata_person_meta_json->>'profile_path' as mm_metadata_person_profile from mm_metadata_person where mm_metadata_person_name &@ $1 offset $2 limit $3"#,
+            r#"select mm_metadata_person_guid,
+            mm_metadata_person_name,
+            COALESCE(mm_metadata_person_image->>'Poster', '') as mm_metadata_person_image,
+            mm_metadata_person_meta_json->>'profile_path' as mm_metadata_person_profile
+            from mm_metadata_person where mm_metadata_person_name &@ $1 offset $2 limit $3"#,
         )
         .bind(search_value)
         .bind(offset)
@@ -62,7 +66,11 @@ pub async fn mk_lib_database_metadata_person_read(
         .await
     } else {
         sqlx::query_as(
-            r#"select mm_metadata_person_guid, mm_metadata_person_name, mm_metadata_person_image, mm_metadata_person_meta_json->>'profile_path' as mm_metadata_person_profile from mm_metadata_person order by LOWER(mm_metadata_person_name) offset $1 limit $2"#,
+            r#"select mm_metadata_person_guid,
+            mm_metadata_person_name,
+            COALESCE(mm_metadata_person_image->>'Poster', '') as mm_metadata_person_image,
+            mm_metadata_person_meta_json->>'profile_path' as mm_metadata_person_profile
+            from mm_metadata_person order by LOWER(mm_metadata_person_name) offset $1 limit $2"#,
         )
         .bind(offset)
         .bind(limit)


### PR DESCRIPTION
### Motivation
- The person metadata list page could return HTTP 500 when rendering images because the code attempted to treat the JSON image column as a plain `String` value and decode the whole JSON payload into templates.
- The goal is a minimal, low-risk change to ensure handlers and DB helpers return a plain poster path string (or empty string) so templates receive stable text values.

### Description
- Changed the DB read query in `mk_lib_database_metadata_person::mk_lib_database_metadata_person_read` to select `COALESCE(mm_metadata_person_image->>'Poster','') as mm_metadata_person_image` so callers receive a plain poster path string instead of raw JSON.
- Updated the web handler `docker/core/mkwebaxum/src/user/metadata/bp_meta_person.rs` to define a concrete `TemplateMetaPersonList` `FromRow` struct and use `sqlx::query_as` with an SQL that returns the `Poster` path, avoiding JSON-to-String decoding at the Rust side.
- Simplified the template existence check to `!person_list.is_empty()` and explicitly ignored unused `State`/`Path` parameters in the person detail handler to avoid warnings while leaving behavior unchanged.

### Testing
- Ran `rustfmt --edition 2024 --check docker/core/mkwebaxum/src/user/metadata/bp_meta_person.rs src/mk_lib_database/src/metadata/mk_lib_database_metadata_person.rs` which passed.
- Attempted `cargo check` but it could not complete in this environment because the private Kellnr registry returned HTTP 403 during dependency resolution, so a full compile check could not be run here.
- Attempted workspace formatting check `cargo fmt --all --manifest-path docker/core/Cargo.toml --check` but it was blocked by workspace/registry resolution errors in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0608955bc8321b89d24567a08b94c)