### PR TITLE
Add YouTube browsing and playback to mkwebaxum

### DIFF
--- a/docker/core/mkwebaxum/src/main.rs
+++ b/docker/core/mkwebaxum/src/main.rs
@@ -279,6 +279,10 @@ async fn main() {
             get(user_internet::bp_inter_youtube::user_inter_youtube),
         )
         .route_with_tsr(
+            "/user/internet/youtube/{guid}",
+            get(user_internet::bp_inter_youtube::user_inter_youtube_detail),
+        )
+        .route_with_tsr(
             "/user/media/book/{page}",
             get(user_media::bp_media_book::user_media_book),
         )

--- a/docker/core/mkwebaxum/src/user/internet/bp_inter_youtube.rs
+++ b/docker/core/mkwebaxum/src/user/internet/bp_inter_youtube.rs
@@ -1,30 +1,50 @@
 use crate::mk_lib_database;
 use askama::Template;
 use axum::{
-    extract::Path,
+    extract::{Path, Query},
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
-use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
+use serde::Deserialize;
+use serde_json::Value;
 use sqlx::postgres::PgPool;
+
+const YOUTUBE_BASE_URL: &str = "https://www.youtube.com";
+const YOUTUBE_VIDEO_ID_LENGTH: usize = 11;
+const YOUTUBE_RESULTS_LIMIT: usize = 30;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
 struct TemplateError401Context {}
 
+#[derive(Clone, Debug)]
+struct YoutubeVideoItem {
+    id: String,
+    title: String,
+    channel_title: String,
+    duration: String,
+    thumbnail_url: String,
+}
+
 #[derive(Template)]
 #[template(path = "bss_user/internet/bss_user_internet_youtube.html")]
 struct UserInternetYoutubeTemplate<'a> {
-    //template_data: &'a Vec<mk_lib_database::mk_lib_database_cron::DBCronList>,
+    template_data: &'a Vec<YoutubeVideoItem>,
     template_data_exists: &'a bool,
+    search_query: &'a str,
     page_title: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct YoutubeSearchQuery {
+    query: Option<String>,
 }
 
 pub async fn user_inter_youtube(
     method: Method,
+    Query(query): Query<YoutubeSearchQuery>,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
 ) -> impl IntoResponse {
     let current_user = auth.current_user.clone().unwrap_or_default();
@@ -38,26 +58,37 @@ pub async fn user_inter_youtube(
     {
         let template = TemplateError401Context {};
         let reply_html = template.render().unwrap();
-        (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
-    } else {
-        let template = UserInternetYoutubeTemplate {
-            template_data_exists: &false,
-            page_title: Some("MediaKraken Youtube".to_string()),
-        };
-        let reply_html = template.render().unwrap();
-        (StatusCode::OK, Html(reply_html).into_response())
+        return (StatusCode::UNAUTHORIZED, Html(reply_html).into_response());
     }
+
+    let search_text = query.query.as_deref().unwrap_or("").trim().to_string();
+    let youtube_videos = fetch_youtube_browser_results(&search_text)
+        .await
+        .unwrap_or_default();
+    let has_data = !youtube_videos.is_empty();
+
+    let template = UserInternetYoutubeTemplate {
+        template_data: &youtube_videos,
+        template_data_exists: &has_data,
+        search_query: &search_text,
+        page_title: Some("MediaKraken Youtube".to_string()),
+    };
+
+    let reply_html = template.render().unwrap();
+    (StatusCode::OK, Html(reply_html).into_response())
 }
 
 #[derive(Template)]
 #[template(path = "bss_user/internet/bss_user_internet_youtube_detail.html")]
 struct UserInternetYoutubeDetailTemplate<'a> {
-    template_youtube_video_guid: &'a String,
+    template_youtube_video_guid: &'a str,
+    template_embed_url: &'a str,
     page_title: Option<String>,
 }
 
 pub async fn user_inter_youtube_detail(
     method: Method,
+    Path(guid): Path<String>,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
 ) -> impl IntoResponse {
     let current_user = auth.current_user.clone().unwrap_or_default();
@@ -71,60 +102,200 @@ pub async fn user_inter_youtube_detail(
     {
         let template = TemplateError401Context {};
         let reply_html = template.render().unwrap();
-        (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
-    } else {
-        let template = UserInternetYoutubeDetailTemplate {
-            template_youtube_video_guid: &"fakeguid".to_string(),
-            page_title: Some("MediaKraken Youtube Detail".to_string()),
-        };
-        let reply_html = template.render().unwrap();
-        (StatusCode::OK, Html(reply_html).into_response())
+        return (StatusCode::UNAUTHORIZED, Html(reply_html).into_response());
+    }
+
+    if !is_valid_video_id(&guid) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Html("Invalid YouTube video id".to_string()).into_response(),
+        );
+    }
+
+    let embed_url = format!("https://www.youtube.com/embed/{}?autoplay=1", guid);
+    let template = UserInternetYoutubeDetailTemplate {
+        template_youtube_video_guid: guid.as_str(),
+        template_embed_url: embed_url.as_str(),
+        page_title: Some("MediaKraken Youtube Playback".to_string()),
+    };
+    let reply_html = template.render().unwrap();
+    (StatusCode::OK, Html(reply_html).into_response())
+}
+
+async fn fetch_youtube_browser_results(
+    search_text: &str,
+) -> Result<Vec<YoutubeVideoItem>, reqwest::Error> {
+    let mut request_url = format!("{}/feed/trending", YOUTUBE_BASE_URL);
+    if !search_text.is_empty() {
+        request_url = format!(
+            "{}/results?search_query={}",
+            YOUTUBE_BASE_URL,
+            urlencoding::encode(search_text)
+        );
+    }
+
+    let page_body = reqwest::Client::new()
+        .get(request_url)
+        .header("Accept-Language", "en-US,en;q=0.9")
+        .send()
+        .await?
+        .text()
+        .await?;
+
+    Ok(extract_videos_from_initial_data(&page_body))
+}
+
+fn extract_videos_from_initial_data(page_body: &str) -> Vec<YoutubeVideoItem> {
+    let Some(json_value) = find_json_block(page_body, "ytInitialData") else {
+        return Vec::new();
+    };
+
+    let Ok(root_json): Result<Value, _> = serde_json::from_str(json_value) else {
+        return Vec::new();
+    };
+
+    let mut results = Vec::new();
+    collect_video_renderers(&root_json, &mut results);
+
+    results
+        .into_iter()
+        .filter(|item| is_valid_video_id(&item.id))
+        .take(YOUTUBE_RESULTS_LIMIT)
+        .collect()
+}
+
+fn find_json_block<'a>(page_body: &'a str, marker: &str) -> Option<&'a str> {
+    let marker_index = page_body.find(marker)?;
+    let after_marker = &page_body[marker_index..];
+    let start_brace_offset = after_marker.find('{')?;
+
+    let mut in_string = false;
+    let mut escaping = false;
+    let mut depth = 0usize;
+    let mut start_index = 0usize;
+
+    for (offset, ch) in after_marker.char_indices().skip(start_brace_offset) {
+        if in_string {
+            if escaping {
+                escaping = false;
+                continue;
+            }
+
+            if ch == '\\' {
+                escaping = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if ch == '"' {
+            in_string = true;
+            continue;
+        }
+
+        if ch == '{' {
+            if depth == 0 {
+                start_index = offset;
+            }
+            depth += 1;
+            continue;
+        }
+
+        if ch == '}' {
+            if depth == 0 {
+                return None;
+            }
+
+            depth -= 1;
+            if depth == 0 {
+                let end_index = offset + ch.len_utf8();
+                return after_marker.get(start_index..end_index);
+            }
+        }
+    }
+
+    None
+}
+
+fn collect_video_renderers(value: &Value, results: &mut Vec<YoutubeVideoItem>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(video_renderer) = map.get("videoRenderer") {
+                if let Some(item) = parse_video_renderer(video_renderer) {
+                    results.push(item);
+                }
+            }
+
+            for nested in map.values() {
+                collect_video_renderers(nested, results);
+            }
+        }
+        Value::Array(array) => {
+            for nested in array {
+                collect_video_renderers(nested, results);
+            }
+        }
+        _ => {}
     }
 }
 
-/*
-@blueprint_user_internet_youtube.route('/user_internet/youtube', methods=["GET", "POST"])
-@common_global.jinja_template.template('bss_user/internet/bss_user_internet_youtube.html')
-@common_global.auth.login_required
-pub async fn url_bp_user_internet_youtube(request):
-    """
-    Display youtube page
-    """
-    youtube_videos = []
-    if request.ctx.session['search_text'] != None:
-        videos, channels, playlists = g.google_instance.com_google_youtube_search(
-            request.ctx.session['search_text'])
-        for url_link in videos:
-            await common_logging_elasticsearch_httpx.com_es_httpx_post_async(message_type='info',
-                                                                             message_text={
-                                                                                 'searchurllink': url_link})
-            youtube_videos.append(
-                g.google_instance.com_google_youtube_info(url_link, 'snippet'))
-    else:
-        # get trending for specified country code
-        for url_link in common_network_youtube.com_net_yt_trending(locale.getdefaultlocale()[0]):
-            await common_logging_elasticsearch_httpx.com_es_httpx_post_async(message_type='info',
-                                                                             message_text={
-                                                                                 'urllink': url_link})
-            youtube_videos.append(g.google_instance.com_google_youtube_info(url_link, 'snippet'))
-    await common_logging_elasticsearch_httpx.com_es_httpx_post_async(message_type='info',
-                                                                     message_text={
-                                                                         'temphold': youtube_videos})
-    return {
-        'media': youtube_videos
+fn parse_video_renderer(video_renderer: &Value) -> Option<YoutubeVideoItem> {
+    let id = video_renderer.get("videoId")?.as_str()?.to_string();
+
+    let title = video_renderer
+        .get("title")
+        .and_then(extract_runs_text)
+        .unwrap_or_else(|| "Untitled video".to_string());
+
+    let channel_title = video_renderer
+        .get("ownerText")
+        .and_then(extract_runs_text)
+        .unwrap_or_else(|| "Unknown channel".to_string());
+
+    let duration = video_renderer
+        .get("lengthText")
+        .and_then(extract_runs_text)
+        .unwrap_or_else(|| "Live".to_string());
+
+    let thumbnail_url = video_renderer
+        .get("thumbnail")
+        .and_then(|thumb| thumb.get("thumbnails"))
+        .and_then(Value::as_array)
+        .and_then(|thumbs| thumbs.last())
+        .and_then(|thumb| thumb.get("url"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+
+    Some(YoutubeVideoItem {
+        id,
+        title,
+        channel_title,
+        duration,
+        thumbnail_url,
+    })
+}
+
+fn extract_runs_text(value: &Value) -> Option<String> {
+    if let Some(simple_text) = value.get("simpleText").and_then(Value::as_str) {
+        return Some(simple_text.to_string());
     }
 
+    value
+        .get("runs")
+        .and_then(Value::as_array)
+        .map(|runs| {
+            runs.iter()
+                .filter_map(|run| run.get("text").and_then(Value::as_str))
+                .collect::<String>()
+        })
+        .filter(|text| !text.is_empty())
+}
 
-@blueprint_user_internet_youtube.route('/user_internet/youtube_detail/<uuid>')
-@common_global.jinja_template.template('bss_user/internet/bss_user_internet_youtube_detail.html')
-@common_global.auth.login_required
-pub async fn url_bp_user_internet_youtube_detail(request, uuid):
-    """
-    Display youtube details page
-    """
-    return {
-        'media': g.google_instance.com_google_youtube_info(uuid),
-        'data_guid': uuid
-    }
-
- */
+fn is_valid_video_id(video_id: &str) -> bool {
+    video_id.len() == YOUTUBE_VIDEO_ID_LENGTH
+        && video_id.chars().all(|character| {
+            character.is_ascii_alphanumeric() || character == '-' || character == '_'
+        })
+}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_youtube.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_youtube.html
@@ -1,23 +1,53 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<div>
-        {% if template_data_exists %}
-        <div>
-            {#{% for row_data in template_data %}
-            <div class="main_photo">
-                <a href="/user/internet/youtube_detail/{{row_data[" items"][0]["id"]}}"">
-                    <img src="{{ row_data[" items"][0]["snippet"]["thumbnails"]["default"]["url"] }}" height="300"
-                        width="200">
-                </a>
-                <div class="description">
-                    <p class="description_content_left">{{row_data["items"][0]["snippet"]["title"]}}</p>
-                </div>
-            </div>
-            {% endfor %}#}
+<div class="space-y-6">
+    <form class="w-full" method="GET" action="/user/internet/youtube" role="search">
+        <label for="youtube-search" class="block text-sm font-medium mb-2">Search YouTube</label>
+        <div class="flex gap-2">
+            <input
+                id="youtube-search"
+                name="query"
+                type="text"
+                value="{{ search_query }}"
+                placeholder="Search videos, channels, or topics"
+                class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                aria-label="Search YouTube"
+            />
+            <button
+                type="submit"
+                class="rounded-md bg-red-600 text-white px-4 py-2 text-sm font-medium hover:bg-red-700"
+                aria-label="Run YouTube search"
+            >
+                Search
+            </button>
         </div>
-        {% else %}
-        <p id="general_text">No YouTube media found.</p>
-        {% endif %}
+    </form>
+
+    {% if template_data_exists %}
+    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {% for row_data in template_data %}
+        <article class="rounded-lg border border-gray-200 shadow-sm overflow-hidden bg-white">
+            <a href="/user/internet/youtube/{{ row_data.id }}" aria-label="Open YouTube video {{ row_data.title }}">
+                <img
+                    src="{{ row_data.thumbnail_url }}"
+                    alt="Thumbnail for {{ row_data.title }}"
+                    class="h-44 w-full object-cover"
+                    loading="lazy"
+                />
+            </a>
+            <div class="p-3 space-y-1">
+                <a href="/user/internet/youtube/{{ row_data.id }}" class="font-semibold text-sm hover:underline">
+                    {{ row_data.title }}
+                </a>
+                <p class="text-xs text-gray-600">{{ row_data.channel_title }}</p>
+                <p class="text-xs text-gray-500">{{ row_data.duration }}</p>
+            </div>
+        </article>
+        {% endfor %}
     </div>
+    {% else %}
+    <p id="general_text" class="text-sm text-gray-600">No YouTube media found for the current browse view.</p>
+    {% endif %}
+</div>
 {% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_youtube_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_youtube_detail.html
@@ -1,18 +1,20 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<div>
-        <form id="SearchForm" class="form form-youtube" method="POST" action="/user/internet/bss_user_internet_youtube"
-            role="form">
-            <div class="form-group">
-                < input label="Search string" , type="text" , name="search_string">
-            </div>
-        </form>
-        <video id="vid1" src="" class="video-js vjs-default-skin" controls preload="auto" width="100%" height="100%"
-            data-setup="{" fluid":"true","techOrder":["youtube"]}">
-            <source src="http://www.youtube.com/watch?v=" {{template_youtube_video_guid}} type="video/youtube">
-        </video>
+<div class="space-y-4">
+    <a href="/user/internet/youtube" class="inline-flex text-sm text-blue-700 hover:underline" aria-label="Back to YouTube browse page">
+        ← Back to YouTube browse
+    </a>
+
+    <div class="aspect-video w-full rounded-lg overflow-hidden border border-gray-200 bg-black">
+        <iframe
+            src="{{ template_embed_url }}"
+            title="YouTube player for {{ template_youtube_video_guid }}"
+            class="h-full w-full"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            referrerpolicy="strict-origin-when-cross-origin"
+            allowfullscreen
+        ></iframe>
     </div>
-<script src="/static/videojs/video.min.js"></script>
-    <script src="/static/videojs/Youtube.min.js"></script>
+</div>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Provide a complete YouTube browse + playback flow in the mkwebaxum internet pages to replace placeholders and allow searching, browsing trending, and embedded playback.

### Description
- Implemented server-side YouTube browsing and parsing in `docker/core/mkwebaxum/src/user/internet/bp_inter_youtube.rs` that fetches YouTube browse/search pages, extracts `ytInitialData`, and parses `videoRenderer` entries to collect `videoId`, `title`, `channel`, `duration`, and `thumbnail` while validating video IDs.
- Added a detail handler that validates a video id and returns an embed URL for playback, and exposed both handlers as `user_inter_youtube` and `user_inter_youtube_detail`.
- Replaced the placeholder UI with a responsive Tailwind-based browse template at `docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_youtube.html` (search form + result cards) and a playback template at `docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_youtube_detail.html` (iframe embed + back link).
- Wired the new detail route `/user/internet/youtube/{guid}` into the Axum router in `docker/core/mkwebaxum/src/main.rs` and kept changes isolated without adding new dependencies.

### Testing
- Ran `cargo fmt` in `docker/core/mkwebaxum` and it completed successfully.
- Ran `cargo check` in `docker/core/mkwebaxum` but it failed in this environment due to a private registry HTTP 403 preventing dependency resolution.
- Ran `cargo clippy -- -D warnings` in `docker/core/mkwebaxum` but it could not complete for the same private registry 403 error.
- Recommend runtime verification by starting the web app and visiting `/user/internet/youtube` (browse/search) and `/user/internet/youtube/{videoId}` (playback) to confirm end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2cc46851083218460c65d0c0c3730)