### PR TITLE
Add TwitchTV browsing and stream playback routes

### DIFF
--- a/docker/core/mkwebaxum/src/main.rs
+++ b/docker/core/mkwebaxum/src/main.rs
@@ -271,6 +271,10 @@ async fn main() {
             get(user_internet::bp_inter_twitchtv::user_inter_twitchtv),
         )
         .route_with_tsr(
+            "/user/internet/twitchtv/{stream_name}",
+            get(user_internet::bp_inter_twitchtv::user_inter_twitchtv_detail),
+        )
+        .route_with_tsr(
             "/user/internet/vimeo",
             get(user_internet::bp_inter_vimeo::user_inter_vimeo),
         )

--- a/docker/core/mkwebaxum/src/user/internet/bp_inter_twitchtv.rs
+++ b/docker/core/mkwebaxum/src/user/internet/bp_inter_twitchtv.rs
@@ -1,15 +1,19 @@
+use crate::AppState;
 use crate::mk_lib_database;
 use askama::Template;
 use axum::{
-    extract::Path,
+    extract::{Path, State},
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
-use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
+use serde::Deserialize;
 use sqlx::postgres::PgPool;
+use std::env;
+
+const TWITCH_TOP_STREAMS_URL: &str = "https://api.twitch.tv/helix/streams?first=24";
+const TWITCH_EMBED_PARENT_DEFAULT: &str = "localhost";
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
@@ -17,13 +21,15 @@ struct TemplateError401Context {}
 
 #[derive(Template)]
 #[template(path = "bss_user/internet/bss_user_internet_twitch.html")]
-struct UserInternetTwitchTVTemplate<'a> {
-    //template_data: &'a Vec<mk_lib_database::mk_lib_database_cron::DBCronList>,
-    template_data_exists: &'a bool,
+struct UserInternetTwitchTVTemplate {
+    streams: Vec<TwitchStreamBrowseItem>,
+    has_streams: bool,
+    error_message: Option<String>,
     page_title: Option<String>,
 }
 
 pub async fn user_inter_twitchtv(
+    State(_state): State<AppState>,
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
 ) -> impl IntoResponse {
@@ -36,75 +42,176 @@ pub async fn user_inter_twitchtv(
     .validate(&current_user, &method, None)
     .await
     {
-        let template = TemplateError401Context {};
-        let reply_html = template.render().unwrap();
-        (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
-    } else {
-        let template = UserInternetTwitchTVTemplate {
-            template_data_exists: &false,
-            page_title: Some("MediaKraken TwitchTV".to_string()),
-        };
-        let reply_html = template.render().unwrap();
-        (StatusCode::OK, Html(reply_html).into_response())
+        return render_401();
+    }
+
+    let client_id = env::var("TWITCH_CLIENT_ID").ok();
+    let bearer_token = env::var("TWITCH_APP_ACCESS_TOKEN").ok();
+
+    let (streams, error_message) = match (client_id, bearer_token) {
+        (Some(client_id), Some(bearer_token)) => {
+            match fetch_twitch_streams(&client_id, &bearer_token).await {
+                Ok(streams) => (streams, None),
+                Err(()) => (
+                    Vec::new(),
+                    Some("Unable to load Twitch streams right now.".to_string()),
+                ),
+            }
+        }
+        _ => (
+            Vec::new(),
+            Some(
+                "Twitch integration is not configured. Set TWITCH_CLIENT_ID and TWITCH_APP_ACCESS_TOKEN."
+                    .to_string(),
+            ),
+        ),
+    };
+
+    let template = UserInternetTwitchTVTemplate {
+        has_streams: !streams.is_empty(),
+        streams,
+        error_message,
+        page_title: Some("MediaKraken TwitchTV".to_string()),
+    };
+
+    match template.render() {
+        Ok(reply_html) => (StatusCode::OK, Html(reply_html).into_response()),
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Html("Internal server error".to_string()).into_response(),
+        ),
     }
 }
 
-/*
-@blueprint_user_internet_twitch.route('/user_internet/twitch')
-@common_global.jinja_template.template('bss_user/internet/bss_user_internet_twitch.html')
-@common_global.auth.login_required
-pub async fn url_bp_user_internet_twitch(request):
-    """
-    Display twitchtv page
-    """
-    twitch_media = []
-    for stream_data in g.twitch_api.com_net_twitch_get_featured():
-        pass
+#[derive(Template)]
+#[template(path = "bss_user/internet/bss_user_internet_twitch_detail.html")]
+struct UserInternetTwitchTVDetailTemplate {
+    twitchtv_channel: String,
+    twitch_embed_parent: String,
+    page_title: Option<String>,
+}
 
-    # twitch_api = common_network_twitch.CommonNetworkTwitch()
-    # twitch_media = []
-    # for stream_data in twitch_api.com_twitch_get_featured_streams()['featured']:
-    #     await common_logging_elasticsearch_httpx.com_es_httpx_post_async(message_type='info',
-    #       message_text= {"stream": stream_data})
-    #     try:
-    #         if stream_data['stream']['game'] is None:
-    #             twitch_media.append((stream_data['stream']['name'],
-    #                                  stream_data['stream']['preview']['medium'],
-    #                                  'Not Available'))
-    #         else:
-    #             twitch_media.append((stream_data['stream']['name'],
-    #                                  stream_data['stream']['preview']['medium'],
-    #                                  stream_data['stream']['game']))
-    #     except:
-    #         if stream_data['stream']['channel']['game'] is None:
-    #             twitch_media.append((stream_data['stream']['channel']['name'],
-    #                                  stream_data['stream']['preview']['medium'],
-    #                                  'Not Available'))
-    #         else:
-    #             twitch_media.append((stream_data['stream']['channel']['name'],
-    #                                  stream_data['stream']['preview']['medium'],
-    #                                  stream_data['stream']['channel']['game']))
-    return {
-        'media': twitch_media
+#[derive(Deserialize)]
+struct TwitchStreamsResponse {
+    data: Vec<TwitchStreamApiItem>,
+}
+
+#[derive(Deserialize)]
+struct TwitchStreamApiItem {
+    user_login: String,
+    user_name: String,
+    title: String,
+    game_name: String,
+    viewer_count: i64,
+    thumbnail_url: String,
+}
+
+struct TwitchStreamBrowseItem {
+    channel_login: String,
+    channel_display_name: String,
+    stream_title: String,
+    game_name: String,
+    viewer_count: i64,
+    preview_image_url: String,
+}
+
+pub async fn user_inter_twitchtv_detail(
+    method: Method,
+    auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
+    Path(stream_name): Path<String>,
+) -> impl IntoResponse {
+    let current_user = auth.current_user.clone().unwrap_or_default();
+    if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
+        [Method::GET],
+        false,
+    )
+    .requires(Rights::any([Rights::permission("User::View")]))
+    .validate(&current_user, &method, None)
+    .await
+    {
+        return render_401();
     }
 
-
-@blueprint_user_internet_twitch.route('/user_internet/twitch_stream_detail/<stream_name>')
-@common_global.jinja_template.template(
-    'bss_user/internet/bss_user_internet_twitch_stream_detail.html')
-@common_global.auth.login_required
-pub async fn url_bp_user_internet_twitch_stream_detail(request, stream_name):
-    """
-    Show twitch stream detail page
-    """
-    # twitch_api = common_network_Twitch.com_Twitch_API()
-    # media = twitch_api.com_Twitch_Channel_by_Name(stream_name)
-    await common_logging_elasticsearch_httpx.com_es_httpx_post_async(message_type='info',
-                                                                     message_text={
-                                                                         'twitch stream_name':
-                                                                             stream_name})
-    return {
-        'media': stream_name
+    if !is_valid_twitch_channel(&stream_name) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Html("Invalid channel".to_string()).into_response(),
+        );
     }
 
- */
+    let template = UserInternetTwitchTVDetailTemplate {
+        twitchtv_channel: stream_name,
+        twitch_embed_parent: env::var("TWITCH_EMBED_PARENT")
+            .unwrap_or_else(|_| TWITCH_EMBED_PARENT_DEFAULT.to_string()),
+        page_title: Some("MediaKraken TwitchTV Stream".to_string()),
+    };
+
+    match template.render() {
+        Ok(reply_html) => (StatusCode::OK, Html(reply_html).into_response()),
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Html("Internal server error".to_string()).into_response(),
+        ),
+    }
+}
+
+fn render_401() -> (StatusCode, axum::response::Response) {
+    let template = TemplateError401Context {};
+    match template.render() {
+        Ok(reply_html) => (StatusCode::UNAUTHORIZED, Html(reply_html).into_response()),
+        Err(_) => (
+            StatusCode::UNAUTHORIZED,
+            Html("Unauthorized".to_string()).into_response(),
+        ),
+    }
+}
+
+async fn fetch_twitch_streams(
+    client_id: &str,
+    bearer_token: &str,
+) -> Result<Vec<TwitchStreamBrowseItem>, ()> {
+    let http_client = reqwest::Client::new();
+    let response = http_client
+        .get(TWITCH_TOP_STREAMS_URL)
+        .header("Client-Id", client_id)
+        .header("Authorization", format!("Bearer {bearer_token}"))
+        .send()
+        .await
+        .map_err(|_| ())?;
+
+    if !response.status().is_success() {
+        return Err(());
+    }
+
+    let response_data: TwitchStreamsResponse = response.json().await.map_err(|_| ())?;
+
+    Ok(response_data
+        .data
+        .into_iter()
+        .map(|stream| TwitchStreamBrowseItem {
+            channel_login: stream.user_login,
+            channel_display_name: stream.user_name,
+            stream_title: stream.title,
+            game_name: if stream.game_name.is_empty() {
+                "Not Available".to_string()
+            } else {
+                stream.game_name
+            },
+            viewer_count: stream.viewer_count,
+            preview_image_url: stream
+                .thumbnail_url
+                .replace("{width}", "640")
+                .replace("{height}", "360"),
+        })
+        .collect())
+}
+
+fn is_valid_twitch_channel(channel: &str) -> bool {
+    if channel.len() < 4 || channel.len() > 25 {
+        return false;
+    }
+
+    channel
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_twitch.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_twitch.html
@@ -1,22 +1,32 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<div>
-        {% if template_data_exists %}
-        <div>
-            {#{% for row_data in template_data %}
-            <div class="main_photo">
-                <a href="/user/internet/twichtv_detail/{{row_data[0]}}">
-                    <img src="{{ row_data[1] }}" height="180" width="320">
-                </a>
-                <div class="description">
-                    <p class="description_content_left">{{row_data[0]}}: {{row_data[2]}}</p>
+<div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+    {% if let Some(message) = error_message %}
+    <p id="general_text" class="mb-4 text-red-500">{{ message }}</p>
+    {% endif %}
+
+    {% if has_streams %}
+    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {% for stream in streams %}
+        <a href="/user/internet/twitchtv/{{ stream.channel_login }}"
+            aria-label="Open Twitch stream {{ stream.channel_display_name }}"
+            class="group block overflow-hidden rounded-lg border border-zinc-700 bg-zinc-900 transition-colors hover:border-purple-400">
+            <img src="{{ stream.preview_image_url }}" alt="Preview image for {{ stream.channel_display_name }}"
+                class="h-44 w-full object-cover" loading="lazy">
+            <div class="space-y-2 p-4">
+                <p class="font-semibold text-white">{{ stream.channel_display_name }}</p>
+                <p class="line-clamp-2 text-sm text-zinc-200">{{ stream.stream_title }}</p>
+                <div class="flex items-center justify-between text-xs text-zinc-300">
+                    <span>{{ stream.game_name }}</span>
+                    <span>{{ stream.viewer_count }} viewers</span>
                 </div>
             </div>
-            {% endfor %} #}
-        </div>
-        {% else %}
-        <p id="general_text">No Twitch TV media found.</p>
-        {% endif %}
+        </a>
+        {% endfor %}
     </div>
+    {% else %}
+    <p id="general_text">No Twitch TV media found.</p>
+    {% endif %}
+</div>
 {% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_twitch_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_twitch_detail.html
@@ -1,17 +1,16 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<div>
-    <div id="twitch-embed"></div>
-    <!-- Load the Twitch embed script -->
+<div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+    <div id="twitch-embed" class="aspect-video w-full overflow-hidden rounded-lg"></div>
     <script src="https://embed.twitch.tv/embed/v1.js"></script>
-    <!-- Create a Twitch.Embed object that will render within the "twitch-embed" root element. -->
     <script type="text/javascript">
       new Twitch.Embed("twitch-embed", {
-        width: 1280,
-        height: 720,
-        channel: "{{twitchtv_channel}}"
+        width: "100%",
+        height: "100%",
+        channel: "{{ twitchtv_channel }}",
+        parent: ["{{ twitch_embed_parent }}"]
       });
     </script>
-  </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Provide full Twitch browsing and playback inside the existing internet UI so users can browse top live streams and play a selected channel inline. 
- Use the Twitch Helix API for reliable stream listing and the official Twitch embed for playback while keeping integration behind configuration. 
- Gracefully handle missing credentials and invalid channel input to avoid exposing internal errors to users. 

### Description
- Added a Twitch browse handler that calls the Helix streams endpoint and maps results to a template-friendly model (`fetch_twitch_streams`, `TwitchStreamBrowseItem`) in `docker/core/mkwebaxum/src/user/internet/bp_inter_twitchtv.rs`.
- Added a stream detail handler with channel-name validation and embed configuration that uses `TWITCH_EMBED_PARENT` (default `localhost`) to render the official Twitch player in `docker/core/mkwebaxum/src/user/internet/bp_inter_twitchtv.rs` and registered the route `GET /user/internet/twitchtv/{stream_name}` in `docker/core/mkwebaxum/src/main.rs`.
- Updated templates to present browse cards and the responsive embedded player in `docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_twitch.html` and `..._twitch_detail.html` and added server-side error messaging when credentials or requests fail.
- Configuration required: set `TWITCH_CLIENT_ID` and `TWITCH_APP_ACCESS_TOKEN` for API calls and optionally `TWITCH_EMBED_PARENT` for embed parent domains, with clear fallback/error messaging if missing. 

### Testing
- Ran `cargo fmt` in `docker/core/mkwebaxum` and it completed successfully. 
- Ran `cargo check` in `docker/core/mkwebaxum` but it was blocked by the private Kellnr registry returning HTTP 403 when fetching the dependency index, so a full compile verification could not be completed. 
- Ran `cargo clippy -- -D warnings` in `docker/core/mkwebaxum` but it was likewise blocked by the private registry HTTP 403, so lints could not be validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2cd15148c8321a96edfe5bd8130ab)