### PR TITLE
mktranscode: add ebook conversion support (EbookConvert subtype)

### DIFF
--- a/docker/core/mktranscode/src/main.rs
+++ b/docker/core/mktranscode/src/main.rs
@@ -3,6 +3,7 @@ use mk_lib_database;
 use mk_lib_rabbitmq;
 use serde_json::{Value, json};
 use std::error::Error;
+use std::path::Path;
 use tokio::process::Command;
 use tokio::sync::Notify;
 
@@ -55,6 +56,93 @@ fn cast_stream_argument(json_message: &Value) -> Option<(&'static str, String)> 
             ("-playfile", target)
         }
     })
+}
+
+fn json_string_from_keys<'a>(json_message: &'a Value, keys: &[&str]) -> Option<&'a str> {
+    keys.iter()
+        .find_map(|key| json_message.get(*key))
+        .and_then(Value::as_str)
+}
+
+fn ebook_conversion_targets(json_message: &Value) -> Option<(String, String)> {
+    let data = &json_message["Data"];
+    let source_path = json_string_from_keys(
+        data,
+        &[
+            "Input",
+            "Input Path",
+            "Source",
+            "Source Path",
+            "Path",
+            "Media Path",
+        ],
+    )
+    .or_else(|| json_string_from_keys(json_message, &["Input", "Input Path", "Media Path"]))?;
+
+    let output_path = json_string_from_keys(data, &["Output", "Output Path"]).map(String::from);
+    if let Some(explicit_path) = output_path {
+        return Some((source_path.to_string(), explicit_path));
+    }
+
+    let output_format = json_string_from_keys(data, &["Format", "Output Format", "To", "Target"])
+        .or_else(|| json_string_from_keys(json_message, &["Format", "Output Format", "To"]))?
+        .trim()
+        .trim_start_matches('.')
+        .to_lowercase();
+
+    if output_format.is_empty() {
+        return None;
+    }
+
+    let source = Path::new(source_path);
+    let source_parent = source.parent().unwrap_or_else(|| Path::new(""));
+    let source_stem = source.file_stem()?.to_str()?;
+    let output_file_name = format!("{source_stem}.{output_format}");
+    let output_target = source_parent.join(output_file_name);
+
+    Some((
+        source_path.to_string(),
+        output_target.to_string_lossy().to_string(),
+    ))
+}
+
+async fn convert_ebook(json_message: &Value) {
+    let Some((input_path, output_path)) = ebook_conversion_targets(json_message) else {
+        eprintln!("mktranscode: ebook conversion skipped, missing input/output parameters");
+        return;
+    };
+
+    let calibre_result = Command::new("ebook-convert")
+        .args([&input_path, &output_path])
+        .status()
+        .await;
+
+    match calibre_result {
+        Ok(status) if status.success() => return,
+        Ok(status) => {
+            eprintln!(
+                "mktranscode: ebook-convert failed with status {status}, falling back to pandoc"
+            );
+        }
+        Err(error) => {
+            eprintln!("mktranscode: ebook-convert unavailable ({error}), falling back to pandoc");
+        }
+    }
+
+    let pandoc_result = Command::new("pandoc")
+        .args([&input_path, "-o", &output_path])
+        .status()
+        .await;
+
+    match pandoc_result {
+        Ok(status) if status.success() => {}
+        Ok(status) => {
+            eprintln!("mktranscode: pandoc ebook conversion failed with status {status}");
+        }
+        Err(error) => {
+            eprintln!("mktranscode: pandoc unavailable for ebook conversion ({error})");
+        }
+    }
 }
 
 #[tokio::main]
@@ -214,6 +302,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         // db_connection.db_update_media_json(json_message["Media UUID"], {
                         //     "ChapterImages": chapter_image_list
                         //});
+                    } else if json_message["Subtype"] == "EbookConvert" {
+                        convert_ebook(&json_message).await;
                     }
                     // } else if json_message["Subtype"] == "Sync" {
                     //     ffmpeg_params = [


### PR DESCRIPTION
### Motivation

- Provide mktranscode worker the ability to convert between ebook formats when a message requests it, so ebooks can be transformed as part of existing RabbitMQ-driven workflows.
- Accept flexible JSON payload keys (e.g. `Input`, `Input Path`, `Format`, `Output`, etc.) to match existing message producers without requiring strict field names.

### Description

- Added `json_string_from_keys` and `ebook_conversion_targets` helpers to extract input path and derive an output path/format from the incoming `Data` payload when available in multiple possible key names (`Input`, `Source`, `Path`, `Format`, `Output`, etc.).
- Implemented `convert_ebook` which attempts conversion by running the `ebook-convert` (Calibre) CLI and falls back to `pandoc` when `ebook-convert` is unavailable or fails, and logs errors to stderr without panicking.
- Wired the conversion flow into the RabbitMQ handler so messages with `Type == "FFMPEG"` and `Subtype == "EbookConvert"` invoke `convert_ebook`.
- Only changed `docker/core/mktranscode/src/main.rs` and added a `use std::path::Path` import; behavior is non-breaking and additive.

### Testing

- Ran `rustfmt --edition 2024 docker/core/mktranscode/src/main.rs` which completed successfully.
- Attempted `cargo fmt --manifest-path docker/core/mktranscode/Cargo.toml` which failed in this environment due to missing `kellnr` registry configuration.
- Attempted `cargo check --manifest-path docker/core/mktranscode/Cargo.toml` and `cargo clippy --manifest-path docker/core/mktranscode/Cargo.toml -- -D warnings` which both failed in this environment for the same missing `kellnr` registry reason.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ebdfa618832182b2336eafdd3fa8)