### PR TITLE
Match person/tv/sports/music metadata templates to movie card/grid style

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_music_album.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_music_album.html
@@ -1,32 +1,50 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<div>
-        <div>
-            {% if template_data_exists %}
-            {% if pagination_bar != "" %}
-            {{ pagination_bar|safe }}
-            {% endif %}
-            <div id="the-node">
-                {% for row_data in template_data %}
-                <div class="main_photo">
-                    <div class="media_context_right" data-id={{row_data.mm_metadata_album_id}}>
-                        <a href="/user/metadata/music_album_detail/{{row_data.mm_metadata_album_id}}">
-                            <img src="/static/image/headphone.png" loading="lazy" decoding="async" height="300" width="300">
-                        </a>
-                        <div class="description">
-                            <p class="description_content_left">{{row_data.mm_metadata_album_artist}} - {{row_data.mm_metadata_album_name}}</p>
-                        </div>
-                    </div>
-                </div>
-                {% endfor %}
-            </div>
-            {% if pagination_bar != "" %}
-            {{ pagination_bar|safe }}
-            {% endif %}
-            {% else %}
-            <p id="general_text">No music album metadata found.</p>
-            {% endif %}
+<section class="w-full px-0 py-4 text-zinc-900 dark:text-zinc-100">
+  <h1 id="music-grid-heading" class="sr-only">Music album list</h1>
+
+  {% if template_data_exists %}
+  {% if pagination_bar != "" %}
+  {{ pagination_bar|safe }}
+  {% endif %}
+  <ul role="list" class="grid gap-4 sm:gap-5
+     grid-cols-2
+     sm:grid-cols-3
+     md:grid-cols-4
+     lg:grid-cols-5
+     xl:grid-cols-6">
+    {% for row_data in template_data %}
+    <li class="group relative overflow-hidden rounded-xl border border-transparent bg-white shadow-sm transition-all duration-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900">
+      <a href="/user/metadata/music_album_detail/{{row_data.mm_metadata_album_id}}" class="block h-full">
+        <div class="relative aspect-square overflow-hidden rounded-t-xl bg-zinc-100 dark:bg-zinc-800">
+          <img
+            src="/static/image/headphone.png"
+            alt="Album artwork placeholder for {{ row_data.mm_metadata_album_artist }} - {{ row_data.mm_metadata_album_name }}"
+            loading="lazy"
+            decoding="async"
+            width="300"
+            height="300"
+            class="h-full w-full object-contain p-8 transition-transform duration-300 group-hover:scale-[1.02]" />
         </div>
-    </div>
+
+        <div class="space-y-1 p-3">
+          <h2 class="text-sm font-bold leading-tight text-zinc-900 line-clamp-2 dark:text-zinc-100">
+            {{ row_data.mm_metadata_album_name }}
+          </h2>
+          <p class="text-[11px] text-zinc-500 line-clamp-2 dark:text-zinc-400">
+            {{ row_data.mm_metadata_album_artist }}
+          </p>
+        </div>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+  {% if pagination_bar != "" %}
+  {{ pagination_bar|safe }}
+  {% endif %}
+  {% else %}
+  <p class="text-sm text-zinc-500 dark:text-zinc-400">No music album metadata found.</p>
+  {% endif %}
+</section>
 {% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_person.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_person.html
@@ -1,28 +1,61 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-{% if template_data_exists %}
-            {% if pagination_bar != "" %}
-            {{ pagination_bar|safe }}
-            {% endif %}
-            <div id="the-node">
-                {% for row_data in template_data %}
-                <div class="main_photo">
-                    <div class="media_context_right" data-id={{row_data.mm_metadata_person_guid}}>
-                        <a href="/user/metadata/person_detail/{{row_data.mm_metadata_person_guid}}">
-                            <img src="/metadata/{{row_data.mm_metadata_person_image}}" loading="lazy" decoding="async"
-                                height="300" width="200"></a>
-                        <div class="description">
-                            <p class="description_content_left">{{row_data.mm_metadata_person_name}}</p>
-                        </div>
-                    </div>
-                </div>
-                {% endfor %}
-            </div>
-            {% if pagination_bar != "" %}
-            {{ pagination_bar|safe }}
-            {% endif %}
-            {% else %}
-            <p id="general_text">No people metadata found.</p>
-            {% endif %}
+<section class="w-full px-0 py-4 text-zinc-900 dark:text-zinc-100">
+  <h1 id="person-grid-heading" class="sr-only">Person list</h1>
+
+  {% if template_data_exists %}
+  {% if pagination_bar != "" %}
+  {{ pagination_bar|safe }}
+  {% endif %}
+  <ul role="list" class="grid gap-4 sm:gap-5
+     grid-cols-2
+     sm:grid-cols-3
+     md:grid-cols-4
+     lg:grid-cols-5
+     xl:grid-cols-6">
+    {% for row_data in template_data %}
+    <li class="group relative overflow-hidden rounded-xl border border-transparent bg-white shadow-sm transition-all duration-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900">
+      <a href="/user/metadata/person_detail/{{row_data.mm_metadata_person_guid}}" class="block h-full">
+        <div class="relative aspect-[2/3] overflow-hidden rounded-t-xl bg-zinc-200 dark:bg-zinc-800">
+          {% if row_data.mm_metadata_person_image != "" %}
+          <img
+            src="/metadata/{{row_data.mm_metadata_person_image}}"
+            alt="Portrait for {{ row_data.mm_metadata_person_name }}"
+            loading="lazy"
+            decoding="async"
+            width="200"
+            height="300"
+            class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]" />
+          {% else %}
+          <img
+            src="/static/image/missing_icon.jpg"
+            alt="Missing portrait for {{ row_data.mm_metadata_person_name }}"
+            loading="lazy"
+            decoding="async"
+            width="200"
+            height="300"
+            class="h-full w-full object-cover" />
+          {% endif %}
+        </div>
+
+        <div class="p-3">
+          <h2 class="text-sm font-bold leading-tight text-zinc-900 line-clamp-2 dark:text-zinc-100">
+            {{ row_data.mm_metadata_person_name }}
+          </h2>
+          <p class="mt-1 text-[11px] font-medium uppercase tracking-[0.2em] text-zinc-500 dark:text-zinc-400">
+            Person Metadata
+          </p>
+        </div>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+  {% if pagination_bar != "" %}
+  {{ pagination_bar|safe }}
+  {% endif %}
+  {% else %}
+  <p class="text-sm text-zinc-500 dark:text-zinc-400">No people metadata found.</p>
+  {% endif %}
+</section>
 {% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_sports.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_sports.html
@@ -1,41 +1,40 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<div>
-                {% if template_data_exists %}
-                {% if pagination_bar != "" %}
-                {{ pagination_bar|safe }}
-                {% endif %}
-                <div class="table-responsive">
-                    <table class="table table-striped table-hover">
-                        <thead>
-                            <tr>
-                                <th>#</th>
-                                <th>Sporting Event</th>
-                                <th>Event Date</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for row_data in template_data %}
-                            <tr>
-                                <td>{{ loop.index + (page - 1) * 30 }}</td>
-                                <td><a href="/user/metadata/sports_detail/{{row_data.mm_metadata_sports_guid}}">{{
-                                        row_data.mm_metadata_sports_name }}</a></td>
-                                {#{% if row_data[2] != None %}
-                                <td>{{ row_data[2] }}</td>
-                                {% else %}
-                                <td>Unknown</td>
-                                {% endif %}#}
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-                {% if pagination_bar != "" %}
-                {{ pagination_bar|safe }}
-                {% endif %}
-                {% else %}
-                <p id="general_text">No sporting event metadata found.</p>
-                {% endif %}
-            </div>
+<section class="w-full px-0 py-4 text-zinc-900 dark:text-zinc-100">
+  <h1 id="sports-grid-heading" class="sr-only">Sports metadata list</h1>
+
+  {% if template_data_exists %}
+  {% if pagination_bar != "" %}
+  {{ pagination_bar|safe }}
+  {% endif %}
+  <ul role="list" class="grid gap-4 sm:gap-5
+     grid-cols-1
+     sm:grid-cols-2
+     lg:grid-cols-3
+     xl:grid-cols-4">
+    {% for row_data in template_data %}
+    <li class="group relative overflow-hidden rounded-xl border border-transparent bg-white shadow-sm transition-all duration-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900">
+      <a href="/user/metadata/sports_detail/{{row_data.mm_metadata_sports_guid}}" class="block h-full">
+        <div class="flex aspect-[3/2] items-end bg-gradient-to-br from-indigo-500 via-sky-500 to-cyan-500 p-4 text-white">
+          <span class="rounded-full bg-white/20 px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] backdrop-blur-sm">
+            Sports Event
+          </span>
+        </div>
+        <div class="p-4">
+          <h2 class="text-sm font-bold leading-tight text-zinc-900 line-clamp-3 dark:text-zinc-100">
+            {{ row_data.mm_metadata_sports_name }}
+          </h2>
+        </div>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+  {% if pagination_bar != "" %}
+  {{ pagination_bar|safe }}
+  {% endif %}
+  {% else %}
+  <p class="text-sm text-zinc-500 dark:text-zinc-400">No sporting event metadata found.</p>
+  {% endif %}
+</section>
 {% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_tv.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_tv.html
@@ -1,60 +1,68 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<div>
-        {% if template_data_exists %}
+<section class="w-full px-0 py-4 text-zinc-900 dark:text-zinc-100">
+  <h1 id="tv-grid-heading" class="sr-only">TV show list</h1>
 
-        <!-- Pagination top -->
-        {% if pagination_bar != "" %}
-        {{ pagination_bar|safe }}
-        {% endif %}
-
-        <!-- TV metadata grid -->
-        <div id="the-tv-metadata-node" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
-
-          {% for row_data in template_data %}
-          <div class="bg-white rounded-lg shadow hover:shadow-lg overflow-hidden relative">
-
-            <a href="/user/metadata/tv_detail/{{row_data.mm_metadata_tvshow_guid}}" class="block">
-              {% if row_data.image_json == "" %}
-              <img src="/static/image/missing_icon.jpg" alt="Missing Image" class="w-full h-75 object-cover"
-                loading="lazy" decoding="async">
-              {% else %}
-              <img src="/metadata/{{row_data.image_json|unquote_json}}" alt="{{row_data.mm_metadata_tvshow_name}}"
-                class="w-full h-75 object-cover" loading="lazy" decoding="async">
-              {% endif %}
-            </a>
-
-            {% if row_data.mm_metadata_tvshow_name != "" %}
-            <div class="p-2 text-left bg-gray-50">
-              <p class="text-sm font-medium text-gray-800 truncate">
-                {{ row_data.mm_metadata_tvshow_name }}
-              </p>
-            </div>
-            {% endif %}
-
-            {% if let Some(alt_name) = row_data.mm_metadata_tvshow_name_alt %}
-              {% if alt_name != &row_data.mm_metadata_tvshow_name %}
-                <div class="p-2 text-left bg-gray-50">
-                  <p>
-                    <span class="font-medium">Also Known As:</span>
-                    {{ alt_name }}
-                  </p>
-                </div>
-              {% endif %}
-            {% endif %}
-          </div>
-          {% endfor %}
-
+  {% if template_data_exists %}
+  {% if pagination_bar != "" %}
+  {{ pagination_bar|safe }}
+  {% endif %}
+  <ul role="list" class="grid gap-4 sm:gap-5
+     grid-cols-2
+     sm:grid-cols-3
+     md:grid-cols-4
+     lg:grid-cols-5
+     xl:grid-cols-6">
+    {% for row_data in template_data %}
+    <li class="group relative overflow-hidden rounded-xl border border-transparent bg-white shadow-sm transition-all duration-300 hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900">
+      <a href="/user/metadata/tv_detail/{{row_data.mm_metadata_tvshow_guid}}" class="block h-full">
+        <div class="relative aspect-[2/3] overflow-hidden rounded-t-xl bg-zinc-200 dark:bg-zinc-800">
+          {% if row_data.image_json == "" %}
+          <img
+            src="/static/image/missing_icon.jpg"
+            alt="Missing poster for {{ row_data.mm_metadata_tvshow_name }}"
+            loading="lazy"
+            decoding="async"
+            width="200"
+            height="300"
+            class="h-full w-full object-cover" />
+          {% else %}
+          <img
+            src="/metadata/{{row_data.image_json|unquote_json}}"
+            alt="Poster for {{ row_data.mm_metadata_tvshow_name }}"
+            loading="lazy"
+            decoding="async"
+            width="200"
+            height="300"
+            class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]" />
+          {% endif %}
         </div>
 
-        <!-- Pagination bottom -->
-        {% if pagination_bar != "" %}
-        {{ pagination_bar|safe }}
-        {% endif %}
-
-        {% else %}
-        <p id="general_text" class="text-center text-gray-500">No TV show metadata found.</p>
-        {% endif %}
-      </div>
+        <div class="space-y-1 p-3">
+          <h2 class="text-sm font-bold leading-tight text-zinc-900 line-clamp-2 dark:text-zinc-100">
+            {{ row_data.mm_metadata_tvshow_name }}
+          </h2>
+          {% if let Some(alt_name) = row_data.mm_metadata_tvshow_name_alt %}
+            {% if alt_name != &row_data.mm_metadata_tvshow_name %}
+          <p class="text-[11px] italic text-zinc-500 line-clamp-2 dark:text-zinc-400">
+            {{ alt_name }}
+          </p>
+            {% endif %}
+          {% endif %}
+          <p class="text-[11px] font-medium text-zinc-500 dark:text-zinc-400">
+            First aired: {{ row_data.air_date|unquote_json }}
+          </p>
+        </div>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+  {% if pagination_bar != "" %}
+  {{ pagination_bar|safe }}
+  {% endif %}
+  {% else %}
+  <p class="text-sm text-zinc-500 dark:text-zinc-400">No TV show metadata found.</p>
+  {% endif %}
+</section>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Unify the metadata listing pages so person, TV, sports, and music views use the same modern card/grid presentation used by the movie metadata page for visual consistency and better mobile/responsive behavior.
- Replace older table/list fragments with a single, predictable Tailwind card layout to simplify maintenance and improve UX.

### Description
- Reworked templates `docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_person.html`, `docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_tv.html`, `docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_sports.html`, and `docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_music_album.html` to follow the movie card/grid structure (UL/LI grid, responsive columns, rounded cards, consistent paddings/empty states).
- Person: show portrait with poster fallback, consistent aspect ratio, headline and small caption preserved in the card layout.
- TV: preserve poster rendering and alternate-title behavior while moving into the card grid and using the `unquote_json` filter for the air date display.
- Sports: replaced the table layout with responsive cards that display an event badge and event title, matching the card visual language.
- Music: use a square artwork area with the existing headphone placeholder image inside a card and show artist + album name in the card body.

### Testing
- Ran `cargo fmt --all` from `docker/core/mkwebaxum` to format files (completed locally for the mkwebaxum crate).
- Attempted `cargo check` and `cargo clippy -- -D warnings` from `docker/core/mkwebaxum` but both were blocked by the configured replacement registry returning HTTP 403 for its `config.json`, so full compile/lint verification could not complete in this environment.
- Reviewed the resulting template diffs to ensure pagination bars, empty-state messages, image fallbacks, and primary fields (name/title/date) are preserved and rendered in the new card layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1ad1b29508321b1b9900dfc168a6b)