### PR TITLE
Add primary language and user status filters to movie metadata listing

### DIFF
--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
@@ -30,6 +30,12 @@ pub struct Genre {
     pub query_value: String,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FilterOption {
+    pub label: String,
+    pub query_value: String,
+}
+
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
 struct TemplateError401Context {}
@@ -65,6 +71,11 @@ struct TemplateMetaMovieContext<'a> {
     pub current: Option<String>,
     pub genre_filter: Option<String>,
     pub genre_filter_query: Option<String>,
+    pub primary_language_filter: Option<String>,
+    pub status_filter: Option<String>,
+    pub status_options: &'a Vec<FilterOption>,
+    pub primary_language_options: &'a Vec<FilterOption>,
+    pub filter_query_suffix: String,
     pub base_path: String,
 }
 
@@ -72,6 +83,8 @@ struct TemplateMetaMovieContext<'a> {
 pub struct FilterQuery {
     pub starts_with: Option<String>,
     pub genre: Option<String>,
+    pub primary_language: Option<String>,
+    pub status: Option<String>,
 }
 
 fn normalize_starts_with(raw: Option<&str>) -> Option<String> {
@@ -89,11 +102,60 @@ fn normalize_starts_with(raw: Option<&str>) -> Option<String> {
     Some("#".to_string())
 }
 
+fn normalize_string_filter(raw: Option<&str>) -> Option<String> {
+    raw.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn normalize_status_filter(raw: Option<&str>) -> Option<String> {
+    let value = raw.map(str::trim).filter(|value| !value.is_empty())?;
+    match value {
+        "favorite" | "watched" | "good" | "bad" | "trash" => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn build_filter_query_suffix(
+    starts_with: Option<&str>,
+    genre: Option<&str>,
+    primary_language: Option<&str>,
+    status_filter: Option<&str>,
+) -> String {
+    let mut query_params: Vec<String> = Vec::new();
+    if let Some(sw) = starts_with.filter(|sw| !sw.is_empty()) {
+        if sw == "#" {
+            query_params.push("starts_with=%23".to_string());
+        } else {
+            query_params.push(format!("starts_with={sw}"));
+        }
+    }
+    if let Some(genre_name) = genre.filter(|genre_name| !genre_name.is_empty()) {
+        query_params.push(format!("genre={}", urlencoding::encode(genre_name)));
+    }
+    if let Some(language) = primary_language.filter(|language| !language.is_empty()) {
+        query_params.push(format!(
+            "primary_language={}",
+            urlencoding::encode(language)
+        ));
+    }
+    if let Some(status) = status_filter.filter(|status| !status.is_empty()) {
+        query_params.push(format!("status={}", urlencoding::encode(status)));
+    }
+    if query_params.is_empty() {
+        String::new()
+    } else {
+        format!("?{}", query_params.join("&"))
+    }
+}
+
 fn build_movie_pagination(
     total_items: i64,
     page: i64,
     starts_with: Option<&str>,
     genre: Option<&str>,
+    primary_language: Option<&str>,
+    status_filter: Option<&str>,
 ) -> Result<String, std::fmt::Error> {
     let total_pages = if total_items > 0 {
         (total_items + 29) / 30
@@ -110,23 +172,7 @@ fn build_movie_pagination(
 <ul class="flex items-center gap-1 whitespace-nowrap text-sm">"#,
     );
 
-    let mut query_params: Vec<String> = Vec::new();
-    if let Some(sw) = starts_with.filter(|sw| !sw.is_empty()) {
-        if sw == "#" {
-            query_params.push("starts_with=%23".to_string());
-        } else {
-            query_params.push(format!("starts_with={sw}"));
-        }
-    }
-    if let Some(genre_name) = genre.filter(|genre_name| !genre_name.is_empty()) {
-        query_params.push(format!("genre={}", urlencoding::encode(genre_name)));
-    }
-
-    let suffix = if query_params.is_empty() {
-        String::new()
-    } else {
-        format!("?{}", query_params.join("&"))
-    };
+    let suffix = build_filter_query_suffix(starts_with, genre, primary_language, status_filter);
 
     if total_pages == 1 {
         write!(
@@ -207,12 +253,10 @@ pub async fn user_metadata_movie(
     Query(params): Query<FilterQuery>,
 ) -> impl IntoResponse {
     let starts_with = normalize_starts_with(params.starts_with.as_deref());
-    let genre = params
-        .genre
-        .as_deref()
-        .map(str::trim)
-        .filter(|genre| !genre.is_empty())
-        .map(ToOwned::to_owned);
+    let genre = normalize_string_filter(params.genre.as_deref());
+    let primary_language = normalize_string_filter(params.primary_language.as_deref())
+        .map(|value| value.to_lowercase());
+    let status_filter = normalize_status_filter(params.status.as_deref());
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
         [Method::GET],
@@ -232,14 +276,63 @@ pub async fn user_metadata_movie(
         mk_lib_database::database_metadata::mk_lib_database_metadata_movie::mk_lib_database_metadata_movie_count(
            &state.sqlx_pool_ro,
             String::new(),
+            current_user.id,
             starts_with.clone().unwrap_or_default(),
             genre.clone().unwrap_or_default(),
+            primary_language.clone().unwrap_or_default(),
+            status_filter.clone().unwrap_or_default(),
         )
         .await
         .unwrap();
-        let pagination_html =
-            build_movie_pagination(total_pages, page, starts_with.as_deref(), genre.as_deref())
-                .unwrap();
+        let pagination_html = build_movie_pagination(
+            total_pages,
+            page,
+            starts_with.as_deref(),
+            genre.as_deref(),
+            primary_language.as_deref(),
+            status_filter.as_deref(),
+        )
+        .unwrap();
+        let primary_language_options: Vec<FilterOption> =
+            mk_lib_database::database_metadata::mk_lib_database_metadata_movie::mk_lib_database_metadata_movie_languages(
+                &state.sqlx_pool_ro,
+            )
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|row| FilterOption {
+                label: row.primary_language.to_uppercase(),
+                query_value: row.primary_language,
+            })
+            .collect();
+        let status_options = vec![
+            FilterOption {
+                label: "Favorite".to_string(),
+                query_value: "favorite".to_string(),
+            },
+            FilterOption {
+                label: "Watched".to_string(),
+                query_value: "watched".to_string(),
+            },
+            FilterOption {
+                label: "Good".to_string(),
+                query_value: "good".to_string(),
+            },
+            FilterOption {
+                label: "Bad".to_string(),
+                query_value: "bad".to_string(),
+            },
+            FilterOption {
+                label: "Trash".to_string(),
+                query_value: "trash".to_string(),
+            },
+        ];
+        let filter_query_suffix = build_filter_query_suffix(
+            starts_with.as_deref(),
+            genre.as_deref(),
+            primary_language.as_deref(),
+            status_filter.as_deref(),
+        );
         let movie_list =
         mk_lib_database::database_metadata::mk_lib_database_metadata_movie::mk_lib_database_metadata_movie_read(
             &state.sqlx_pool_ro,
@@ -247,6 +340,8 @@ pub async fn user_metadata_movie(
             current_user.id,
             starts_with.clone().unwrap_or_default(),
             genre.clone().unwrap_or_default(),
+            primary_language.clone().unwrap_or_default(),
+            status_filter.clone().unwrap_or_default(),
             db_offset,
             30,
         )
@@ -342,6 +437,11 @@ pub async fn user_metadata_movie(
             genre_filter_query: genre
                 .as_ref()
                 .map(|value| urlencoding::encode(value).into_owned()),
+            primary_language_filter: primary_language.clone(),
+            status_filter: status_filter.clone(),
+            status_options: &status_options,
+            primary_language_options: &primary_language_options,
+            filter_query_suffix,
             base_path: "/user/metadata/movie".to_string(),
         };
         let reply_html = template.render().unwrap();

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html
@@ -5,6 +5,35 @@
 <section class="w-full px-0 py-4 text-zinc-900 dark:text-zinc-100">
   <h1 id="movie-grid-heading" class="sr-only">Movie list</h1>
   {% include "filters/pagination_letters.html" %}
+
+  <div class="mt-4 space-y-4 rounded-xl border border-zinc-200 bg-white/70 p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900/70">
+    <div class="space-y-2">
+      <h2 class="text-sm font-semibold tracking-wide text-zinc-700 dark:text-zinc-200">Primary language</h2>
+      <div class="flex flex-wrap gap-2">
+        {% for option in primary_language_options %}
+        <a href="{{ base_path }}/1?{% if let Some(current_filter) = current %}starts_with={% if current_filter == "#" %}%23{% else %}{{ current_filter }}{% endif %}&{% endif %}{% if let Some(genre_name) = genre_filter_query %}genre={{ genre_name }}&{% endif %}primary_language={{ option.query_value }}{% if let Some(status_value) = status_filter %}&status={{ status_value }}{% endif %}"
+           class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors {% if let Some(active_primary_language) = primary_language_filter %}{% if active_primary_language == option.query_value %}border-indigo-600 bg-indigo-600 text-white{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}"
+           aria-label="Filter movies by primary language {{ option.label }}">
+          {{ option.label }}
+        </a>
+        {% endfor %}
+      </div>
+    </div>
+
+    <div class="space-y-2">
+      <h2 class="text-sm font-semibold tracking-wide text-zinc-700 dark:text-zinc-200">User status</h2>
+      <div class="flex flex-wrap gap-2">
+        {% for option in status_options %}
+        <a href="{{ base_path }}/1?{% if let Some(current_filter) = current %}starts_with={% if current_filter == "#" %}%23{% else %}{{ current_filter }}{% endif %}&{% endif %}{% if let Some(genre_name) = genre_filter_query %}genre={{ genre_name }}&{% endif %}{% if let Some(language_value) = primary_language_filter %}primary_language={{ language_value }}&{% endif %}status={{ option.query_value }}"
+           class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium capitalize transition-colors {% if let Some(active_status) = status_filter %}{% if active_status == option.query_value %}border-indigo-600 bg-indigo-600 text-white{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}"
+           aria-label="Filter movies by user status {{ option.label }}">
+          {{ option.label }}
+        </a>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+
   {% if template_data_exists %}
   {% if pagination_bar != "" %}
   {{ pagination_bar|safe }}

--- a/docker/core/mkwebaxum/templates/cards/movie_card.html
+++ b/docker/core/mkwebaxum/templates/cards/movie_card.html
@@ -83,7 +83,7 @@
 
         <div class="flex flex-wrap gap-1 mt-1">
             {% for genre in row_data.template_metadata_genre %}
-                <a href="/user/metadata/movie/1?genre={{ genre.query_value }}"
+                <a href="/user/metadata/movie/1?genre={{ genre.query_value }}{% if let Some(primary_language) = primary_language_filter %}&primary_language={{ primary_language }}{% endif %}{% if let Some(status_value) = status_filter %}&status={{ status_value }}{% endif %}"
                    class="px-1.5 py-0.5 text-[10px] rounded bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors"
                    aria-label="Filter movies by genre {{ genre.name }}">
                     {{ genre.name }}

--- a/docker/core/mkwebaxum/templates/filters/pagination_letters.html
+++ b/docker/core/mkwebaxum/templates/filters/pagination_letters.html
@@ -5,7 +5,7 @@
 
     <!-- # Symbols -->
     <li>
-      <a href="{{ base_path }}/1?starts_with=%23{% if let Some(genre_name) = genre_filter_query %}&genre={{ genre_name }}{% endif %}"
+      <a href="{{ base_path }}/1?starts_with=%23{% if let Some(genre_name) = genre_filter_query %}&genre={{ genre_name }}{% endif %}{% if let Some(primary_language) = primary_language_filter %}&primary_language={{ primary_language }}{% endif %}{% if let Some(status_value) = status_filter %}&status={{ status_value }}{% endif %}"
          class="px-2 py-1.5 rounded-md transition-colors
          {% if current == Some("#".to_string()) %}
             bg-indigo-600 text-white
@@ -19,7 +19,7 @@
     <!-- Numbers -->
     {% for n in 0..10 %}
     <li>
-      <a href="{{ base_path }}/1?starts_with={{ n }}{% if let Some(genre_name) = genre_filter_query %}&genre={{ genre_name }}{% endif %}"
+      <a href="{{ base_path }}/1?starts_with={{ n }}{% if let Some(genre_name) = genre_filter_query %}&genre={{ genre_name }}{% endif %}{% if let Some(primary_language) = primary_language_filter %}&primary_language={{ primary_language }}{% endif %}{% if let Some(status_value) = status_filter %}&status={{ status_value }}{% endif %}"
          class="px-2 py-1.5 rounded-md transition-colors
          {% if current == Some(n.to_string()) %}
             bg-indigo-600 text-white
@@ -34,7 +34,7 @@
     <!-- Letters -->
     {% for c in 'A'..='Z' %}
     <li>
-      <a href="{{ base_path }}/1?starts_with={{ c }}{% if let Some(genre_name) = genre_filter_query %}&genre={{ genre_name }}{% endif %}"
+      <a href="{{ base_path }}/1?starts_with={{ c }}{% if let Some(genre_name) = genre_filter_query %}&genre={{ genre_name }}{% endif %}{% if let Some(primary_language) = primary_language_filter %}&primary_language={{ primary_language }}{% endif %}{% if let Some(status_value) = status_filter %}&status={{ status_value }}{% endif %}"
          class="px-2 py-1.5 rounded-md transition-colors
          {% if current == Some(c.to_string()) %}
             bg-indigo-600 text-white
@@ -49,7 +49,7 @@
   </ul>
 </nav>
 
-{% if current.is_some() || genre_filter.is_some() %}
+{% if current.is_some() || genre_filter.is_some() || primary_language_filter.is_some() || status_filter.is_some() %}
 <div class="mt-3 flex justify-center">
   <a href="{{ base_path }}/1"
      class="inline-flex items-center rounded-md border border-zinc-300 px-3 py-1.5 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs
@@ -41,6 +41,8 @@ pub async fn mk_lib_database_metadata_movie_read(
     user_id: i64,
     starts_with: String,
     genre_name: String,
+    primary_language: String,
+    status_filter: String,
     offset: i64,
     limit: i64,
 ) -> Result<Vec<DBMetaMovieList>, sqlx::Error> {
@@ -74,12 +76,22 @@ pub async fn mk_lib_database_metadata_movie_read(
                     WHERE lower(genre->>'name') = lower($4)
                 )
              )
-             offset $5 limit $6"#,
+             AND (
+                $5 = ''
+                OR lower(mm_metadata_movie_json->>'original_language') = lower($5)
+             )
+             AND (
+                $6 = ''
+                OR COALESCE((mm_status_user_json->>$6)::boolean, false)
+             )
+             offset $7 limit $8"#,
         )
         .bind(&user_id)
          .bind(&search_value)
         .bind(&search_value)
         .bind(&genre_name)
+        .bind(&primary_language)
+        .bind(&status_filter)
         .bind(offset)
         .bind(limit)
             .fetch_all(sqlx_pool)
@@ -113,12 +125,22 @@ pub async fn mk_lib_database_metadata_movie_read(
                     WHERE lower(genre->>'name') = lower($3)
                 )
             )
+            AND (
+                $4 = ''
+                OR lower(mm_metadata_movie_json->>'original_language') = lower($4)
+            )
+            AND (
+                $5 = ''
+                OR COALESCE((mm_status_user_json->>$5)::boolean, false)
+            )
             order by LOWER(mm_metadata_movie_name), mm_date
-            offset $4 limit $5"#,
+            offset $6 limit $7"#,
         )
         .bind(&user_id)
          .bind(&starts_with)
         .bind(&genre_name)
+        .bind(&primary_language)
+        .bind(&status_filter)
         .bind(offset)
         .bind(limit)
             .fetch_all(sqlx_pool)
@@ -126,48 +148,97 @@ pub async fn mk_lib_database_metadata_movie_read(
     }
 }
 
+#[derive(Debug, FromRow, Deserialize, Serialize)]
+pub struct DBMetaMoviePrimaryLanguage {
+    pub primary_language: String,
+}
+
+pub async fn mk_lib_database_metadata_movie_languages(
+    sqlx_pool: &sqlx::PgPool,
+) -> Result<Vec<DBMetaMoviePrimaryLanguage>, sqlx::Error> {
+    sqlx::query_as(
+        r#"select distinct lower(mm_metadata_movie_json->>'original_language') as primary_language
+        from mm_metadata_movie
+        where coalesce(mm_metadata_movie_json->>'original_language', '') <> ''
+        order by lower(mm_metadata_movie_json->>'original_language')"#,
+    )
+    .fetch_all(sqlx_pool)
+    .await
+}
+
 pub async fn mk_lib_database_metadata_movie_count(
     sqlx_pool: &sqlx::PgPool,
     search_value: String,
+    user_id: i64,
     starts_with: String,
     genre_name: String,
+    primary_language: String,
+    status_filter: String,
 ) -> Result<i64, sqlx::Error> {
     if !search_value.is_empty() {
         let row: (i64,) = sqlx::query_as(
             r#"select count(*) from mm_metadata_movie
-            where mm_metadata_movie_name &@ $1
+            LEFT JOIN mm_metadata_user_status
+            ON mm_metadata_user_status.mm_status_type_movie = mm_metadata_movie.mm_metadata_movie_guid
+            and mm_metadata_user_status.mm_status_user_id = $1
+            where mm_metadata_movie_name &@ $2
             AND (
-                $2 = ''
+                $3 = ''
                 OR EXISTS (
                     SELECT 1
                     FROM jsonb_array_elements(mm_metadata_movie_json->'genres') AS genre
-                    WHERE lower(genre->>'name') = lower($2)
+                    WHERE lower(genre->>'name') = lower($3)
                 )
+            )
+            AND (
+                $4 = ''
+                OR lower(mm_metadata_movie_json->>'original_language') = lower($4)
+            )
+            AND (
+                $5 = ''
+                OR COALESCE((mm_status_user_json->>$5)::boolean, false)
             )"#,
         )
+        .bind(user_id)
         .bind(search_value)
         .bind(genre_name)
+        .bind(primary_language)
+        .bind(status_filter)
         .fetch_one(sqlx_pool)
         .await?;
         Ok(row.0)
     } else {
         let row: (i64,) = sqlx::query_as(
             r#"select count(*) from mm_metadata_movie 
+            LEFT JOIN mm_metadata_user_status
+            ON mm_metadata_user_status.mm_status_type_movie = mm_metadata_movie.mm_metadata_movie_guid
+            and mm_metadata_user_status.mm_status_user_id = $1
             WHERE (
-                ($1 = '#' AND left(lower(mm_metadata_movie_name), 1) !~ '^[a-z0-9]$')
-                OR ($1 <> '#' AND lower(mm_metadata_movie_name) LIKE lower($1) || '%')
+                ($2 = '#' AND left(lower(mm_metadata_movie_name), 1) !~ '^[a-z0-9]$')
+                OR ($2 <> '#' AND lower(mm_metadata_movie_name) LIKE lower($2) || '%')
             )
             AND (
-                $2 = ''
+                $3 = ''
                 OR EXISTS (
                     SELECT 1
                     FROM jsonb_array_elements(mm_metadata_movie_json->'genres') AS genre
-                    WHERE lower(genre->>'name') = lower($2)
+                    WHERE lower(genre->>'name') = lower($3)
                 )
+            )
+            AND (
+                $4 = ''
+                OR lower(mm_metadata_movie_json->>'original_language') = lower($4)
+            )
+            AND (
+                $5 = ''
+                OR COALESCE((mm_status_user_json->>$5)::boolean, false)
             )"#,
         )
+        .bind(user_id)
         .bind(starts_with)
         .bind(genre_name)
+        .bind(primary_language)
+        .bind(status_filter)
         .fetch_one(sqlx_pool)
         .await?;
         Ok(row.0)


### PR DESCRIPTION
### Motivation
- Provide additional filtering on the movie metadata listing so users can filter by primary language and by user status (favorite/watched/good/bad/trash) and persist those filters through pagination and UI links.

### Description
- Add `FilterOption` struct, context fields for `primary_language` and `status`, normalization helpers, `build_filter_query_suffix`, and wire these into the `TemplateMetaMovieContext` and handler state.
- Update the `user_metadata_movie` handler to parse `primary_language` and `status` query params, fetch available primary languages via `mk_lib_database_metadata_movie_languages`, construct status options, and supply a filter query suffix and updated pagination HTML.
- Extend pagination logic to include the new filters via `build_filter_query_suffix` and propagate filter params into cards, pagination letters, and filter UI templates.
- Modify database layer in `mk_lib_database_metadata_movie` to accept `primary_language` and `status_filter`, apply them in the `read` and `count` queries, add `mk_lib_database_metadata_movie_languages` to list available languages, and adjust joins to include user status lookup by `user_id`.

### Testing
- Ran `cargo build` across the workspace and `cargo test`, and the build and automated test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c097a19f048321a61e00b15733e5ca)