### PR TITLE
Fix movie title search metadata call

### DIFF
--- a/docker/core/mkwebaxum/src/api/bp_api_title_search.rs
+++ b/docker/core/mkwebaxum/src/api/bp_api_title_search.rs
@@ -55,10 +55,18 @@ pub async fn api_title_search(
     } else {
         let title = title.replace("%20", " ");
         let movie_metadata = mk_lib_database::database_metadata::mk_lib_database_metadata_movie::mk_lib_database_metadata_movie_read(
-        &state.sqlx_pool_ro, title.clone(), current_user.id, "a".to_string(), String::new(), 0, 100
-    )
-    .await
-    .unwrap();
+            &state.sqlx_pool_ro,
+            title.clone(),
+            current_user.id,
+            "a".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+            0,
+            100,
+        )
+        .await
+        .unwrap();
         let tv_metadata = mk_lib_database::database_metadata::mk_lib_database_metadata_tv::mk_lib_database_metadata_tv_read(
         &state.sqlx_pool_ro, title.clone(), 0, 100
     )


### PR DESCRIPTION
### Motivation
- Resolve a compiler error from calling `mk_lib_database_metadata_movie_read` with too few arguments by supplying the newly-required filter parameters while preserving existing unfiltered behavior.

### Description
- In `docker/core/mkwebaxum/src/api/bp_api_title_search.rs` add the missing `primary_language` and `status_filter` arguments (passed as empty strings) to the `mk_lib_database_metadata_movie_read` call and reformat the call site.

### Testing
- Ran `rustfmt --edition 2024 docker/core/mkwebaxum/src/api/bp_api_title_search.rs` which succeeded, and attempted `cargo check --manifest-path docker/core/mkwebaxum/Cargo.toml` and `cargo clippy --manifest-path docker/core/mkwebaxum/Cargo.toml -- -D warnings` which were blocked in this environment due to Cargo registry/network (`kellnr` / crates.io) resolution errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a34aa3d48321a989846c007268ba)