### PR TITLE
Fix flash response tuples in public auth pages

### DIFF
--- a/docker/core/mkwebaxum/src/public/bp_login.rs
+++ b/docker/core/mkwebaxum/src/public/bp_login.rs
@@ -3,7 +3,6 @@ use crate::mk_lib_database;
 use askama::Template;
 use axum::{
     extract::{Form, State},
-    http::StatusCode,
     response::{Html, IntoResponse, Redirect},
 };
 use axum_flash::{Flash, IncomingFlashes};
@@ -26,7 +25,7 @@ pub async fn public_login(flashes: IncomingFlashes) -> impl IntoResponse {
             .collect(),
     };
     let reply_html = template.render().unwrap();
-    (flashes, StatusCode::OK, Html(reply_html).into_response())
+    (flashes, Html(reply_html))
 }
 
 #[derive(Deserialize)]

--- a/docker/core/mkwebaxum/src/public/bp_register.rs
+++ b/docker/core/mkwebaxum/src/public/bp_register.rs
@@ -3,7 +3,6 @@ use crate::mk_lib_database;
 use askama::Template;
 use axum::{
     extract::{Form, State},
-    http::StatusCode,
     response::{Html, IntoResponse, Redirect},
 };
 use axum_flash::{Flash, IncomingFlashes};
@@ -23,7 +22,7 @@ pub async fn public_register(flashes: IncomingFlashes) -> impl IntoResponse {
             .collect(),
     };
     let reply_html = template.render().unwrap();
-    (flashes, StatusCode::OK, Html(reply_html).into_response())
+    (flashes, Html(reply_html))
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
### Motivation
- Resolve an `IntoResponseParts` compile error by returning an Axum-compatible response shape from the public auth handlers so the `IncomingFlashes` wrapper and HTML body form a valid response tuple.

### Description
- Remove the explicit `StatusCode::OK` import and `StatusCode::OK` element from the response tuple in `public_register` so the handler now returns `(flashes, Html(reply_html))` instead of `(flashes, StatusCode::OK, Html(...).into_response())` in `docker/core/mkwebaxum/src/public/bp_register.rs`.
- Apply the identical tuple change to `public_login` in `docker/core/mkwebaxum/src/public/bp_login.rs` to keep both public auth pages consistent.

### Testing
- Ran `cargo fmt` in `docker/core/mkwebaxum` which completed (formatting step performed).
- Attempted `cargo check` but dependency resolution was blocked by the configured registry returning HTTP 403 so a full compile could not be completed.
- Attempted `cargo clippy -- -D warnings` but it was also blocked by registry/offline dependency resolution, so linting could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c065330b588321b517093e2e5ea37d)