### PR TITLE
Add Internet section links to user sidebar

### DIFF
--- a/docker/core/mkwebaxum/templates/partials/sidebar_user.html
+++ b/docker/core/mkwebaxum/templates/partials/sidebar_user.html
@@ -67,6 +67,27 @@
                 </a>
             </div>
 
+
+            <div class="space-y-1">
+                <h3 class="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">Internet</h3>
+                <a href="/user/internet/flickr" class="flex items-center rounded-lg px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-200 dark:text-zinc-200 dark:hover:bg-zinc-800">
+                    <span class="w-5 flex justify-center">{% include "icons/link.svg" %}</span>
+                    <span class="ml-3">Flickr</span>
+                </a>
+                <a href="/user/internet/youtube" class="flex items-center rounded-lg px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-200 dark:text-zinc-200 dark:hover:bg-zinc-800">
+                    <span class="w-5 flex justify-center">{% include "icons/play.svg" %}</span>
+                    <span class="ml-3">YouTube</span>
+                </a>
+                <a href="/user/internet/twitchtv" class="flex items-center rounded-lg px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-200 dark:text-zinc-200 dark:hover:bg-zinc-800">
+                    <span class="w-5 flex justify-center">{% include "icons/video.svg" %}</span>
+                    <span class="ml-3">TwitchTV</span>
+                </a>
+                <a href="/user/internet/vimeo" class="flex items-center rounded-lg px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-200 dark:text-zinc-200 dark:hover:bg-zinc-800">
+                    <span class="w-5 flex justify-center">{% include "icons/video.svg" %}</span>
+                    <span class="ml-3">Vimeo</span>
+                </a>
+            </div>
+
             <div class="space-y-1">
                 <h3 class="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">System</h3>
                 <a href="/user/hardware" class="flex items-center rounded-lg px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-200 dark:text-zinc-200 dark:hover:bg-zinc-800">


### PR DESCRIPTION
### Motivation
- Add an "Internet" section to the mkwebaxum user side navigation so users can access Flickr, YouTube, TwitchTV and Vimeo directly from the sidebar.

### Description
- Inserted a new `Internet` block into `docker/core/mkwebaxum/templates/partials/sidebar_user.html` that adds links for `Flickr` (`/user/internet/flickr`), `YouTube` (`/user/internet/youtube`), `TwitchTV` (`/user/internet/twitchtv`) and `Vimeo` (`/user/internet/vimeo`).
- Reused existing Tailwind classes and icon includes (`icons/link.svg`, `icons/play.svg`, `icons/video.svg`) so the new items match existing sidebar styling and behavior.

### Testing
- Ran `cargo fmt --manifest-path docker/core/mkwebaxum/Cargo.toml`, which failed in this environment due to missing registry configuration (`kellnr`).
- Ran `cargo check --manifest-path docker/core/mkwebaxum/Cargo.toml`, which failed for the same missing registry reason.
- Ran `cargo clippy --manifest-path docker/core/mkwebaxum/Cargo.toml -- -D warnings`, which also failed due to the missing `kellnr` registry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c321082e148321b2fb594860a71f03)