### PR TITLE
Install calibre in mkdownload final image from Alpine edge repos

### DIFF
--- a/docker/core/mkdownload/Dockerfile
+++ b/docker/core/mkdownload/Dockerfile
@@ -41,6 +41,7 @@ COPY --from=cargo-build-mkdownload /mediakraken/deps/* /
 ADD https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp_linux /yt-dlp
 RUN chmod a+rx /yt-dlp \
  && apk update && apk add --no-cache py3-pip libssl3 libcrypto3 ca-certificates \
+ && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing calibre \
  && rm -rf /var/cache/apk/* \
  && pip3 install --no-cache-dir dosage==3.2 cssselect==1.4.0 subliminal==2.6.0 --break-system-packages
  #&& pip3 install --no-cache-dir --trusted-host mksonatype -i http://mksonatype:8081/repository/pypi/simple dosage==3.0 cssselect==1.2.0 subliminal==2.2.1 --break-system-packages


### PR DESCRIPTION
### Motivation
- The final mkdownload image needs `calibre` available for ebook processing and the package is not present in the stable Alpine repositories.
- Pulling `calibre` from Alpine edge community/testing ensures the binary is available in the scratch-based runtime image.

### Description
- Add `calibre` to the final image `RUN` line by invoking `apk add --no-cache --repository=...` with the Alpine edge `community` and `testing` repositories.
- Keep existing runtime additions including `yt-dlp` and Python dependencies installed via `pip3` unchanged.
- The final image still copies runtime library dependencies from the builder stage and runs as the unprivileged `mediakraken` user.

### Testing
- Built the updated Dockerfile with `docker build` for `docker/core/mkdownload` and the image build completed successfully.
- Performed an automated container smoke test with `docker run --rm <image> which calibre` and `docker run --rm <image> yt-dlp --version`, both commands returned the expected executables indicating the install succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2f0da92948321835100d475aab582)