### PR TITLE
Unify bss_user templates with shared user layout

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_user/bss_user_home.html
+++ b/docker/core/mkwebaxum/templates/bss_user/bss_user_home.html
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "layouts/base_user.html" %}
 
-{% include "bss_include_header.html" %}
-
-<body class="bg-gray-900 text-gray-100 font-sans">
-        {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-        <div>
+{% block content %}
+<div>
                 {% if template_data_new_media %}
                 <a href="/user/media/new"><img src="/static/image/new.png" width="200" height="200" loading="lazy" decoding="async"></a>
                 {% endif %}
@@ -130,8 +125,7 @@
                         </div>
                 </section>
         </div>
-        {% include "bss_public/bss_public_footer.html" %}
-               <!-- Alpine.js -->
+<!-- Alpine.js -->
         <script>
                 function mediaApp() {
                         return {
@@ -146,7 +140,4 @@
                         }
                 }
         </script>
-
-</body>
-
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/bss_user_media_search.html
+++ b/docker/core/mkwebaxum/templates/bss_user/bss_user_media_search.html
@@ -1,11 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-    {% include "partials/sidebar_user.html" %}
-    <div></div>
-    {% include "bss_public/bss_public_footer.html" %}
-   </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/bss_user_queue.html
+++ b/docker/core/mkwebaxum/templates/bss_user/bss_user_queue.html
@@ -1,12 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-    <div></div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/hardware/bss_user_hardware.html
+++ b/docker/core/mkwebaxum/templates/bss_user/hardware/bss_user_hardware.html
@@ -1,17 +1,11 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div>
+{% block content %}
+<div>
         {% if template_data_phue_exists %}
         <a href="/user/hardware/phue" id="user_hardware_page">
             <img src="/static/image/light-bulb.png" width="200" height="200">
         </a>
         {% endif %}
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
-</body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/hardware/bss_user_hardware_chromecast.html
+++ b/docker/core/mkwebaxum/templates/bss_user/hardware/bss_user_hardware_chromecast.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-   </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/hardware/bss_user_hardware_phue.html
+++ b/docker/core/mkwebaxum/templates/bss_user/hardware/bss_user_hardware_phue.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div>
+{% block content %}
+<div>
         <div class="container">
             <div class="row">
                 <div class="col">
@@ -27,6 +23,4 @@
             </div>
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/hardware/bss_user_hardware_tvtuner.html
+++ b/docker/core/mkwebaxum/templates/bss_user/hardware/bss_user_hardware_tvtuner.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-    <div>
+{% block content %}
+<div>
         <a href="/user/internet/youtube"><img src="/static/image/internet/youtube-logo.png" width="200" height="200"
                 loading="lazy" decoding="async"></a>
         <a href="/user/internet/vimeo"><img src="/static/image/internet/vimeo_icon_white_on_blue_rounded.png"
@@ -18,6 +14,4 @@
             OpenLibrary
         </a>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_flickr.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_flickr.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div>
+{% block content %}
+<div>
         {% if template_data_exists %}
         <div>
             {# {% for row_data in template_data %}
@@ -23,6 +19,4 @@
         <p id="general_text">No Flickr media found.</p>
         {% endif %}
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_flickr_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_flickr_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-  </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_openlibrary.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_openlibrary.html
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="bg-slate-950 text-slate-100">
-    {% include "bss_user/bss_user_include_menu.html" %}
-    {% include "partials/sidebar_user.html" %}
-
-    <main class="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8" x-data="{ onlyWithCovers: false }">
+{% block content %}
+<main class="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8" x-data="{ onlyWithCovers: false }">
         <section class="mb-6 flex flex-col gap-4 rounded-xl border border-slate-800 bg-slate-900/60 p-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
                 <h1 class="text-2xl font-semibold">OpenLibrary Browse</h1>
@@ -93,8 +88,4 @@
             </div>
         </nav>
     </main>
-
-    {% include "bss_public/bss_public_footer.html" %}
-</body>
-
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_openlibrary_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_openlibrary_detail.html
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="bg-slate-950 text-slate-100">
-    {% include "bss_user/bss_user_include_menu.html" %}
-    {% include "partials/sidebar_user.html" %}
-
-    <main class="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
+{% block content %}
+<main class="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
         <a href="/user/internet/openlibrary/1" class="mb-4 inline-flex rounded-lg border border-slate-600 px-3 py-2 text-sm hover:border-slate-400 hover:bg-slate-800" aria-label="Back to OpenLibrary browse">← Back to browse</a>
 
         <article class="rounded-xl border border-slate-800 bg-slate-900 p-5" x-data="{ showSubjects: true }">
@@ -57,8 +52,4 @@
             </section>
         </article>
     </main>
-
-    {% include "bss_public/bss_public_footer.html" %}
-</body>
-
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_twitch.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_twitch.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-    <div>
+{% block content %}
+<div>
         {% if template_data_exists %}
         <div>
             {#{% for row_data in template_data %}
@@ -23,6 +19,4 @@
         <p id="general_text">No Twitch TV media found.</p>
         {% endif %}
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_twitch_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_twitch_detail.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-  {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-  <div>
+{% block content %}
+<div>
     <div id="twitch-embed"></div>
     <!-- Load the Twitch embed script -->
     <script src="https://embed.twitch.tv/embed/v1.js"></script>
@@ -18,6 +14,4 @@
       });
     </script>
   </div>
-  {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_vimeo.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_vimeo.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-    <div>
+{% block content %}
+<div>
         {% if template_data_exists %}
         <div>
             {#{% for row_data in template_data %}
@@ -22,6 +18,4 @@
         <p id="general_text">No Vimeo media found.</p>
         {% endif %}
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_vimeo_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_vimeo_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-  </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_youtube.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_youtube.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-    <div>
+{% block content %}
+<div>
         {% if template_data_exists %}
         <div>
             {#{% for row_data in template_data %}
@@ -24,6 +20,4 @@
         <p id="general_text">No YouTube media found.</p>
         {% endif %}
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
-</body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_youtube_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_youtube_detail.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div>
+{% block content %}
+<div>
         <form id="SearchForm" class="form form-youtube" method="POST" action="/user/internet/bss_user_internet_youtube"
             role="form">
             <div class="form-group">
@@ -17,8 +13,6 @@
             <source src="http://www.youtube.com/watch?v=" {{template_youtube_video_guid}} type="video/youtube">
         </video>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
-    <script src="/static/videojs/video.min.js"></script>
+<script src="/static/videojs/video.min.js"></script>
     <script src="/static/videojs/Youtube.min.js"></script>
- </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_3d.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_3d.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-  </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_blank_template.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_blank_template.html
@@ -1,20 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
-</head>
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_book.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_book.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div>
+{% block content %}
+<div>
         <div>
             {% if template_data_exists %}
             <div id="filter_media_div">
@@ -88,6 +84,4 @@
             {% endif %}
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
-  </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_book_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_book_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-  </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_cctv.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_cctv.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_game.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_game.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-    {% if template_data_exists %}
+{% block content %}
+{% if template_data_exists %}
     <div id="filter_game_div">
         <form name="media_filter" action="/user/media/game_genre" method="post">
             <p>Media Filters:
@@ -84,6 +80,4 @@
     {% else %}
     <p id="general_text">No game media found.</p>
     {% endif %}
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_game_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_game_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-</body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_game_server.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_game_server.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-</body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_game_server_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_game_server_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_game_system.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_game_system.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-    <div>
+{% block content %}
+<div>
         {% if template_data_exists %}
         {% if pagination_bar != "" %}
         {{ pagination_bar|safe }}
@@ -63,6 +59,4 @@
         <p id="general_text">No game systems found.</p>
         {% endif %}
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_game_system_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_game_system_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_genre_video.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_genre_video.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-    <div>
+{% block content %}
+<div>
         <div>
             {#{% if template_data_exists %}
             <div>
@@ -26,6 +22,4 @@
             {% endif %}#}
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_home_movie.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_home_movie.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div>
+{% block content %}
+<div>
         <div>
             {% if template_data_exists %}
             <div id="filter_homediv">
@@ -77,6 +73,4 @@
             {% endif %}
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
-  </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_home_movie_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_home_movie_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_image_gallery.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_image_gallery.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_iradio.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_iradio.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-  </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_iradio_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_iradio_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-   </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_movie_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_movie_detail.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div>
+{% block content %}
+<div>
         <div class="container">
             <div class="row">
                 <div class="col-xl-12">
@@ -149,6 +145,4 @@
         </div>
         <div></div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
-  </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_music_album.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_music_album.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div></div>
+{% block content %}
+<div></div>
     {% if template_data_exists %}
     <div id="filter_album_div">
         <form name="media_filter" action="/user/media/music_genre" method="post">
@@ -75,6 +71,4 @@
     {% else %}
     <p id="general_text">No music album media found.</p>
     {% endif %}
-    {% include "bss_public/bss_public_footer.html" %}
-     </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_music_album_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_music_album_detail.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-          {% include "partials/sidebar_user.html" %}
-  <div class="row">
+{% block content %}
+<div class="row">
         <div class="col"><img src="/static/image/headphone.png"></div>
         <div class="col">
             <div class="row">
@@ -52,6 +48,4 @@
         </div>
         {% endif %}
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
-  </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_music_video.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_music_video.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div></div>
+{% block content %}
+<div></div>
     {% if template_data_exists %}
     <div id="filter_music_video_div">
         <form name="media_filter" action="/user/media/music_video_genre" method="post">
@@ -75,6 +71,4 @@
     {% else %}
     <p id="general_text">No music video media found.</p>
     {% endif %}
-    {% include "bss_public/bss_public_footer.html" %}
-    </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_music_video_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_music_video_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-  </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_new.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_new.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-   </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_queue.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_queue.html
@@ -1,20 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "layouts/base_user.html" %}
 
-{% include "bss_include_header.html" %}
-
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-   </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_sports.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_sports.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-    <div></div>
+{% block content %}
+<div></div>
     {% if template_data_exists %}
     <div id="filter_sports_div">
         <form name="media_filter" action="/user/media/ports_genre" method="post">
@@ -75,7 +71,4 @@
     {% else %}
     <p id="general_text">No sports media found.</p>
     {% endif %}
-    {% include "bss_public/bss_public_footer.html" %}
- 
-</body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_sports_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_sports_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-   </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_sync.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_sync.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-    <div class="d-flex flex-column" id="content-wrapper">
+{% block content %}
+<div class="d-flex flex-column" id="content-wrapper">
         <div id="content">
             <div class="container-fluid">
                 <fieldset>
@@ -144,8 +140,5 @@
                 </fieldset>
             </div>
         </div>
-        {% include "bss_public/bss_public_footer.html" %}
-    </div>
- 
-</body>
-</html>
+</div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_tv.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_tv.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <!-- this div is needed to show up between pagination correctly -->
+{% block content %}
+<!-- this div is needed to show up between pagination correctly -->
     {% if template_data_exists %}
     <div id="filter_tv_div">
         <form name="media_filter" action="/user/media/tv_genre" method="post">
@@ -75,7 +71,4 @@
     {% else %}
     <p id="general_text">No TV media found.</p>
     {% endif %}
-    {% include "bss_public/bss_public_footer.html" %}
-   
-</body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_tv_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_tv_detail.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-    <div>
+{% block content %}
+<div>
         <div class="row">
             <div class="col"><img src="/static/image/Movie-icon.png"></div>
             <div class="col-xl-9">
@@ -58,7 +54,4 @@
             </div>
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- 
-</body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_tv_episode_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_tv_episode_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-   </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_tv_live.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_tv_live.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-</body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_tv_season_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_tv_season_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-    </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_book.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_book.html
@@ -1,18 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "layouts/base_user.html" %}
 
-{% include "bss_include_header.html" %}
-
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div>
+{% block content %}
+<div>
                 {% if template_data_exists %}
                 {% if pagination_bar != "" %}
                 {{ pagination_bar|safe }}
@@ -38,9 +27,4 @@
                 <p id="general_text">No periodical metadata found.</p>
                 {% endif %}
             </div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-</body>
-
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_book_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_book_detail.html
@@ -1,21 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "layouts/base_user.html" %}
 
-{% include "bss_include_header.html" %}
-
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_game.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_game.html
@@ -1,18 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "layouts/base_user.html" %}
 
-{% include "bss_include_header.html" %}
-
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div>
+{% block content %}
+<div>
                 {% if template_data_exists %}
                 {% if pagination_bar != "" %}
                 {{ pagination_bar|safe }}
@@ -48,10 +37,4 @@
                 <p id="general_text">No game metadata found.</p>
                 {% endif %}
             </div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-   
-</body>
-
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_game_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_game_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_game_system.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_game_system.html
@@ -1,18 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "layouts/base_user.html" %}
 
-{% include "bss_include_header.html" %}
-
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div>
+{% block content %}
+<div>
                 {% if template_data_exists %}
                 {% if pagination_bar != "" %}
                 {{ pagination_bar|safe }}
@@ -44,10 +33,4 @@
                 <p id="general_text">No game system metadata found.</p>
                 {% endif %}
             </div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
- 
-</body>
-
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_game_system_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_game_system_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-   </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_collection.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_collection.html
@@ -1,18 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "layouts/base_user.html" %}
 
-{% include "bss_include_header.html" %}
-
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div>
+{% block content %}
+<div>
                 {% if template_data_exists %}
                 {% if pagination_bar != "" %}
                 {{ pagination_bar|safe }}
@@ -45,10 +34,4 @@
                 <p id="general_text">No collection metadata found.</p>
                 {% endif %}
             </div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-
-</body>
-
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_collection_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_collection_detail.html
@@ -1,18 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "layouts/base_user.html" %}
 
-{% include "bss_include_header.html" %}
-
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div>
+{% block content %}
+<div>
                 {% if template_data_exists %}
                 <div id="movie_detail">
                     <img alt="fs_bg_image" src="/static/data_background_image.png" loading="lazy" decoding="async"
@@ -52,10 +41,4 @@
                 <p id="general_text">No info found. ERROR! You should never see this message.</p>
                 {% endif %}
             </div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-  
-</body>
-
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail copy.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail copy.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div>
+{% block content %}
+<div>
         <div>
             <div>
                 <div class="container">
@@ -86,7 +82,4 @@
             </div>
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- 
-</body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_music_album.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_music_album.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div>
+{% block content %}
+<div>
         <div>
             {% if template_data_exists %}
             {% if pagination_bar != "" %}
@@ -33,6 +29,4 @@
             {% endif %}
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
-</body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_music_album_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_music_album_detail.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-    <div>
+{% block content %}
+<div>
         <div class="row">
             <div class="col"><img style="width: 600px;height: 600px;"></div>
             <div class="col">
@@ -27,7 +23,4 @@
             </div>
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
-  
-</body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_music_video.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_music_video.html
@@ -1,17 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div>
+{% block content %}
+<div>
             {% if template_data_exists %}
             {% if pagination_bar != "" %}
             {{ pagination_bar|safe }}
@@ -49,9 +39,4 @@
             <p id="general_text">No music video metadata found.</p>
             {% endif %}
             </div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-</body>
-
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_music_video_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_music_video_detail.html
@@ -1,23 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "layouts/base_user.html" %}
 
-{% include "bss_include_header.html" %}
-
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div>
+{% block content %}
+<div>
 
             </div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-</body>
-
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_person.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_person.html
@@ -1,18 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "layouts/base_user.html" %}
 
-{% include "bss_include_header.html" %}
-
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            {% if template_data_exists %}
+{% block content %}
+{% if template_data_exists %}
             {% if pagination_bar != "" %}
             {{ pagination_bar|safe }}
             {% endif %}
@@ -36,10 +25,4 @@
             {% else %}
             <p id="general_text">No people metadata found.</p>
             {% endif %}
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-
-</body>
-
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_person_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_person_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-    </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_sports.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_sports.html
@@ -1,17 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div>
+{% block content %}
+<div>
                 {% if template_data_exists %}
                 {% if pagination_bar != "" %}
                 {{ pagination_bar|safe }}
@@ -48,9 +38,4 @@
                 <p id="general_text">No sporting event metadata found.</p>
                 {% endif %}
             </div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-</body>
-
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_sports_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_sports_detail.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div>
+{% block content %}
+<div>
         <div>
             {% if template_data_exists %}
             <div class="table-responsive">
@@ -36,7 +32,4 @@
             {% endif %}
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- 
-</body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_tv.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_tv.html
@@ -1,18 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
+{% extends "layouts/base_user.html" %}
 
-{% include "bss_include_header.html" %}
-
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-  <!-- Top navbar -->
-  {% include "bss_user/bss_user_include_menu.html" %}
-  <!-- Below top nav -->
-  <div class="flex flex-1">
-    <!-- Left sidebar -->
-    {% include "partials/sidebar_user.html" %}
-    <!-- Main content -->
-    <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-      <div>
+{% block content %}
+<div>
         {% if template_data_exists %}
 
         <!-- Pagination top -->
@@ -68,9 +57,4 @@
         <p id="general_text" class="text-center text-gray-500">No TV show metadata found.</p>
         {% endif %}
       </div>
-    </main>
-  </div>
-  {% include "bss_public/bss_public_footer.html" %}
-</body>
-
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_tv_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_tv_detail.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-    <div>
+{% block content %}
+<div>
         <div class="row">
             <div class="col"><img src="/static/image/Movie-icon.png"></div>
             <div class="col-xl-9">
@@ -58,7 +54,4 @@
             </div>
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
-  
-</body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_tv_episode_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_tv_episode_detail.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-    </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_tv_season_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_tv_season_detail.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div>
+{% block content %}
+<div>
         <div>
             {% if template_data_exists %}
             {% if pagination_bar != "" %}
@@ -38,7 +34,4 @@
             {% endif %}
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- 
-</body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/playback/bss_user_playback_album.html
+++ b/docker/core/mkwebaxum/templates/bss_user/playback/bss_user_playback_album.html
@@ -1,13 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-
-
-    {% include "bss_public/bss_public_footer.html" %}
-    <script src="/static/videojs/video.min.js"></script>
-</body>
-</html>
+{% block content %}
+<script src="/static/videojs/video.min.js"></script>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/playback/bss_user_playback_comic.html
+++ b/docker/core/mkwebaxum/templates/bss_user/playback/bss_user_playback_comic.html
@@ -1,13 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-
-
-    {% include "bss_public/bss_public_footer.html" %}
-    <script src="/static/videojs/video.min.js"></script>
- </body>
-</html>
+{% block content %}
+<script src="/static/videojs/video.min.js"></script>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/playback/bss_user_playback_video.html
+++ b/docker/core/mkwebaxum/templates/bss_user/playback/bss_user_playback_video.html
@@ -1,14 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-
-        {% include "partials/sidebar_user.html" %}
-
-    {% include "bss_public/bss_public_footer.html" %}
-    <script src="/static/videojs/video.min.js"></script>
+{% block content %}
+<script src="/static/videojs/video.min.js"></script>
     <script src="/static/videojs/Youtube.min.js"></script>
- </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_baseball.html
+++ b/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_baseball.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-    <div></div>
+{% block content %}
+<div></div>
     <div class="container">
         <div class="row">
             <div class="col-xl-12">
@@ -118,6 +114,4 @@
             </div>
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_basketball.html
+++ b/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_basketball.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-        {% include "partials/sidebar_user.html" %}
-    <div></div>
+{% block content %}
+<div></div>
     <div class="container">
         <div class="row">
             <div class="col-xl-12">
@@ -118,6 +114,4 @@
             </div>
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_boxing.html
+++ b/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_boxing.html
@@ -1,20 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    
-    {% include "bss_public/bss_public_footer.html" %}
-     </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_cricket.html
+++ b/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_cricket.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-    </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_football.html
+++ b/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_football.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div></div>
+{% block content %}
+<div></div>
     <div class="container">
         <div class="row">
             <div class="col-xl-12">
@@ -119,6 +115,4 @@
             </div>
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
-  </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_football_usa.html
+++ b/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_football_usa.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div></div>
+{% block content %}
+<div></div>
     <div class="container">
         <div class="row">
             <div class="col-xl-12">
@@ -119,6 +115,4 @@
             </div>
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- </body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_golf.html
+++ b/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_golf.html
@@ -1,19 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-   </body>
-</html>
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_hockey.html
+++ b/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_hockey.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div>
+{% block content %}
+<div>
         <div class="container">
             <div class="row">
                 <div class="col-xl-12">
@@ -122,7 +118,4 @@
             </div>
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- 
-</body>
-</html>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_mma.html
+++ b/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_mma.html
@@ -1,18 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
-<body class="min-h-screen flex flex-col bg-gray-100 text-gray-900">
-    <!-- Top navbar -->
-    {% include "bss_user/bss_user_include_menu.html" %}
-    <!-- Below top nav -->
-    <div class="flex flex-1">
-        <!-- Left sidebar -->
-        {% include "partials/sidebar_user.html" %}
-        <!-- Main content -->
-        <main class="flex-1 p-6 bg-gray-50 overflow-y-auto">
-            <div></div>
-        </main>
-    </div>
-    {% include "bss_public/bss_public_footer.html" %}
-   </body>
-</html>
+{% extends "layouts/base_user.html" %}
+
+{% block content %}
+<div></div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_motorsports.html
+++ b/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_motorsports.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div>
+{% block content %}
+<div>
         <div class="container">
             <div class="row">
                 <div class="col-xl-12">
@@ -126,8 +122,5 @@
                 </div>
             </div>
         </div>
-        {% include "bss_public/bss_public_footer.html" %}
-    </div>
-  
-</body>
-</html>
+</div>
+{% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_rugby.html
+++ b/docker/core/mkwebaxum/templates/bss_user/sports_detail/bss_user_media_sports_detail_rugby.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-{% include "bss_include_header.html" %}
+{% extends "layouts/base_user.html" %}
 
-<body>
-    {% include "bss_user/bss_user_include_menu.html" %}
-         {% include "partials/sidebar_user.html" %}
-   <div></div>
+{% block content %}
+<div></div>
     <div class="container">
         <div class="row">
             <div class="col-xl-12">
@@ -119,7 +115,4 @@
             </div>
         </div>
     </div>
-    {% include "bss_public/bss_public_footer.html" %}
- 
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
### Motivation
- Consolidate `bss_user` templates to use the same sidebar and Alpine dark/light controls already provided to metadata movie pages by `layouts/base_user.html`. 
- Remove duplicated per-template header/menu/sidebar/footer shells so those concerns are centralized in the base layout and templates only supply page-specific content.

### Description
- Converted 85 `bss_user` templates under `docker/core/mkwebaxum/templates/bss_user` to extend the shared layout by adding `{% extends "layouts/base_user.html" %}` and wrapping page content in `{% block content %}...{% endblock %}`. 
- Removed duplicated includes from those templates (`bss_include_header.html`, `bss_user/bss_user_include_menu.html`, `partials/sidebar_user.html`, and `bss_public/bss_public_footer.html`) so the shared `sidebar_user` partial and the Alpine theme toggle in `layouts/base_user.html` provide consistent behavior. 
- Kept each template's existing page-specific markup intact (minimal, non-destructive changes) and normalized a small set of wrapper patterns to eliminate nesting introduced by the legacy shells. 
- Changes committed as `Unify bss_user templates with base layout` (HEAD: `c4a58fcb`). Diff: 85 files changed, 345 insertions(+), 1246 deletions(-).

### Testing
- Verified every converted template now extends the base layout using a Python check: `python -c "...missing_extends..."`, which reported `missing_extends=0` (success). 
- Confirmed legacy header/menu/sidebar/footer includes were removed via `rg` searches for `bss_user_include_menu|bss_public_footer|bss_include_header` in the `bss_user` templates (no matches after conversion). 
- Inspected `git diff --stat` and committed the change (`git commit -m "Unify bss_user templates with base layout"`) which recorded the 85-file update (success). 
- Attempted Rust tooling checks (`cargo fmt`, `cargo check`, `cargo clippy` with `--manifest-path docker/core/mkwebaxum/Cargo.toml`) but these were blocked in this environment because the crate manifest depends on an unavailable registry (`kellnr`); those checks could not be completed here (blocked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c08a9c037c83219fe2b6b671dcccd4)