### PR TITLE
mkwebaxum: add user-configurable site-wide pagination size

### DIFF
--- a/docker/core/mkwebaxum/src/admin/bp_backup.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_backup.rs
@@ -1,12 +1,15 @@
+use crate::AppState;
 use crate::axum_custom_filters::filters;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
     routing::{get, post},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -14,8 +17,6 @@ use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_enum_backup_type;
 use mk_lib_common::mk_lib_common_pagination;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_403.html")]
@@ -52,23 +53,30 @@ pub async fn admin_backup(
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
         // TODO show local backups here as well
-        let db_offset: i64 = (page * 30) - 30;
-        let total_pages: i64 =
-            mk_lib_database::mk_lib_database_backup::mk_lib_database_backup_count(&state.sqlx_pool_ro)
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
                 .await
-                .unwrap();
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
+        let total_pages: i64 =
+            mk_lib_database::mk_lib_database_backup::mk_lib_database_backup_count(
+                &state.sqlx_pool_ro,
+            )
+            .await
+            .unwrap();
         let pagination_html = mk_lib_common_pagination::mk_lib_common_paginate(
             total_pages,
             page,
             "/admin/backup".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
         let backup_list = mk_lib_database::mk_lib_database_backup::mk_lib_database_backup_read(
             &state.sqlx_pool_ro,
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();

--- a/docker/core/mkwebaxum/src/admin/bp_game_servers.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_game_servers.rs
@@ -1,18 +1,19 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_403.html")]
@@ -47,10 +48,14 @@ pub async fn admin_game_servers(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
             mk_lib_database::mk_lib_database_game_servers::mk_lib_database_game_server_count(
-              &state.sqlx_pool_ro,
+                &state.sqlx_pool_ro,
                 String::new(),
             )
             .await
@@ -60,15 +65,16 @@ pub async fn admin_game_servers(
             page,
             "/admin/game_servers".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
         let dedicated_server_list =
             mk_lib_database::mk_lib_database_game_servers::mk_lib_database_game_server_read(
-               &state.sqlx_pool_ro,
+                &state.sqlx_pool_ro,
                 String::new(),
                 db_offset,
-                30,
+                pagination_count,
             )
             .await
             .unwrap();

--- a/docker/core/mkwebaxum/src/admin/bp_reports.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_reports.rs
@@ -1,18 +1,19 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_403.html")]
@@ -47,10 +48,14 @@ pub async fn admin_report_known_media(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
             mk_lib_database::mk_lib_database_report::mk_lib_database_report_known_media_count(
-               &state.sqlx_pool_ro,
+                &state.sqlx_pool_ro,
             )
             .await
             .unwrap();
@@ -59,6 +64,7 @@ pub async fn admin_report_known_media(
             page,
             "/admin/report_known_media".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -66,7 +72,7 @@ pub async fn admin_report_known_media(
             mk_lib_database::mk_lib_database_report::mk_lib_database_report_known_media_read(
                 &state.sqlx_pool_ro,
                 db_offset,
-                30,
+                pagination_count,
             )
             .await
             .unwrap();

--- a/docker/core/mkwebaxum/src/admin/bp_user.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_user.rs
@@ -1,11 +1,14 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
     routing::{get, post},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -14,8 +17,6 @@ use mk_lib_common::mk_lib_common_pagination;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_403.html")]
@@ -49,9 +50,13 @@ pub async fn admin_user(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 = mk_lib_database::mk_lib_database_user::mk_lib_database_user_count(
-           &state.sqlx_pool_ro,
+            &state.sqlx_pool_ro,
             String::new(),
         )
         .await
@@ -61,13 +66,14 @@ pub async fn admin_user(
             page,
             "/admin/user".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
         let user_list = mk_lib_database::mk_lib_database_user::mk_lib_database_user_read(
-          &state.sqlx_pool_ro,
+            &state.sqlx_pool_ro,
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();

--- a/docker/core/mkwebaxum/src/main.rs
+++ b/docker/core/mkwebaxum/src/main.rs
@@ -48,6 +48,7 @@ use tower_http::set_header::SetResponseHeaderLayer;
 type Client = hyper_util::client::legacy::Client<HttpConnector, Body>;
 mod axum_custom_filters;
 mod error_handling;
+mod user_preferences;
 
 #[path = "admin"]
 pub mod admin {
@@ -458,6 +459,10 @@ async fn main() {
         .route(
             "/user/profile/photo",
             post(user::bp_profile::user_profile_photo_post),
+        )
+        .route(
+            "/user/profile/pagination",
+            post(user::bp_profile::user_profile_pagination_post),
         )
         .route_with_tsr("/user/queue", get(user::bp_queue::user_queue))
         //.route_with_tsr("/user/search", get(user::bp_search::user_search))

--- a/docker/core/mkwebaxum/src/user/bp_profile.rs
+++ b/docker/core/mkwebaxum/src/user/bp_profile.rs
@@ -1,8 +1,9 @@
 use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
 use axum::{
-    extract::{Multipart, Query, State},
+    extract::{Form, Multipart, Query, State},
     http::{Method, StatusCode},
     response::{Html, IntoResponse, Redirect},
 };
@@ -26,6 +27,7 @@ struct UserProfileTemplate {
     page_title: Option<String>,
     username: String,
     profile_image_url: String,
+    pagination_count: i64,
     success_message: Option<String>,
     error_message: Option<String>,
 }
@@ -40,6 +42,11 @@ pub struct UserProfileQuery {
 struct UserProfileRow {
     mm_user_profile_guid: uuid::Uuid,
     mm_user_profile_json: Option<Value>,
+}
+
+#[derive(Deserialize)]
+pub struct PaginationPreferenceForm {
+    pagination_count: i64,
 }
 
 pub async fn user_profile(
@@ -67,8 +74,17 @@ pub async fn user_profile(
             profile_image_url: load_profile_image_url(&state.sqlx_pool_ro, current_user.id)
                 .await
                 .unwrap_or_else(|_| DEFAULT_PROFILE_IMAGE_URL.to_string()),
+            pagination_count: user_preferences::load_user_pagination_count(
+                &state.sqlx_pool_ro,
+                current_user.id,
+            )
+            .await
+            .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT),
             success_message: match query.status.as_deref() {
                 Some("updated") => Some("Profile picture updated.".to_string()),
+                Some("pagination-updated") => {
+                    Some("Pagination preference updated for your account.".to_string())
+                }
                 _ => None,
             },
             error_message: match query.error.as_deref() {
@@ -82,6 +98,11 @@ pub async fn user_profile(
                 Some("save-failed") => {
                     Some("MediaKraken could not save that profile picture right now.".to_string())
                 }
+                Some("invalid-pagination") => Some(format!(
+                    "Pagination count must be between {} and {}.",
+                    user_preferences::MIN_PAGINATION_COUNT,
+                    user_preferences::MAX_PAGINATION_COUNT
+                )),
                 _ => None,
             },
         };
@@ -174,6 +195,44 @@ pub async fn user_profile_photo_post(
     }
 
     Redirect::to("/user/profile?status=updated")
+}
+
+pub async fn user_profile_pagination_post(
+    State(state): State<AppState>,
+    method: Method,
+    auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
+    Form(form): Form<PaginationPreferenceForm>,
+) -> Redirect {
+    let current_user = auth.current_user.clone().unwrap_or_default();
+    if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
+        [Method::POST],
+        false,
+    )
+    .requires(Rights::any([Rights::permission("User::View")]))
+    .validate(&current_user, &method, None)
+    .await
+    {
+        return Redirect::to("/error/401");
+    }
+
+    if form.pagination_count < user_preferences::MIN_PAGINATION_COUNT
+        || form.pagination_count > user_preferences::MAX_PAGINATION_COUNT
+    {
+        return Redirect::to("/user/profile?error=invalid-pagination");
+    }
+
+    if user_preferences::upsert_user_pagination_count(
+        &state.sqlx_pool_rw,
+        current_user.id,
+        form.pagination_count,
+    )
+    .await
+    .is_err()
+    {
+        return Redirect::to("/user/profile?error=save-failed");
+    }
+
+    Redirect::to("/user/profile?status=pagination-updated")
 }
 
 async fn load_profile_image_url(sqlx_pool: &PgPool, user_id: i64) -> Result<String, sqlx::Error> {

--- a/docker/core/mkwebaxum/src/user/bp_sync.rs
+++ b/docker/core/mkwebaxum/src/user/bp_sync.rs
@@ -1,18 +1,19 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -47,7 +48,11 @@ pub async fn user_sync(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
             mk_lib_database::mk_lib_database_sync::mk_lib_database_sync_count(&state.sqlx_pool_ro)
                 .await
@@ -57,14 +62,15 @@ pub async fn user_sync(
             page,
             "/user/metadata/book".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
         let sync_list = mk_lib_database::mk_lib_database_sync::mk_lib_database_sync_list(
-           &state.sqlx_pool_ro,
+            &state.sqlx_pool_ro,
             uuid::Uuid::nil(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();

--- a/docker/core/mkwebaxum/src/user/media/bp_media_book.rs
+++ b/docker/core/mkwebaxum/src/user/media/bp_media_book.rs
@@ -1,11 +1,14 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -13,8 +16,6 @@ use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use serde_json::json;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -50,7 +51,11 @@ pub async fn user_media_book(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_media::mk_lib_database_media_book::mk_lib_database_media_book_count(
            &state.sqlx_pool_ro,
@@ -63,6 +68,7 @@ pub async fn user_media_book(
             page,
             "/user/media/book".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -70,7 +76,7 @@ pub async fn user_media_book(
       &state.sqlx_pool_ro,
         String::new(),
         db_offset,
-        30,
+        pagination_count,
     )
     .await
     .unwrap();

--- a/docker/core/mkwebaxum/src/user/media/bp_media_collection.rs
+++ b/docker/core/mkwebaxum/src/user/media/bp_media_collection.rs
@@ -1,11 +1,14 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -13,8 +16,6 @@ use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use serde_json::json;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -52,7 +53,11 @@ pub async fn user_media_collection(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_metadata::mk_lib_database_metadata_collection::mk_lib_database_metadata_collection_count(
            &state.sqlx_pool_ro,
@@ -65,6 +70,7 @@ pub async fn user_media_collection(
             page,
             "/user/media/collection".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -73,7 +79,7 @@ pub async fn user_media_collection(
            &state.sqlx_pool_ro,
             String::new(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();

--- a/docker/core/mkwebaxum/src/user/media/bp_media_game.rs
+++ b/docker/core/mkwebaxum/src/user/media/bp_media_game.rs
@@ -1,11 +1,14 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -13,8 +16,6 @@ use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use serde_json::json;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -50,7 +51,11 @@ pub async fn user_media_game(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_media::mk_lib_database_media_game::mk_lib_database_media_game_count(
           &state.sqlx_pool_ro,
@@ -63,6 +68,7 @@ pub async fn user_media_game(
             page,
             "/user/media/game".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -70,7 +76,7 @@ pub async fn user_media_game(
        &state.sqlx_pool_ro,
         String::new(),
         db_offset,
-        30,
+        pagination_count,
     )
     .await
     .unwrap();

--- a/docker/core/mkwebaxum/src/user/media/bp_media_game_servers.rs
+++ b/docker/core/mkwebaxum/src/user/media/bp_media_game_servers.rs
@@ -1,12 +1,15 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
+    Extension, Router,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
     routing::{get, post},
-    Extension, Router,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -15,8 +18,6 @@ use mk_lib_common::mk_lib_common_pagination;
 use serde_json::json;
 use sqlx::postgres::PgPool;
 use stdext::function_name;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -51,10 +52,14 @@ pub async fn user_media_game_servers(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
             mk_lib_database::mk_lib_database_game_servers::mk_lib_database_game_server_count(
-               &state.sqlx_pool_ro,
+                &state.sqlx_pool_ro,
                 String::new(),
             )
             .await
@@ -64,15 +69,16 @@ pub async fn user_media_game_servers(
             page,
             "/user/media/game_servers".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
         let game_server_list =
             mk_lib_database::mk_lib_database_game_servers::mk_lib_database_game_server_read(
-              &state.sqlx_pool_ro,
+                &state.sqlx_pool_ro,
                 String::new(),
                 db_offset,
-                30,
+                pagination_count,
             )
             .await
             .unwrap();

--- a/docker/core/mkwebaxum/src/user/media/bp_media_home_media.rs
+++ b/docker/core/mkwebaxum/src/user/media/bp_media_home_media.rs
@@ -1,11 +1,14 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -13,8 +16,6 @@ use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use serde_json::json;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -51,7 +52,11 @@ pub async fn user_media_home_media(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_media::mk_lib_database_media_home_media::mk_lib_database_media_home_media_count(
            &state.sqlx_pool_ro,
@@ -64,6 +69,7 @@ pub async fn user_media_home_media(
             page,
             "/user/media/home_media".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -72,7 +78,7 @@ pub async fn user_media_home_media(
            &state.sqlx_pool_ro,
             String::new(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();

--- a/docker/core/mkwebaxum/src/user/media/bp_media_movie.rs
+++ b/docker/core/mkwebaxum/src/user/media/bp_media_movie.rs
@@ -1,22 +1,23 @@
+use crate::AppState;
 use crate::axum_custom_filters::filters;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::response::Response;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
-use axum::extract::State;
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
-use sqlx::postgres::PgPool;
-use crate::AppState;
 use serde_json::json;
+use sqlx::postgres::PgPool;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -52,7 +53,11 @@ pub async fn user_media_movie(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_media::mk_lib_database_media_movie::mk_lib_database_media_movie_count(
            &state.sqlx_pool_ro,
@@ -65,6 +70,7 @@ pub async fn user_media_movie(
             page,
             "/user/media/movie".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -73,7 +79,7 @@ pub async fn user_media_movie(
            &state.sqlx_pool_ro,
             String::new(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -130,11 +136,11 @@ pub async fn user_media_movie_detail(
 }
 
 pub async fn user_media_movie_status(
-     State(state): State<AppState>,
+    State(state): State<AppState>,
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
     axum::Json(payload): axum::Json<mk_lib_database::mk_lib_database::MediaStatusUpdatePayload>,
-) -> impl IntoResponse  {
+) -> impl IntoResponse {
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
         [Method::GET],
@@ -144,14 +150,14 @@ pub async fn user_media_movie_status(
     .validate(&current_user, &method, None)
     .await
     {
-             return StatusCode::UNAUTHORIZED.into_response();
+        return StatusCode::UNAUTHORIZED.into_response();
     } else {
         let _row_data = mk_lib_database::database_metadata::mk_lib_database_metadata_movie::mk_lib_database_metadata_movie_status(
             &state.sqlx_pool_rw, payload, current_user.id
         )
         .await
         .unwrap();
-           StatusCode::OK.into_response()
+        StatusCode::OK.into_response()
     }
 }
 

--- a/docker/core/mkwebaxum/src/user/media/bp_media_music.rs
+++ b/docker/core/mkwebaxum/src/user/media/bp_media_music.rs
@@ -1,12 +1,15 @@
+use crate::AppState;
 use crate::axum_custom_filters::filters;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -14,8 +17,6 @@ use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use serde_json::json;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -51,7 +52,11 @@ pub async fn user_media_music(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_media::mk_lib_database_media_music::mk_lib_database_media_music_count(
             &state.sqlx_pool_ro,
@@ -64,6 +69,7 @@ pub async fn user_media_music(
             page,
             "/user/media/music/".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -72,7 +78,7 @@ pub async fn user_media_music(
            &state.sqlx_pool_ro,
             String::new(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();

--- a/docker/core/mkwebaxum/src/user/media/bp_media_music_video.rs
+++ b/docker/core/mkwebaxum/src/user/media/bp_media_music_video.rs
@@ -1,11 +1,14 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -13,8 +16,6 @@ use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use serde_json::json;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -51,7 +52,11 @@ pub async fn user_media_music_video(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_media::mk_lib_database_media_music_video::mk_lib_database_media_music_video_count(
             &state.sqlx_pool_ro,
@@ -64,6 +69,7 @@ pub async fn user_media_music_video(
             page,
             "/user/media/music_video".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -72,7 +78,7 @@ pub async fn user_media_music_video(
             &state.sqlx_pool_ro,
             String::new(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();

--- a/docker/core/mkwebaxum/src/user/media/bp_media_sports.rs
+++ b/docker/core/mkwebaxum/src/user/media/bp_media_sports.rs
@@ -1,11 +1,14 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -13,8 +16,6 @@ use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use serde_json::json;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -50,7 +51,11 @@ pub async fn user_media_sports(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_media::mk_lib_database_media_sports::mk_lib_database_media_sports_count(
             &state.sqlx_pool_ro,
@@ -63,6 +68,7 @@ pub async fn user_media_sports(
             page,
             "/user/media/sports".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -71,7 +77,7 @@ pub async fn user_media_sports(
             &state.sqlx_pool_ro,
             String::new(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();

--- a/docker/core/mkwebaxum/src/user/media/bp_media_tv.rs
+++ b/docker/core/mkwebaxum/src/user/media/bp_media_tv.rs
@@ -1,12 +1,15 @@
+use crate::AppState;
 use crate::axum_custom_filters::filters;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -14,8 +17,6 @@ use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use serde_json::json;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -51,7 +52,11 @@ pub async fn user_media_tv(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_media::mk_lib_database_media_tv::mk_lib_database_media_tv_count(
             &state.sqlx_pool_ro,
@@ -64,6 +69,7 @@ pub async fn user_media_tv(
             page,
             "/user/media/tv".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -72,7 +78,7 @@ pub async fn user_media_tv(
             &state.sqlx_pool_ro,
             String::new(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -131,7 +137,7 @@ pub async fn user_media_tv_detail(
 }
 
 pub async fn user_media_tv_status(
-     State(state): State<AppState>,
+    State(state): State<AppState>,
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
     Path(guid): Path<uuid::Uuid>,

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_book.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_book.rs
@@ -1,19 +1,20 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -49,7 +50,11 @@ pub async fn user_metadata_book(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_metadata::mk_lib_database_metadata_book::mk_lib_database_metadata_book_count(
             &state.sqlx_pool_ro,
@@ -62,6 +67,7 @@ pub async fn user_metadata_book(
             page,
             "/user/metadata/book".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -70,7 +76,7 @@ pub async fn user_metadata_book(
            &state.sqlx_pool_ro,
             String::new(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_game.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_game.rs
@@ -1,11 +1,14 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -13,8 +16,6 @@ use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use serde_json::json;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -50,7 +51,11 @@ pub async fn user_metadata_game(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_metadata::mk_lib_database_metadata_game::mk_lib_database_metadata_game_count(
            &state.sqlx_pool_ro,
@@ -63,6 +68,7 @@ pub async fn user_metadata_game(
             page,
             "/user/metadata/game".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -71,7 +77,7 @@ pub async fn user_metadata_game(
            &state.sqlx_pool_ro,
             String::new(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_game_system.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_game_system.rs
@@ -1,19 +1,20 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -49,7 +50,11 @@ pub async fn user_metadata_game_system(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_metadata::mk_lib_database_metadata_game_system::mk_lib_database_metadata_game_system_count(
            &state.sqlx_pool_ro,
@@ -62,6 +67,7 @@ pub async fn user_metadata_game_system(
             page,
             "/user/metadata/game_system".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -70,7 +76,7 @@ pub async fn user_metadata_game_system(
             &state.sqlx_pool_ro,
             String::new(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
@@ -1,16 +1,17 @@
+use crate::AppState;
 use crate::axum_custom_filters::filters;
 use crate::mk_lib_database;
-use crate::AppState;
+use crate::user_preferences;
 use askama::Template;
 use axum::extract::Query;
 use axum::extract::State;
 use axum::response::Redirect;
 use axum::response::Response;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -152,13 +153,14 @@ fn build_filter_query_suffix(
 fn build_movie_pagination(
     total_items: i64,
     page: i64,
+    pagination_count: i64,
     starts_with: Option<&str>,
     genre: Option<&str>,
     primary_language: Option<&str>,
     status_filter: Option<&str>,
 ) -> Result<String, std::fmt::Error> {
     let total_pages = if total_items > 0 {
-        (total_items + 29) / 30
+        (total_items + pagination_count - 1) / pagination_count
     } else {
         0
     };
@@ -271,7 +273,11 @@ pub async fn user_metadata_movie(
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
         let current_user = auth.current_user.clone().unwrap_or_default();
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_metadata::mk_lib_database_metadata_movie::mk_lib_database_metadata_movie_count(
            &state.sqlx_pool_ro,
@@ -287,6 +293,7 @@ pub async fn user_metadata_movie(
         let pagination_html = build_movie_pagination(
             total_pages,
             page,
+            pagination_count,
             starts_with.as_deref(),
             genre.as_deref(),
             primary_language.as_deref(),
@@ -347,7 +354,7 @@ pub async fn user_metadata_movie(
             primary_language.clone().unwrap_or_default(),
             status_filter.clone().unwrap_or_default(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_music.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_music.rs
@@ -1,11 +1,14 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -13,8 +16,6 @@ use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use serde_json::json;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -51,7 +52,11 @@ pub async fn user_metadata_music(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_metadata::mk_lib_database_metadata_music_brainz::mk_lib_database_metadata_music_album_count(
            &state.sqlx_pool_ro,
@@ -64,6 +69,7 @@ pub async fn user_metadata_music(
             page,
             "/user/metadata/music".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -72,7 +78,7 @@ pub async fn user_metadata_music(
            &state.sqlx_pool_ro,
             String::new(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_music_video.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_music_video.rs
@@ -1,11 +1,14 @@
+use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -13,8 +16,6 @@ use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use serde_json::json;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -50,7 +51,11 @@ pub async fn user_metadata_music_video(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_metadata::mk_lib_database_metadata_music_video::mk_lib_database_metadata_music_video_count(
            &state.sqlx_pool_ro,
@@ -64,6 +69,7 @@ pub async fn user_metadata_music_video(
             page,
             "/user/metadata/music_video".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -72,7 +78,7 @@ pub async fn user_metadata_music_video(
            &state.sqlx_pool_ro,
             String::new(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_person.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_person.rs
@@ -1,4 +1,5 @@
 use crate::AppState;
+use crate::user_preferences;
 use askama::Template;
 use axum::{
     extract::{Path, State},
@@ -54,7 +55,11 @@ pub async fn user_metadata_person(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 = mk_lib_database::database_metadata::mk_lib_database_metadata_person::mk_lib_database_metadata_person_count(
             &state.sqlx_pool_ro,
             String::new(),
@@ -66,6 +71,7 @@ pub async fn user_metadata_person(
             page,
             "/user/metadata/person".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_sports.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_sports.rs
@@ -1,5 +1,6 @@
 use crate::AppState;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
 use axum::{
     extract::{Path, State},
@@ -51,7 +52,11 @@ pub async fn user_metadata_sports(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages = match mk_lib_database::database_metadata::mk_lib_database_metadata_sports::mk_lib_database_metadata_sports_count(
             &state.sqlx_pool_ro,
             String::new(),
@@ -71,6 +76,7 @@ pub async fn user_metadata_sports(
             page,
             "/user/metadata/sports".to_string(),
             None,
+            pagination_count,
         )
         .await
         {
@@ -89,7 +95,7 @@ pub async fn user_metadata_sports(
             &state.sqlx_pool_ro,
             String::new(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         {

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_tv.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_tv.rs
@@ -1,12 +1,15 @@
+use crate::AppState;
 use crate::axum_custom_filters::filters;
 use crate::mk_lib_database;
+use crate::user_preferences;
 use askama::Template;
+use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -14,8 +17,6 @@ use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
 use serde_json::json;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -51,7 +52,11 @@ pub async fn user_metadata_tv(
         let reply_html = template.render().unwrap();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let db_offset: i64 = (page * 30) - 30;
+        let pagination_count =
+            user_preferences::load_user_pagination_count(&state.sqlx_pool_ro, current_user.id)
+                .await
+                .unwrap_or(user_preferences::DEFAULT_PAGINATION_COUNT);
+        let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_metadata::mk_lib_database_metadata_tv::mk_lib_database_metadata_tv_count(
            &state.sqlx_pool_ro,
@@ -64,6 +69,7 @@ pub async fn user_metadata_tv(
             page,
             "/user/metadata/tv".to_string(),
             None,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -71,7 +77,7 @@ pub async fn user_metadata_tv(
            &state.sqlx_pool_ro,
             String::new(),
             db_offset,
-            30,
+            pagination_count,
         )
         .await
         .unwrap();
@@ -130,7 +136,7 @@ pub async fn user_metadata_tv_detail(
 }
 
 pub async fn user_metadata_tv_status(
-     State(state): State<AppState>,
+    State(state): State<AppState>,
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
     Path(guid): Path<uuid::Uuid>,

--- a/docker/core/mkwebaxum/src/user_preferences.rs
+++ b/docker/core/mkwebaxum/src/user_preferences.rs
@@ -1,0 +1,118 @@
+use serde_json::{Value, json};
+use sqlx::{FromRow, postgres::PgPool};
+
+pub const DEFAULT_PAGINATION_COUNT: i64 = 30;
+pub const MIN_PAGINATION_COUNT: i64 = 5;
+pub const MAX_PAGINATION_COUNT: i64 = 200;
+
+#[derive(FromRow)]
+struct UserProfileRow {
+    mm_user_profile_guid: uuid::Uuid,
+    mm_user_profile_json: Option<Value>,
+}
+
+pub fn normalize_pagination_count(value: i64) -> i64 {
+    value.clamp(MIN_PAGINATION_COUNT, MAX_PAGINATION_COUNT)
+}
+
+pub async fn load_user_pagination_count(
+    sqlx_pool: &PgPool,
+    user_id: i64,
+) -> Result<i64, sqlx::Error> {
+    let profile_name = profile_name_for_user(user_id);
+    let row = sqlx::query_scalar::<_, Option<String>>(
+        r#"
+        select mm_user_profile_json ->> 'pagination_count'
+        from mm_user_profile
+        where mm_user_profile_name = $1
+        order by mm_user_profile_guid
+        limit 1
+        "#,
+    )
+    .bind(profile_name)
+    .fetch_optional(sqlx_pool)
+    .await?;
+
+    let pagination_count = row
+        .flatten()
+        .and_then(|value| value.parse::<i64>().ok())
+        .map(normalize_pagination_count)
+        .unwrap_or(DEFAULT_PAGINATION_COUNT);
+
+    Ok(pagination_count)
+}
+
+pub async fn upsert_user_pagination_count(
+    sqlx_pool: &PgPool,
+    user_id: i64,
+    pagination_count: i64,
+) -> Result<(), sqlx::Error> {
+    let profile_name = profile_name_for_user(user_id);
+    let existing_profile = sqlx::query_as::<_, UserProfileRow>(
+        r#"
+        select mm_user_profile_guid, mm_user_profile_json
+        from mm_user_profile
+        where mm_user_profile_name = $1
+        order by mm_user_profile_guid
+        limit 1
+        "#,
+    )
+    .bind(&profile_name)
+    .fetch_optional(sqlx_pool)
+    .await?;
+
+    let mut transaction = sqlx_pool.begin().await?;
+    let normalized = normalize_pagination_count(pagination_count);
+
+    if let Some(existing_profile) = existing_profile {
+        let mut profile_json = existing_profile
+            .mm_user_profile_json
+            .unwrap_or_else(|| json!({}));
+
+        if !profile_json.is_object() {
+            profile_json = json!({});
+        }
+
+        if let Some(profile_object) = profile_json.as_object_mut() {
+            profile_object.insert(
+                "pagination_count".to_string(),
+                Value::Number(normalized.into()),
+            );
+        }
+
+        sqlx::query(
+            r#"
+            update mm_user_profile
+            set mm_user_profile_json = $2
+            where mm_user_profile_guid = $1
+            "#,
+        )
+        .bind(existing_profile.mm_user_profile_guid)
+        .bind(profile_json)
+        .execute(&mut *transaction)
+        .await?;
+    } else {
+        sqlx::query(
+            r#"
+            insert into mm_user_profile (
+                mm_user_profile_guid,
+                mm_user_profile_name,
+                mm_user_profile_json
+            )
+            values ($1, $2, $3)
+            "#,
+        )
+        .bind(uuid::Uuid::now_v7())
+        .bind(profile_name)
+        .bind(json!({ "pagination_count": normalized }))
+        .execute(&mut *transaction)
+        .await?;
+    }
+
+    transaction.commit().await?;
+    Ok(())
+}
+
+fn profile_name_for_user(user_id: i64) -> String {
+    format!("axum_user_{}", user_id)
+}

--- a/docker/core/mkwebaxum/templates/bss_user/bss_user_profile.html
+++ b/docker/core/mkwebaxum/templates/bss_user/bss_user_profile.html
@@ -52,7 +52,7 @@
         </section>
 
         <section class="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
-            <h2 class="text-lg font-semibold text-zinc-900 dark:text-zinc-100">Photo settings</h2>
+            <h2 class="text-lg font-semibold text-zinc-900 dark:text-zinc-100">Account settings</h2>
             <dl class="mt-6 space-y-4 text-sm text-zinc-600 dark:text-zinc-300">
                 <div>
                     <dt class="font-medium text-zinc-900 dark:text-zinc-100">Username</dt>
@@ -67,6 +67,25 @@
                     <dd class="mt-1">Uploading a new image replaces your existing saved profile picture and updates the profile page immediately.</dd>
                 </div>
             </dl>
+            <form class="mt-8 flex flex-col gap-3" action="/user/profile/pagination" method="post">
+                <label for="pagination_count" class="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                    Items per page (site-wide)
+                </label>
+                <input id="pagination_count"
+                       name="pagination_count"
+                       type="number"
+                       min="5"
+                       max="200"
+                       value="{{ pagination_count }}"
+                       aria-label="Items per page for paginated lists"
+                       class="block w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-100">
+                <p class="text-xs text-zinc-500 dark:text-zinc-400">This setting controls pagination across media, metadata, sync, and admin list pages.</p>
+                <button type="submit"
+                        aria-label="Save pagination preference"
+                        class="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:bg-indigo-500 dark:hover:bg-indigo-400 dark:focus:ring-offset-zinc-900">
+                    Save pagination preference
+                </button>
+            </form>
         </section>
     </div>
 </div>

--- a/src/mk_lib_common/src/mk_lib_common_pagination.rs
+++ b/src/mk_lib_common/src/mk_lib_common_pagination.rs
@@ -21,9 +21,14 @@ pub async fn mk_lib_common_paginate(
     page: i64,
     base_url: String,
     starts_with: Option<&str>,
+    pagination_count: i64,
 ) -> Result<String, Box<dyn Error>> {
-    // Convert total items → total pages (30 per page)
-    let total_pages = if total_items > 0 { (total_items + 29) / 30 } else { 0 };
+    let page_size = pagination_count.max(1);
+    let total_pages = if total_items > 0 {
+        (total_items + page_size - 1) / page_size
+    } else {
+        0
+    };
 
     let mut pagination_html = String::new();
 


### PR DESCRIPTION
### Motivation
- Provide a per-user, site-wide pagination preference so users can control how many items are shown per page across media, metadata, sync, and admin list pages.
- Keep existing behavior safe by defaulting to `30` and enforcing bounds to avoid extreme or invalid values.

### Description
- Add a new `user_preferences` module that persists `pagination_count` in `mm_user_profile.mm_user_profile_json` and exposes `load_user_pagination_count` and `upsert_user_pagination_count` with normalization and bounds (`5..=200`).
- Add a profile UI field and handler: template changes to `bss_user/bss_user_profile.html` and a new POST handler `user_profile_pagination_post` in `user/bp_profile.rs` to validate and save the preference.
- Wire a new route `/user/profile/pagination` in `main.rs` and return friendly success/error messages on the profile page.
- Make pagination dynamic by changing `mk_lib_common_paginate` to accept `pagination_count` and updating paginated handlers (media/metadata/sync/admin) to load the user's `pagination_count` and use it for offset math, DB limits, and pagination bar calculations.

### Testing
- Ran formatting with `cargo fmt` in `docker/core/mkwebaxum` which completed successfully.
- Attempted `cargo check` and `cargo clippy -- -D warnings` in this environment but they failed due to private registry / network access restrictions (HTTP 403) preventing dependency resolution, so a full compile/lint verification could not be completed here.
- Attempted `cargo check --offline -p mkwebaxum` which failed because a git dependency is not available in offline mode, so offline checks could not finish.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d28236408321acdb05265c4b0de7)