### PR TITLE
Add 'Unwatched' filter to metadata movie page

### DIFF
--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
@@ -1,16 +1,16 @@
-use crate::AppState;
 use crate::axum_custom_filters::filters;
 use crate::mk_lib_database;
+use crate::AppState;
 use askama::Template;
 use axum::extract::Query;
 use axum::extract::State;
 use axum::response::Redirect;
 use axum::response::Response;
 use axum::{
-    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
+    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -111,7 +111,7 @@ fn normalize_string_filter(raw: Option<&str>) -> Option<String> {
 fn normalize_status_filter(raw: Option<&str>) -> Option<String> {
     let value = raw.map(str::trim).filter(|value| !value.is_empty())?;
     match value {
-        "favorite" | "watched" | "good" | "bad" | "trash" => Some(value.to_string()),
+        "favorite" | "watched" | "unwatched" | "good" | "bad" | "trash" => Some(value.to_string()),
         _ => None,
     }
 }
@@ -313,6 +313,10 @@ pub async fn user_metadata_movie(
             FilterOption {
                 label: "Watched".to_string(),
                 query_value: "watched".to_string(),
+            },
+            FilterOption {
+                label: "Unwatched".to_string(),
+                query_value: "unwatched".to_string(),
             },
             FilterOption {
                 label: "Good".to_string(),

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs
@@ -82,7 +82,14 @@ pub async fn mk_lib_database_metadata_movie_read(
              )
              AND (
                 $6 = ''
-                OR COALESCE((mm_status_user_json->>$6)::boolean, false)
+                OR (
+                    $6 = 'unwatched'
+                    AND NOT COALESCE((mm_status_user_json->>'watched')::boolean, false)
+                )
+                OR (
+                    $6 <> 'unwatched'
+                    AND COALESCE((mm_status_user_json->>$6)::boolean, false)
+                )
              )
              offset $7 limit $8"#,
         )
@@ -131,7 +138,14 @@ pub async fn mk_lib_database_metadata_movie_read(
             )
             AND (
                 $5 = ''
-                OR COALESCE((mm_status_user_json->>$5)::boolean, false)
+                OR (
+                    $5 = 'unwatched'
+                    AND NOT COALESCE((mm_status_user_json->>'watched')::boolean, false)
+                )
+                OR (
+                    $5 <> 'unwatched'
+                    AND COALESCE((mm_status_user_json->>$5)::boolean, false)
+                )
             )
             order by LOWER(mm_metadata_movie_name), mm_date
             offset $6 limit $7"#,
@@ -197,7 +211,14 @@ pub async fn mk_lib_database_metadata_movie_count(
             )
             AND (
                 $5 = ''
-                OR COALESCE((mm_status_user_json->>$5)::boolean, false)
+                OR (
+                    $5 = 'unwatched'
+                    AND NOT COALESCE((mm_status_user_json->>'watched')::boolean, false)
+                )
+                OR (
+                    $5 <> 'unwatched'
+                    AND COALESCE((mm_status_user_json->>$5)::boolean, false)
+                )
             )"#,
         )
         .bind(user_id)
@@ -232,7 +253,14 @@ pub async fn mk_lib_database_metadata_movie_count(
             )
             AND (
                 $5 = ''
-                OR COALESCE((mm_status_user_json->>$5)::boolean, false)
+                OR (
+                    $5 = 'unwatched'
+                    AND NOT COALESCE((mm_status_user_json->>'watched')::boolean, false)
+                )
+                OR (
+                    $5 <> 'unwatched'
+                    AND COALESCE((mm_status_user_json->>$5)::boolean, false)
+                )
             )"#,
         )
         .bind(user_id)


### PR DESCRIPTION
### Motivation
- Users need a way to filter metadata movie listings for items that have not been watched yet (i.e. `watched` is false or missing).

### Description
- Accept `status=unwatched` in query parsing by updating `normalize_status_filter` to permit the `unwatched` token in `docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs`.
- Add an `Unwatched` status chip to the metadata movie UI so users can select this filter in the page template via the `status_options` vector in `bp_meta_movie.rs`.
- Update SQL filtering in `src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs` to treat `unwatched` specially by matching rows where `watched` is false (or missing), while preserving existing behavior for other status flags, and apply this to both list (`mk_lib_database_metadata_movie_read`) and count (`mk_lib_database_metadata_movie_count`) query paths.
- Files changed: `docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs` and `src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs`.

### Testing
- Ran `rustfmt --edition 2021` on the two modified files, which completed successfully.
- Attempted `cargo fmt`, `cargo check`, and `cargo clippy` for the affected crates but they failed to run in this environment due to an unavailable external registry (`kellnr`) referenced in the manifests, so full build/lint verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1e6254cc88321a46824a0d6c10a77)