### PR TITLE
Fix movie metadata template string comparisons

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html
@@ -12,7 +12,7 @@
       <div class="flex flex-wrap gap-2">
         {% for option in primary_language_options %}
         <a href="{{ base_path }}/1?{% if let Some(current_filter) = current %}starts_with={% if current_filter == "#" %}%23{% else %}{{ current_filter }}{% endif %}&{% endif %}{% if let Some(genre_name) = genre_filter_query %}genre={{ genre_name }}&{% endif %}primary_language={{ option.query_value }}{% if let Some(status_value) = status_filter %}&status={{ status_value }}{% endif %}"
-           class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors {% if let Some(active_primary_language) = primary_language_filter %}{% if active_primary_language == option.query_value %}border-indigo-600 bg-indigo-600 text-white{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}"
+           class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors {% if let Some(active_primary_language) = primary_language_filter %}{% if active_primary_language.as_str() == option.query_value.as_str() %}border-indigo-600 bg-indigo-600 text-white{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}"
            aria-label="Filter movies by primary language {{ option.label }}">
           {{ option.label }}
         </a>
@@ -25,7 +25,7 @@
       <div class="flex flex-wrap gap-2">
         {% for option in status_options %}
         <a href="{{ base_path }}/1?{% if let Some(current_filter) = current %}starts_with={% if current_filter == "#" %}%23{% else %}{{ current_filter }}{% endif %}&{% endif %}{% if let Some(genre_name) = genre_filter_query %}genre={{ genre_name }}&{% endif %}{% if let Some(language_value) = primary_language_filter %}primary_language={{ language_value }}&{% endif %}status={{ option.query_value }}"
-           class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium capitalize transition-colors {% if let Some(active_status) = status_filter %}{% if active_status == option.query_value %}border-indigo-600 bg-indigo-600 text-white{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}"
+           class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium capitalize transition-colors {% if let Some(active_status) = status_filter %}{% if active_status.as_str() == option.query_value.as_str() %}border-indigo-600 bg-indigo-600 text-white{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}"
            aria-label="Filter movies by user status {{ option.label }}">
           {{ option.label }}
         </a>


### PR DESCRIPTION
### Motivation
- Askama-generated code failed to compile due to an invalid comparison between `&String` and `String` in the movie metadata template, so the template must compare `&str` values instead to produce valid Rust code.

### Description
- Updated `docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html` to compare `active_primary_language` and `option.query_value` as `&str` using `.as_str()` to avoid `&String == String` mismatches.
- Applied the same `.as_str()` change to the user-status filter comparison in the same template so both filter chips use compatible string types.

### Testing
- Ran `cargo fmt --all --check` in `docker/core` which reported pre-existing formatting drift in unrelated workspace files (did not fail because of this change). 
- Ran `cargo check -p mkwebaxum` in `docker/core` which failed to complete due to dependency resolution being blocked by the configured registry mirror returning HTTP 403 for `config.json` (external registry issue). 
- Ran `cargo clippy -p mkwebaxum -- -D warnings` which was also blocked by the same registry mirror HTTP 403 error and could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a48b18e4832190f1fc42de8a63e6)