### PR TITLE
Add Flickr browse and detail viewing pages

### DIFF
--- a/docker/core/mkwebaxum/src/user/internet/bp_inter_flickr.rs
+++ b/docker/core/mkwebaxum/src/user/internet/bp_inter_flickr.rs
@@ -1,32 +1,111 @@
 use crate::mk_lib_database;
 use askama::Template;
 use axum::{
-    extract::Path,
+    extract::{Path, Query},
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
-use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
+use serde::Deserialize;
 use sqlx::postgres::PgPool;
-//use flickr::methods::favorites::Photos;
+
+const FLICKR_PUBLIC_FEED_URL: &str = "https://www.flickr.com/services/feeds/photos_public.gne";
+const MAX_TAG_LENGTH: usize = 120;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
 struct TemplateError401Context {}
 
 #[derive(Template)]
-#[template(path = "bss_user/internet/bss_user_internet_flickr.html")]
-struct TemplateUserInternetFlickr<'a> {
-    // template_data: &'a Photos,
-    template_data_exists: &'a bool,
+#[template(path = "bss_error/bss_error_500.html")]
+struct TemplateError500Context {
     page_title: Option<String>,
+}
+
+#[derive(Clone)]
+struct FlickrBrowseItem {
+    id: String,
+    title: String,
+    author: String,
+    image_url: String,
+    published: String,
+    link_url: String,
+    tags: String,
+    description: String,
+}
+
+#[derive(Clone)]
+struct FlickrDetailItem {
+    id: String,
+    title: String,
+    author: String,
+    image_url: String,
+    published: String,
+    link_url: String,
+    tags: String,
+    description: String,
+}
+
+#[derive(Template)]
+#[template(path = "bss_user/internet/bss_user_internet_flickr.html")]
+struct TemplateUserInternetFlickr {
+    items: Vec<FlickrBrowseItem>,
+    has_items: bool,
+    tags: String,
+    page_title: Option<String>,
+}
+
+#[derive(Template)]
+#[template(path = "bss_user/internet/bss_user_internet_flickr_detail.html")]
+struct TemplateUserInternetFlickrDetail {
+    item: FlickrDetailItem,
+    page_title: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct FlickrBrowseQuery {
+    tags: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct FlickrDetailQuery {
+    title: Option<String>,
+    author: Option<String>,
+    image: Option<String>,
+    published: Option<String>,
+    link: Option<String>,
+    tags: Option<String>,
+    description: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct FlickrFeedResponse {
+    items: Vec<FlickrFeedItem>,
+}
+
+#[derive(Deserialize)]
+struct FlickrFeedItem {
+    title: String,
+    link: String,
+    media: FlickrMedia,
+    #[serde(rename = "date_taken")]
+    _date_taken: String,
+    description: String,
+    published: String,
+    author: String,
+    tags: String,
+}
+
+#[derive(Deserialize)]
+struct FlickrMedia {
+    m: String,
 }
 
 pub async fn user_inter_flickr(
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
+    Query(query): Query<FlickrBrowseQuery>,
 ) -> impl IntoResponse {
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
@@ -37,30 +116,40 @@ pub async fn user_inter_flickr(
     .validate(&current_user, &method, None)
     .await
     {
-        let template = TemplateError401Context {};
-        let reply_html = template.render().unwrap();
-        (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
-    } else {
-        let template = TemplateUserInternetFlickr {
-            // template_data: ,
-            template_data_exists: &false,
-            page_title: Some("MediaKraken Flickr".to_string()),
-        };
-        let reply_html = template.render().unwrap();
-        (StatusCode::OK, Html(reply_html).into_response())
+        return render_401();
     }
-}
 
-#[derive(Template)]
-#[template(path = "bss_user/internet/bss_user_internet_flickr_detail.html")]
-struct TemplateUserInternetFlickrDetail<'a> {
-    template_data_exists: &'a bool,
-    page_title: Option<String>,
+    let tags = sanitize_tags(query.tags.as_deref().unwrap_or_default());
+
+    let feed =
+        match fetch_flickr_public_feed(if tags.is_empty() { None } else { Some(&tags) }).await {
+            Ok(items) => items,
+            Err(_) => return render_500(),
+        };
+
+    let items = feed
+        .into_iter()
+        .filter_map(|item| map_feed_item_to_browse_item(&item))
+        .collect::<Vec<FlickrBrowseItem>>();
+
+    let template = TemplateUserInternetFlickr {
+        has_items: !items.is_empty(),
+        items,
+        tags,
+        page_title: Some("MediaKraken Flickr".to_string()),
+    };
+
+    match template.render() {
+        Ok(reply_html) => (StatusCode::OK, Html(reply_html).into_response()),
+        Err(_) => render_500(),
+    }
 }
 
 pub async fn user_inter_flickr_detail(
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
+    Path(guid): Path<String>,
+    Query(query): Query<FlickrDetailQuery>,
 ) -> impl IntoResponse {
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
@@ -71,15 +160,177 @@ pub async fn user_inter_flickr_detail(
     .validate(&current_user, &method, None)
     .await
     {
-        let template = TemplateError401Context {};
-        let reply_html = template.render().unwrap();
-        (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
+        return render_401();
+    }
+
+    let from_query = build_detail_from_query(&guid, &query);
+    let detail_item = if let Some(detail) = from_query {
+        detail
     } else {
-        let template = TemplateUserInternetFlickrDetail {
-            template_data_exists: &false,
-            page_title: Some("MediaKraken Flickr Detail".to_string()),
+        let feed = match fetch_flickr_public_feed(None).await {
+            Ok(items) => items,
+            Err(_) => return render_500(),
         };
-        let reply_html = template.render().unwrap();
-        (StatusCode::OK, Html(reply_html).into_response())
+
+        match feed
+            .iter()
+            .find_map(|item| map_feed_item_to_detail_item(item, &guid))
+        {
+            Some(item) => item,
+            None => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Html(String::from("Flickr item not found")).into_response(),
+                );
+            }
+        }
+    };
+
+    let template = TemplateUserInternetFlickrDetail {
+        item: detail_item,
+        page_title: Some("MediaKraken Flickr Detail".to_string()),
+    };
+
+    match template.render() {
+        Ok(reply_html) => (StatusCode::OK, Html(reply_html).into_response()),
+        Err(_) => render_500(),
+    }
+}
+
+async fn fetch_flickr_public_feed(
+    tags: Option<&str>,
+) -> Result<Vec<FlickrFeedItem>, Box<dyn std::error::Error + Send + Sync>> {
+    let mut request = reqwest::Client::new()
+        .get(FLICKR_PUBLIC_FEED_URL)
+        .query(&[("format", "json"), ("nojsoncallback", "1")]);
+
+    if let Some(tag_filter) = tags {
+        if !tag_filter.trim().is_empty() {
+            request = request.query(&[("tags", tag_filter)]);
+        }
+    }
+
+    let response = request.send().await?.error_for_status()?;
+    let payload = response.json::<FlickrFeedResponse>().await?;
+    Ok(payload.items)
+}
+
+fn map_feed_item_to_browse_item(item: &FlickrFeedItem) -> Option<FlickrBrowseItem> {
+    let id = extract_photo_id(&item.link)?;
+
+    Some(FlickrBrowseItem {
+        id,
+        title: fallback_text(&item.title, "Untitled"),
+        author: fallback_text(&item.author, "Unknown author"),
+        image_url: item.media.m.clone(),
+        published: item.published.clone(),
+        link_url: item.link.clone(),
+        tags: fallback_text(&item.tags, "No tags"),
+        description: fallback_text(&item.description, "No description."),
+    })
+}
+
+fn map_feed_item_to_detail_item(
+    item: &FlickrFeedItem,
+    requested_id: &str,
+) -> Option<FlickrDetailItem> {
+    let id = extract_photo_id(&item.link)?;
+    if id != requested_id {
+        return None;
+    }
+
+    Some(FlickrDetailItem {
+        id,
+        title: fallback_text(&item.title, "Untitled"),
+        author: fallback_text(&item.author, "Unknown author"),
+        image_url: item.media.m.clone(),
+        published: item.published.clone(),
+        link_url: item.link.clone(),
+        tags: fallback_text(&item.tags, "No tags"),
+        description: fallback_text(&item.description, "No description."),
+    })
+}
+
+fn build_detail_from_query(guid: &str, query: &FlickrDetailQuery) -> Option<FlickrDetailItem> {
+    let (Some(image_url), Some(link_url)) = (query.image.clone(), query.link.clone()) else {
+        return None;
+    };
+
+    Some(FlickrDetailItem {
+        id: guid.to_string(),
+        title: fallback_text(query.title.as_deref().unwrap_or_default(), "Untitled"),
+        author: fallback_text(
+            query.author.as_deref().unwrap_or_default(),
+            "Unknown author",
+        ),
+        image_url,
+        published: fallback_text(
+            query.published.as_deref().unwrap_or_default(),
+            "Unknown publish date",
+        ),
+        link_url,
+        tags: fallback_text(query.tags.as_deref().unwrap_or_default(), "No tags"),
+        description: fallback_text(
+            query.description.as_deref().unwrap_or_default(),
+            "No description.",
+        ),
+    })
+}
+
+fn extract_photo_id(link: &str) -> Option<String> {
+    let path_without_query = link.split('?').next().unwrap_or_default();
+    let trimmed = path_without_query.trim_end_matches('/');
+    trimmed.rsplit('/').next().map(str::to_string)
+}
+
+fn fallback_text(input: &str, fallback: &str) -> String {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn sanitize_tags(input: &str) -> String {
+    let compact = input
+        .split(',')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<&str>>()
+        .join(",");
+
+    if compact.len() > MAX_TAG_LENGTH {
+        compact[..MAX_TAG_LENGTH].to_string()
+    } else {
+        compact
+    }
+}
+
+fn render_401() -> (StatusCode, axum::response::Response) {
+    let template = TemplateError401Context {};
+    match template.render() {
+        Ok(reply_html) => (StatusCode::UNAUTHORIZED, Html(reply_html).into_response()),
+        Err(_) => (
+            StatusCode::UNAUTHORIZED,
+            Html(String::from("Unauthorized")).into_response(),
+        ),
+    }
+}
+
+fn render_500() -> (StatusCode, axum::response::Response) {
+    let template = TemplateError500Context {
+        page_title: Some("MediaKraken Error".to_string()),
+    };
+
+    match template.render() {
+        Ok(reply_html) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Html(reply_html).into_response(),
+        ),
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Html(String::from("Internal server error")).into_response(),
+        ),
     }
 }

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_flickr.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_flickr.html
@@ -1,22 +1,54 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<div>
-        {% if template_data_exists %}
-        <div>
-            {# {% for row_data in template_data %}
-            <div class="main_photo">
-                <a href="/user/internet/flickr_detail/{{row_data.id}}">
-                    <img src="{{ row_data[1] }}" height="180" width="320">
-                </a>
-                <div class="description">
-                    <p class="description_content_left">{{row_data.id}}: {{row_data.title}}</p>
-                </div>
+<main class="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+    <section class="mb-6 rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+        <h1 class="text-2xl font-semibold">Flickr Browse</h1>
+        <p class="mt-1 text-sm text-slate-300">Browse Flickr public photos, optionally filtered by tags.</p>
+
+        <form action="/user/internet/flickr" method="get" class="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end">
+            <div class="w-full sm:max-w-md">
+                <label for="flickr-tags" class="block text-sm font-medium text-slate-200">Tags (comma separated)</label>
+                <input
+                    id="flickr-tags"
+                    name="tags"
+                    type="text"
+                    value="{{ tags }}"
+                    placeholder="nature,sunset"
+                    class="mt-1 w-full rounded-lg border border-slate-600 bg-slate-950 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-teal-400 focus:outline-none"
+                >
             </div>
-            {% endfor %} #}
-        </div>
-        {% else %}
-        <p id="general_text">No Flickr media found.</p>
-        {% endif %}
-    </div>
+            <div class="flex gap-2">
+                <button type="submit" class="rounded-lg bg-teal-700 px-4 py-2 text-sm font-medium text-white hover:bg-teal-600" aria-label="Search Flickr tags">Search</button>
+                <a href="/user/internet/flickr" class="rounded-lg border border-slate-600 px-4 py-2 text-sm text-slate-200 hover:border-slate-400 hover:bg-slate-800" aria-label="Clear Flickr tag filter">Clear</a>
+            </div>
+        </form>
+    </section>
+
+    {% if has_items %}
+    <section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {% for item in items %}
+        <article class="overflow-hidden rounded-xl border border-slate-800 bg-slate-900">
+            <img src="{{ item.image_url }}" alt="{{ item.title }}" class="h-56 w-full object-cover" loading="lazy" decoding="async">
+            <div class="space-y-2 p-4">
+                <h2 class="truncate text-base font-semibold text-slate-100">{{ item.title }}</h2>
+                <p class="truncate text-sm text-slate-300">{{ item.author }}</p>
+                <p class="text-xs text-slate-400">Published: {{ item.published }}</p>
+                <a
+                    href="/user/internet/flickr/{{ item.id }}?title={{ item.title|urlencode }}&author={{ item.author|urlencode }}&image={{ item.image_url|urlencode }}&published={{ item.published|urlencode }}&link={{ item.link_url|urlencode }}&tags={{ item.tags|urlencode }}&description={{ item.description|urlencode }}"
+                    class="mt-2 inline-flex w-full items-center justify-center rounded-lg bg-slate-800 px-3 py-2 text-sm font-medium text-slate-100 hover:bg-slate-700"
+                    aria-label="View Flickr details for {{ item.title }}"
+                >
+                    View details
+                </a>
+            </div>
+        </article>
+        {% endfor %}
+    </section>
+    {% else %}
+    <section class="rounded-xl border border-slate-800 bg-slate-900 p-6 text-center text-slate-300">
+        No Flickr media found for this filter.
+    </section>
+    {% endif %}
+</main>
 {% endblock %}

--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_flickr_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_flickr_detail.html
@@ -1,5 +1,27 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<div></div>
+<main class="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
+    <a href="/user/internet/flickr" class="mb-4 inline-flex rounded-lg border border-slate-600 px-3 py-2 text-sm hover:border-slate-400 hover:bg-slate-800" aria-label="Back to Flickr browse">← Back to browse</a>
+
+    <article class="rounded-xl border border-slate-800 bg-slate-900 p-5">
+        <header class="flex flex-col gap-4 sm:flex-row">
+            <img src="{{ item.image_url }}" alt="{{ item.title }}" class="h-72 w-full rounded-lg object-cover sm:w-80" loading="lazy" decoding="async">
+            <div class="min-w-0">
+                <p class="text-xs uppercase tracking-wide text-slate-400">Flickr Photo ID: {{ item.id }}</p>
+                <h1 class="mt-1 text-3xl font-semibold text-slate-100">{{ item.title }}</h1>
+                <p class="mt-2 text-slate-300">{{ item.author }}</p>
+                <p class="mt-1 text-sm text-slate-400">Published: {{ item.published }}</p>
+                <p class="mt-1 text-sm text-slate-400">Tags: {{ item.tags }}</p>
+
+                <a href="{{ item.link_url }}" target="_blank" rel="noopener noreferrer" class="mt-4 inline-flex rounded-lg bg-teal-700 px-4 py-2 text-sm font-medium text-white hover:bg-teal-600" aria-label="Open Flickr photo on flickr.com">Open on Flickr</a>
+            </div>
+        </header>
+
+        <section class="mt-5">
+            <h2 class="text-lg font-medium text-slate-100">Description</h2>
+            <p class="mt-2 whitespace-pre-wrap text-slate-200">{{ item.description }}</p>
+        </section>
+    </article>
+</main>
 {% endblock %}


### PR DESCRIPTION
### Motivation

- Provide full Flickr browsing and photo viewing inside the web UI using the existing Flickr source code and public feed, so users can browse public Flickr photos (with optional tag filters) and view full photo details. 

### Description

- Implemented a new, fully-functional Flickr browsing handler at `docker/core/mkwebaxum/src/user/internet/bp_inter_flickr.rs` that accepts `tags` query input, sanitizes it, fetches Flickr's public JSON feed, maps feed items to typed structs, and returns rendered Askama templates.
- Implemented a Flickr detail route that accepts a path `guid` and optional query-provided metadata and falls back to a feed lookup by photo id when needed, returning 401/404/500 responses safely via `render_401()`/`render_500()` helpers.
- Added and updated Askama templates for browse and detail views at `docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_flickr.html` and `..._flickr_detail.html` to provide a tag search form, card-based browse UI, and a full detail card with image, tags and external link.
- Input handling and parsing are confined to the new handler: `FlickrBrowseQuery`, `FlickrDetailQuery`, `FlickrFeedResponse/FlickrFeedItem` structs, `sanitize_tags()`, `extract_photo_id()`, and small mapping helpers for safe template contexts.

### Testing

- Ran `cargo fmt` in `docker/core/mkwebaxum` which completed successfully.
- Attempted `cargo check` and `cargo clippy -- -D warnings` for the package but both were blocked by the environment's external registry (the configured Kellnr crates registry returned `403 Forbidden`).
- Ran `cargo fmt --check` repo-wide which reported unrelated formatting diffs outside the scope of this change (formatting drift), so a full repo check could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2cf1eb3d883218b3b525a37706d89)