### PR TITLE
Fix admin server links response type

### DIFF
--- a/docker/core/mkwebaxum/src/admin/bp_server_links.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_server_links.rs
@@ -82,7 +82,7 @@ pub async fn admin_server_links_post(
     {
         let template = TemplateError403Context {};
         let reply_html = template.render().unwrap();
-        (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
+        (StatusCode::UNAUTHORIZED, Html(reply_html).into_response()).into_response()
     } else {
         let host_or_ip = input_data.host_or_ip.trim();
         let username = input_data.username.trim();


### PR DESCRIPTION
### Motivation
- Resolve a Rust compile error where the `if` (unauthorized) and `else` branches in `admin_server_links_post` returned incompatible types, causing an `if`/`else` type mismatch during compilation.

### Description
- Return a concrete Axum response from the unauthorized branch by appending `.into_response()` to the `(StatusCode::UNAUTHORIZED, Html(reply_html).into_response())` tuple in `docker/core/mkwebaxum/src/admin/bp_server_links.rs` so both branches yield the same `impl IntoResponse`.

### Testing
- Ran `rustfmt --edition 2024 docker/core/mkwebaxum/src/admin/bp_server_links.rs` which succeeded. 
- Attempted `cargo fmt --manifest-path docker/core/mkwebaxum/Cargo.toml`, `cargo check --manifest-path docker/core/mkwebaxum/Cargo.toml`, and `cargo clippy --manifest-path docker/core/mkwebaxum/Cargo.toml -- -D warnings`, but these could not be completed in this environment because the crate depends on a private `kellnr` registry that is not configured here (commands failed due to registry resolution).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c06554d2f08321b172791619b235ae)