### PR TITLE
mkwebaxum: Add Vimeo browse and playback pages

### DIFF
--- a/docker/core/mkwebaxum/src/main.rs
+++ b/docker/core/mkwebaxum/src/main.rs
@@ -275,6 +275,10 @@ async fn main() {
             get(user_internet::bp_inter_vimeo::user_inter_vimeo),
         )
         .route_with_tsr(
+            "/user/internet/vimeo/{video_id}",
+            get(user_internet::bp_inter_vimeo::user_inter_vimeo_detail),
+        )
+        .route_with_tsr(
             "/user/internet/youtube",
             get(user_internet::bp_inter_youtube::user_inter_youtube),
         )

--- a/docker/core/mkwebaxum/src/user/internet/bp_inter_vimeo.rs
+++ b/docker/core/mkwebaxum/src/user/internet/bp_inter_vimeo.rs
@@ -1,31 +1,83 @@
+use crate::AppState;
 use crate::mk_lib_database;
 use askama::Template;
 use axum::{
-    extract::Path,
+    extract::{Path, Query, State},
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
-use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
+use serde::Deserialize;
 use sqlx::postgres::PgPool;
+use std::collections::BTreeMap;
+
+const VIMEO_BROWSE_PAGE_SIZE: usize = 24;
+const VIMEO_CHANNEL_DEFAULT: &str = "staffpicks";
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
 struct TemplateError401Context {}
 
 #[derive(Template)]
+#[template(path = "bss_error/bss_error_500.html")]
+struct TemplateError500Context {
+    page_title: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct VimeoBrowseQuery {
+    #[serde(default)]
+    q: String,
+    #[serde(default = "default_page")]
+    page: usize,
+}
+
+fn default_page() -> usize {
+    1
+}
+
+#[derive(Debug, Deserialize)]
+struct VimeoVideoItemRaw {
+    id: u64,
+    title: Option<String>,
+    description: Option<String>,
+    upload_date: Option<String>,
+    duration: Option<u64>,
+    thumbnail_large: Option<String>,
+    url: Option<String>,
+    user_name: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct VimeoVideoItem {
+    id: String,
+    title: String,
+    description_preview: String,
+    upload_date: String,
+    duration: String,
+    thumbnail_url: Option<String>,
+    user_name: String,
+    direct_url: Option<String>,
+}
+
+#[derive(Template)]
 #[template(path = "bss_user/internet/bss_user_internet_vimeo.html")]
-struct UserInternetVimeoTemplate<'a> {
-    //template_data: &'a Vec<mk_lib_database::mk_lib_database_cron::DBCronList>,
-    template_data_exists: &'a bool,
+struct UserInternetVimeoTemplate {
+    videos: Vec<VimeoVideoItem>,
+    has_videos: bool,
+    query: String,
+    page: usize,
+    pagination_prev: Option<usize>,
+    pagination_next: Option<usize>,
     page_title: Option<String>,
 }
 
 pub async fn user_inter_vimeo(
+    State(_state): State<AppState>,
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
+    Query(params): Query<VimeoBrowseQuery>,
 ) -> impl IntoResponse {
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
@@ -36,28 +88,77 @@ pub async fn user_inter_vimeo(
     .validate(&current_user, &method, None)
     .await
     {
-        let template = TemplateError401Context {};
-        let reply_html = template.render().unwrap();
-        (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
+        return render_401();
+    }
+
+    if params.page == 0 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Html("Invalid page. Page must be 1 or greater.".to_string()).into_response(),
+        );
+    }
+
+    let fetched = fetch_vimeo_videos(params.page).await;
+    let mut videos = match fetched {
+        Ok(items) => items,
+        Err(_) => return render_500(),
+    };
+
+    let query = params.q.trim().to_string();
+    if !query.is_empty() {
+        let query_lower = query.to_lowercase();
+        videos.retain(|video| {
+            video.title.to_lowercase().contains(&query_lower)
+                || video
+                    .description_preview
+                    .to_lowercase()
+                    .contains(&query_lower)
+                || video.user_name.to_lowercase().contains(&query_lower)
+        });
+    }
+
+    let has_videos = !videos.is_empty();
+    let pagination_prev = if params.page > 1 {
+        Some(params.page - 1)
     } else {
-        let template = UserInternetVimeoTemplate {
-            template_data_exists: &false,
-            page_title: Some("MediaKraken Vimeo".to_string()),
-        };
-        let reply_html = template.render().unwrap();
-        (StatusCode::OK, Html(reply_html).into_response())
+        None
+    };
+    let pagination_next = if has_videos {
+        Some(params.page + 1)
+    } else {
+        None
+    };
+
+    let template = UserInternetVimeoTemplate {
+        videos,
+        has_videos,
+        query,
+        page: params.page,
+        pagination_prev,
+        pagination_next,
+        page_title: Some("MediaKraken Vimeo".to_string()),
+    };
+
+    match template.render() {
+        Ok(reply_html) => (StatusCode::OK, Html(reply_html).into_response()),
+        Err(_) => render_500(),
     }
 }
 
 #[derive(Template)]
 #[template(path = "bss_user/internet/bss_user_internet_vimeo_detail.html")]
 struct UserInternetVimeoDetailTemplate {
+    video_id: String,
+    embed_url: String,
+    watch_url: String,
     page_title: Option<String>,
 }
 
 pub async fn user_inter_vimeo_detail(
+    State(_state): State<AppState>,
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
+    Path(video_id): Path<String>,
 ) -> impl IntoResponse {
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
@@ -68,14 +169,114 @@ pub async fn user_inter_vimeo_detail(
     .validate(&current_user, &method, None)
     .await
     {
-        let template = TemplateError401Context {};
-        let reply_html = template.render().unwrap();
-        (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
+        return render_401();
+    }
+
+    if !video_id.chars().all(|ch| ch.is_ascii_digit()) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Html("Invalid Vimeo video id.".to_string()).into_response(),
+        );
+    }
+
+    let template = UserInternetVimeoDetailTemplate {
+        embed_url: format!("https://player.vimeo.com/video/{video_id}?autoplay=0"),
+        watch_url: format!("https://vimeo.com/{video_id}"),
+        video_id,
+        page_title: Some("MediaKraken Vimeo Detail".to_string()),
+    };
+
+    match template.render() {
+        Ok(reply_html) => (StatusCode::OK, Html(reply_html).into_response()),
+        Err(_) => render_500(),
+    }
+}
+
+async fn fetch_vimeo_videos(page: usize) -> Result<Vec<VimeoVideoItem>, reqwest::Error> {
+    let mut query_params = BTreeMap::new();
+    query_params.insert("page", page.to_string());
+    query_params.insert("per_page", VIMEO_BROWSE_PAGE_SIZE.to_string());
+
+    let url = format!("https://vimeo.com/api/v2/channel/{VIMEO_CHANNEL_DEFAULT}/videos.json");
+    let response = reqwest::Client::new()
+        .get(url)
+        .query(&query_params)
+        .send()
+        .await?;
+    let raw: Vec<VimeoVideoItemRaw> = response.error_for_status()?.json().await?;
+    Ok(raw.into_iter().map(map_video_item).collect())
+}
+
+fn map_video_item(raw: VimeoVideoItemRaw) -> VimeoVideoItem {
+    let title = raw
+        .title
+        .unwrap_or_else(|| "Untitled Vimeo video".to_string());
+    let description_preview = truncate(raw.description.as_deref().unwrap_or(""), 180);
+    let upload_date = raw
+        .upload_date
+        .unwrap_or_else(|| "Unknown upload date".to_string());
+    let duration = format_duration(raw.duration.unwrap_or(0));
+    let user_name = raw
+        .user_name
+        .unwrap_or_else(|| "Unknown creator".to_string());
+
+    VimeoVideoItem {
+        id: raw.id.to_string(),
+        title,
+        description_preview,
+        upload_date,
+        duration,
+        thumbnail_url: raw.thumbnail_large,
+        user_name,
+        direct_url: raw.url,
+    }
+}
+
+fn format_duration(total_seconds: u64) -> String {
+    if total_seconds == 0 {
+        return "Unknown".to_string();
+    }
+    let hours = total_seconds / 3600;
+    let minutes = (total_seconds % 3600) / 60;
+    let seconds = total_seconds % 60;
+    if hours > 0 {
+        format!("{hours:02}:{minutes:02}:{seconds:02}")
     } else {
-        let template = UserInternetVimeoDetailTemplate {
-            page_title: Some("MediaKraken Vimeo Detail".to_string()),
-        };
-        let reply_html = template.render().unwrap();
-        (StatusCode::OK, Html(reply_html).into_response())
+        format!("{minutes:02}:{seconds:02}")
+    }
+}
+
+fn truncate(input: &str, max_chars: usize) -> String {
+    if input.chars().count() <= max_chars {
+        return input.to_string();
+    }
+    let trimmed: String = input.chars().take(max_chars).collect();
+    format!("{trimmed}…")
+}
+
+fn render_401() -> (StatusCode, axum::response::Response) {
+    let template = TemplateError401Context {};
+    match template.render() {
+        Ok(reply_html) => (StatusCode::UNAUTHORIZED, Html(reply_html).into_response()),
+        Err(_) => (
+            StatusCode::UNAUTHORIZED,
+            Html(String::from("Unauthorized")).into_response(),
+        ),
+    }
+}
+
+fn render_500() -> (StatusCode, axum::response::Response) {
+    let template = TemplateError500Context {
+        page_title: Some("MediaKraken Error".to_string()),
+    };
+    match template.render() {
+        Ok(reply_html) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Html(reply_html).into_response(),
+        ),
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Html(String::from("Internal server error")).into_response(),
+        ),
     }
 }

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_vimeo.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_vimeo.html
@@ -1,21 +1,88 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<div>
-        {% if template_data_exists %}
-        <div>
-            {#{% for row_data in template_data %}
-            {% if row_data[2] == None %}
-            <a href="/user/internet/vimeo_detail/{{row_data[1]}}"> {{row_data[0]}}</a>
-            {% else %}
-            <a href="/user/internet/vimeo_detail/{{row_data[1]}}">
-                <img src="/static/meta/images/{{row_data[2]}}" height="300" width="200">
-            </a>
-            {% endif %}
-            {% endfor %}#}
-        </div>
+<main class="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <section class="mb-6 rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                    <h1 class="text-2xl font-semibold">Vimeo Browse</h1>
+                    <p class="text-sm text-slate-300">Browse Vimeo staff picks and play videos directly in MediaKraken.</p>
+                </div>
+                <form method="get" action="/user/internet/vimeo" class="flex w-full max-w-xl gap-2" role="search" aria-label="Search Vimeo videos">
+                    <input
+                        type="search"
+                        name="q"
+                        value="{{ query }}"
+                        placeholder="Filter by title, description, or creator"
+                        class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-200 placeholder:text-slate-500 focus:border-sky-400 focus:outline-none"
+                        aria-label="Vimeo search query"
+                    />
+                    <input type="hidden" name="page" value="1" />
+                    <button type="submit" class="rounded-lg bg-sky-700 px-4 py-2 text-sm font-medium hover:bg-sky-600" aria-label="Apply Vimeo search filter">Search</button>
+                </form>
+            </div>
+        </section>
+
+        {% if has_videos %}
+        <section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {% for video in videos %}
+            <article class="flex flex-col gap-3 rounded-xl border border-slate-800 bg-slate-900 p-4">
+                <a href="/user/internet/vimeo/{{ video.id }}" class="block" aria-label="Open Vimeo video {{ video.title }}">
+                    {% if let Some(thumbnail_url) = video.thumbnail_url %}
+                    <img src="{{ thumbnail_url }}" alt="Thumbnail for {{ video.title }}" class="h-44 w-full rounded-lg object-cover" loading="lazy" decoding="async" />
+                    {% else %}
+                    <div class="flex h-44 w-full items-center justify-center rounded-lg bg-slate-800 text-sm text-slate-400">No thumbnail</div>
+                    {% endif %}
+                </a>
+
+                <div class="min-w-0">
+                    <h2 class="line-clamp-2 text-base font-semibold">{{ video.title }}</h2>
+                    <p class="mt-1 text-xs text-slate-400">By {{ video.user_name }}</p>
+                    <p class="mt-2 text-sm text-slate-300">{{ video.description_preview }}</p>
+                </div>
+
+                <dl class="grid grid-cols-2 gap-2 text-xs text-slate-400">
+                    <div>
+                        <dt>Uploaded</dt>
+                        <dd class="text-slate-200">{{ video.upload_date }}</dd>
+                    </div>
+                    <div>
+                        <dt>Duration</dt>
+                        <dd class="text-slate-200">{{ video.duration }}</dd>
+                    </div>
+                </dl>
+
+                <div class="mt-1 flex gap-2">
+                    <a href="/user/internet/vimeo/{{ video.id }}" class="inline-flex flex-1 items-center justify-center rounded-lg bg-teal-700 px-3 py-2 text-sm font-medium hover:bg-teal-600" aria-label="Play {{ video.title }} in embedded Vimeo player">
+                        Play
+                    </a>
+                    {% if let Some(direct_url) = video.direct_url %}
+                    <a href="{{ direct_url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center rounded-lg border border-slate-600 px-3 py-2 text-sm hover:border-slate-400 hover:bg-slate-800" aria-label="Open {{ video.title }} on Vimeo website">
+                        Vimeo
+                    </a>
+                    {% endif %}
+                </div>
+            </article>
+            {% endfor %}
+        </section>
         {% else %}
-        <p id="general_text">No Vimeo media found.</p>
+        <section class="rounded-xl border border-slate-800 bg-slate-900 p-6 text-center text-slate-300">
+            No Vimeo videos found for this page/filter.
+        </section>
         {% endif %}
-    </div>
+
+        <nav class="mt-6 flex items-center justify-between" aria-label="Vimeo pagination">
+            <div>
+                {% if let Some(previous_page) = pagination_prev %}
+                <a href="/user/internet/vimeo?page={{ previous_page }}&q={{ query }}" class="rounded-lg border border-slate-600 px-4 py-2 text-sm hover:border-slate-400 hover:bg-slate-800" aria-label="Go to previous Vimeo page">Previous</a>
+                {% endif %}
+            </div>
+            <p class="text-sm text-slate-300">Page {{ page }}</p>
+            <div>
+                {% if let Some(next_page) = pagination_next %}
+                <a href="/user/internet/vimeo?page={{ next_page }}&q={{ query }}" class="rounded-lg border border-slate-600 px-4 py-2 text-sm hover:border-slate-400 hover:bg-slate-800" aria-label="Go to next Vimeo page">Next</a>
+                {% endif %}
+            </div>
+        </nav>
+    </main>
 {% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_vimeo_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_vimeo_detail.html
@@ -1,5 +1,30 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<div></div>
+<main class="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+        <a href="/user/internet/vimeo" class="mb-4 inline-flex rounded-lg border border-slate-600 px-3 py-2 text-sm hover:border-slate-400 hover:bg-slate-800" aria-label="Back to Vimeo browse">← Back to Vimeo</a>
+
+        <article class="rounded-xl border border-slate-800 bg-slate-900 p-4 sm:p-6">
+            <header class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <h1 class="text-2xl font-semibold">Vimeo Playback</h1>
+                    <p class="text-sm text-slate-300">Video ID: {{ video_id }}</p>
+                </div>
+                <a href="{{ watch_url }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center rounded-lg border border-slate-600 px-4 py-2 text-sm hover:border-slate-400 hover:bg-slate-800" aria-label="Open Vimeo video {{ video_id }} on vimeo.com">
+                    Open on Vimeo
+                </a>
+            </header>
+
+            <div class="aspect-video w-full overflow-hidden rounded-lg border border-slate-800 bg-black">
+                <iframe
+                    src="{{ embed_url }}"
+                    title="Vimeo player for {{ video_id }}"
+                    class="h-full w-full"
+                    allow="autoplay; fullscreen; picture-in-picture"
+                    allowfullscreen
+                    loading="lazy"
+                ></iframe>
+            </div>
+        </article>
+    </main>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Provide full Vimeo browsing and playback in the mkwebaxum frontend where only placeholders previously existed, enabling users to discover and play Vimeo videos inside MediaKraken.

### Description
- Implemented browse handler `user_inter_vimeo` with query params (`q`, `page`), page validation, in-memory text filtering, and pagination using a new `VimeoBrowseQuery` type and mapping structs. 
- Implemented detail handler `user_inter_vimeo_detail` which validates the path `video_id` and generates `embed_url` and `watch_url` for the embedded Vimeo player.
- Added `fetch_vimeo_videos` to call Vimeo API v2 (channel `staffpicks`) and mapping functions (`VimeoVideoItemRaw` → `VimeoVideoItem`) plus helpers for duration formatting and truncation.
- Added route `/user/internet/vimeo/{video_id}` in `main.rs` and replaced the browse and detail Askama templates with responsive Tailwind UI supporting search, cards, metadata, and an embedded iframe player.

### Testing
- Ran `cargo fmt` in `docker/core/mkwebaxum` and it completed successfully. 
- Ran `cargo check` in `docker/core/mkwebaxum` which failed due to the environment's private registry/network returning HTTP 403 (external to these changes). 
- Ran `cargo clippy -- -D warnings` in `docker/core/mkwebaxum` which also failed for the same registry/network issue and not because of the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ccf2b2fc8321bb50769fe06eaa63)