### PR TITLE
Speed up movie language metadata lookup with indexed expression

### DIFF
--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs
@@ -1,10 +1,10 @@
 use crate::mk_lib_database::MediaStatusUpdatePayload;
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::postgres::PgRow;
-use sqlx::types::Uuid;
 use sqlx::types::chrono::DateTime;
 use sqlx::types::chrono::Utc;
+use sqlx::types::Uuid;
+use sqlx::FromRow;
 
 pub async fn mk_lib_database_metadata_exists_movie(
     sqlx_pool: &sqlx::PgPool,
@@ -157,10 +157,11 @@ pub async fn mk_lib_database_metadata_movie_languages(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<DBMetaMoviePrimaryLanguage>, sqlx::Error> {
     sqlx::query_as(
-        r#"select distinct lower(mm_metadata_movie_json->>'original_language') as primary_language
+        r#"select lower(mm_metadata_movie_json->>'original_language') as primary_language
         from mm_metadata_movie
         where coalesce(mm_metadata_movie_json->>'original_language', '') <> ''
-        order by lower(mm_metadata_movie_json->>'original_language')"#,
+        group by 1
+        order by 1"#,
     )
     .fetch_all(sqlx_pool)
     .await

--- a/src/mk_lib_database/src/mk_lib_database_version_schema.rs
+++ b/src/mk_lib_database/src/mk_lib_database_version_schema.rs
@@ -845,13 +845,28 @@ pub async fn mk_lib_database_update_schema(
 
     if version_no < 79 {
         let mut transaction = sqlx_pool.begin().await?;
-        sqlx::query(r#"ALTER TABLE ONLY mm_radio
+        sqlx::query(
+            r#"ALTER TABLE ONLY mm_radio
                 ADD CONSTRAINT mm_radio_address_uk UNIQUE (mm_radio_address);
-            "#)
-            .execute(&mut *transaction)
-            .await?;
+            "#,
+        )
+        .execute(&mut *transaction)
+        .await?;
         transaction.commit().await?;
         mk_lib_database_version_update(&sqlx_pool, 79).await?;
+    }
+
+    if version_no < 80 {
+        let mut transaction = sqlx_pool.begin().await?;
+        sqlx::query(
+            r#"CREATE INDEX IF NOT EXISTS mm_metadata_movie_original_language_lower_ndx
+            ON mm_metadata_movie USING btree (lower((mm_metadata_movie_json->>'original_language')))
+            WHERE coalesce(mm_metadata_movie_json->>'original_language', '') <> '';"#,
+        )
+        .execute(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+        mk_lib_database_version_update(&sqlx_pool, 80).await?;
     }
 
     // TODO, movie alt name, tv alt name and person alt name cleanup


### PR DESCRIPTION
### Motivation

- The language list query repeatedly computed and sorted a JSON expression which becomes slow as `mm_metadata_movie` grows. 
- Adding an index over the lowercased JSON value and simplifying the query lets the planner avoid re-evaluating the expression and speeds lookups.

### Description

- Rewrote `mk_lib_database_metadata_movie_languages` to select `lower(mm_metadata_movie_json->>'original_language')` and use `GROUP BY 1 ORDER BY 1` so deduplication and sorting operate on a single expression. 
- Added a schema upgrade step (`if version_no < 80`) that creates a partial functional btree index `mm_metadata_movie_original_language_lower_ndx` on `lower((mm_metadata_movie_json->>'original_language'))` for non-empty values to directly support the query pattern. 
- Changes are minimal and non-destructive: the migration only adds a conditional index and the query change is localized to the language metadata function.

### Testing

- Formatted the modified files with `rustfmt --edition 2021` which completed successfully. 
- Ran `cargo fmt` inside `src/mk_lib_database` which succeeded. 
- Attempted `cargo check` and `cargo clippy -- -D warnings` for the crate, but both were blocked in this environment by the configured private registry returning HTTP 403, so compilation/lint verification could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1da8ce7948321a876c5b1fedce154)