### PR TITLE
Add Dioxus mobile boilerplate crate for MediaKraken (src_app/mediakraken)

### DIFF
--- a/src_app/Cargo.toml
+++ b/src_app/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     "brother_print_label",
+    "mediakraken",
     "pi_upc",
     "pi_voice",
     "theater_controller_pi",

--- a/src_app/mediakraken/Cargo.toml
+++ b/src_app/mediakraken/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "mediakraken"
+version = "0.0.1"
+edition = "2024"
+
+[profile.release]
+panic = 'abort'
+strip = "symbols"
+lto = true
+codegen-units = 1
+
+[dependencies]
+dioxus = "0.4.3"
+reqwest = { version = "0.12.28", default-features = false, features = [
+    "json",
+    "rustls-tls",
+] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.148"
+
+[target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
+dioxus-mobile = "0.4.3"
+
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+dioxus-desktop = { version = "0.4.3", features = ["tokio_runtime"], default-features = false }
+
+[dev-dependencies]
+tokio-test = "*"

--- a/src_app/mediakraken/README.md
+++ b/src_app/mediakraken/README.md
@@ -1,0 +1,37 @@
+# MediaKraken Dioxus mobile boilerplate
+
+This crate is a minimal Dioxus starter app intended for iOS and Android clients that call the MediaKraken HTTP API.
+
+## What is included
+
+- A small `ApiClient` wrapper around `reqwest`
+- A simple login/config form for the MediaKraken API base URL and bearer token
+- A sample `GET /api/v1/library/summary` request path for initial integration work
+- Conditional launch targets for Dioxus mobile (`ios` / `android`) and desktop fallback for local UI development
+
+## Expected API contract
+
+The boilerplate expects a JSON response shaped roughly like this:
+
+```json
+{
+  "server_name": "MediaKraken",
+  "version": "0.0.1",
+  "movie_count": 120,
+  "show_count": 45,
+  "music_album_count": 12
+}
+```
+
+If your API endpoint differs, update `src/api.rs` and `src/models.rs`.
+
+## Local desktop preview
+
+```bash
+cd src_app/mediakraken
+cargo run
+```
+
+## Android / iOS
+
+Use the Dioxus mobile tooling that matches the installed SDKs in your environment, then point the app at a reachable MediaKraken API base URL.

--- a/src_app/mediakraken/src/api.rs
+++ b/src_app/mediakraken/src/api.rs
@@ -1,0 +1,37 @@
+use reqwest::Client;
+
+use crate::models::LibrarySummary;
+
+#[derive(Clone, Debug)]
+pub struct ApiClient {
+    base_url: String,
+    bearer_token: String,
+    http_client: Client,
+}
+
+impl ApiClient {
+    pub fn new(base_url: impl Into<String>, bearer_token: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into().trim_end_matches('/').to_owned(),
+            bearer_token: bearer_token.into(),
+            http_client: Client::new(),
+        }
+    }
+
+    pub async fn fetch_library_summary(&self) -> Result<LibrarySummary, reqwest::Error> {
+        let mut request = self
+            .http_client
+            .get(format!("{}/api/v1/library/summary", self.base_url));
+
+        if !self.bearer_token.trim().is_empty() {
+            request = request.bearer_auth(self.bearer_token.trim());
+        }
+
+        request
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<LibrarySummary>()
+            .await
+    }
+}

--- a/src_app/mediakraken/src/main.rs
+++ b/src_app/mediakraken/src/main.rs
@@ -1,0 +1,120 @@
+mod api;
+mod models;
+
+use dioxus::prelude::*;
+
+use crate::api::ApiClient;
+use crate::models::LibrarySummary;
+
+#[derive(Clone, Debug, PartialEq)]
+enum ApiState {
+    Idle,
+    Loading,
+    Loaded(LibrarySummary),
+    Error(String),
+}
+
+#[cfg(any(target_os = "android", target_os = "ios"))]
+fn main() {
+    dioxus_mobile::launch(app);
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn main() {
+    dioxus_desktop::launch(app);
+}
+
+fn app(cx: Scope) -> Element {
+    let base_url = use_state(cx, || "https://mediakraken.example.com".to_string());
+    let bearer_token = use_state(cx, String::new);
+    let api_state = use_state(cx, || ApiState::Idle);
+
+    cx.render(rsx! {
+        main {
+            class: "app-shell",
+            h1 { "MediaKraken mobile starter" }
+            p {
+                "Use this Dioxus screen as a starting point for Android/iOS clients that talk to the MediaKraken API."
+            }
+            div {
+                class: "form-grid",
+                label {
+                    "API base URL"
+                    input {
+                        value: "{base_url}",
+                        oninput: move |event| base_url.set(event.value.clone()),
+                        placeholder: "https://mediakraken.example.com",
+                    }
+                }
+                label {
+                    "Bearer token"
+                    input {
+                        r#type: "password",
+                        value: "{bearer_token}",
+                        oninput: move |event| bearer_token.set(event.value.clone()),
+                        placeholder: "Optional API token",
+                    }
+                }
+                button {
+                    onclick: move |_| {
+                        let base_url_value = base_url.current().clone();
+                        let bearer_token_value = bearer_token.current().clone();
+                        let api_state = api_state.clone();
+
+                        cx.spawn(async move {
+                            api_state.set(ApiState::Loading);
+
+                            let next_state = match ApiClient::new(base_url_value, bearer_token_value)
+                                .fetch_library_summary()
+                                .await
+                            {
+                                Ok(summary) => ApiState::Loaded(summary),
+                                Err(error) => ApiState::Error(error.to_string()),
+                            };
+
+                            api_state.set(next_state);
+                        });
+                    },
+                    "Load library summary"
+                }
+            }
+            {render_api_state(cx, api_state.current())}
+        }
+    })
+}
+
+fn render_api_state<'a>(cx: Scope<'a>, api_state: &'a ApiState) -> Element<'a> {
+    match api_state {
+        ApiState::Idle => cx.render(rsx! {
+            section {
+                h2 { "Ready" }
+                p { "Set the API URL above and tap the button to verify connectivity." }
+            }
+        }),
+        ApiState::Loading => cx.render(rsx! {
+            section {
+                h2 { "Loading" }
+                p { "Requesting MediaKraken library summary..." }
+            }
+        }),
+        ApiState::Loaded(summary) => cx.render(rsx! {
+            section {
+                h2 { "Connected" }
+                ul {
+                    li { "Server: {summary.server_name}" }
+                    li { "Version: {summary.version}" }
+                    li { "Movies: {summary.movie_count}" }
+                    li { "Shows: {summary.show_count}" }
+                    li { "Music albums: {summary.music_album_count}" }
+                }
+            }
+        }),
+        ApiState::Error(message) => cx.render(rsx! {
+            section {
+                h2 { "Request failed" }
+                p { "{message}" }
+                p { "Confirm the base URL, authentication token, and route path match your server." }
+            }
+        }),
+    }
+}

--- a/src_app/mediakraken/src/models.rs
+++ b/src_app/mediakraken/src/models.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+pub struct LibrarySummary {
+    pub server_name: String,
+    pub version: String,
+    pub movie_count: u64,
+    pub show_count: u64,
+    pub music_album_count: u64,
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal Dioxus starter app for iOS/Android that can be used to integrate with the MediaKraken HTTP API. 
- Include a tiny, well-scoped API client and data model so mobile clients have an immediate example of calling `GET /api/v1/library/summary`.
- Register the crate in the existing `src_app` workspace so it is available alongside other platform apps.

### Description
- Added a new workspace member entry in `src_app/Cargo.toml` for `mediakraken`.
- Created a new crate at `src_app/mediakraken` with `Cargo.toml`, `README.md`, and `src/` files: `main.rs`, `api.rs`, and `models.rs`.
- `Cargo.toml` includes conditional dependencies for `dioxus-mobile` (Android/iOS) and `dioxus-desktop` (local desktop preview) and runtime deps `reqwest` and `serde`.
- Implemented `ApiClient` in `src/api.rs` (small `reqwest` wrapper with bearer token support) and a serializable `LibrarySummary` model in `src/models.rs`, plus a minimal Dioxus UI in `src/main.rs` with base-URL/token inputs and idle/loading/loaded/error states.

### Testing
- Ran formatting and workspace metadata checks including `cargo fmt -p mediakraken` and `cargo metadata --format-version 1 --no-deps`, which completed in this environment.
- Ran `rustfmt --edition 2024 src_app/mediakraken/src/*.rs` as a local formatting step (applies local formatting rules).
- `cargo check -p mediakraken` from the `src_app` workspace failed due to the repository's configured private registry returning HTTP 403 for workspace dependencies.
- `cargo check` on an isolated copy of the crate also failed because the environment could not download crates from crates.io (`CONNECT tunnel failed, response 403`), so full dependency resolution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1a949d0ac8321a15f857e501019ba)