### PR TITLE
mkwebaxum: source movie language filter from language table and render as combobox

### DIFF
--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
@@ -301,15 +301,15 @@ pub async fn user_metadata_movie(
         )
         .unwrap();
         let primary_language_options: Vec<FilterOption> =
-            mk_lib_database::database_metadata::mk_lib_database_metadata_movie::mk_lib_database_metadata_movie_languages(
+            mk_lib_database::mk_lib_database_language::mk_lib_database_language_read(
                 &state.sqlx_pool_ro,
             )
             .await
             .unwrap_or_default()
             .into_iter()
             .map(|row| FilterOption {
-                label: row.primary_language.to_uppercase(),
-                query_value: row.primary_language,
+                label: row.language,
+                query_value: row.code.to_lowercase(),
             })
             .collect();
         let status_options = vec![

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html
@@ -9,15 +9,28 @@
   <div class="mt-4 space-y-4 rounded-xl border border-zinc-200 bg-white/70 p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900/70">
     <div class="space-y-2">
       <h2 class="text-sm font-semibold tracking-wide text-zinc-700 dark:text-zinc-200">Primary language</h2>
-      <div class="flex flex-wrap gap-2">
-        {% for option in primary_language_options %}
-        <a href="{{ base_path }}/1?{% if let Some(current_filter) = current %}starts_with={% if current_filter == "#" %}%23{% else %}{{ current_filter }}{% endif %}&{% endif %}{% if let Some(genre_name) = genre_filter_query %}genre={{ genre_name }}&{% endif %}primary_language={{ option.query_value }}{% if let Some(status_value) = status_filter %}&status={{ status_value }}{% endif %}"
-           class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors {% if let Some(active_primary_language) = primary_language_filter %}{% if active_primary_language.as_str() == option.query_value.as_str() %}border-indigo-600 bg-indigo-600 text-white{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}"
-           aria-label="Filter movies by primary language {{ option.label }}">
-          {{ option.label }}
-        </a>
-        {% endfor %}
-      </div>
+      <form method="get" action="{{ base_path }}/1" class="max-w-xs">
+        {% if let Some(current_filter) = current %}
+        <input type="hidden" name="starts_with" value="{{ current_filter }}">
+        {% endif %}
+        {% if let Some(genre_name) = genre_filter %}
+        <input type="hidden" name="genre" value="{{ genre_name }}">
+        {% endif %}
+        {% if let Some(status_value) = status_filter %}
+        <input type="hidden" name="status" value="{{ status_value }}">
+        {% endif %}
+        <select name="primary_language"
+                class="block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100"
+                aria-label="Filter movies by primary language"
+                onchange="this.form.submit()">
+          <option value="">All languages</option>
+          {% for option in primary_language_options %}
+          <option value="{{ option.query_value }}"{% if let Some(active_primary_language) = primary_language_filter %}{% if active_primary_language.as_str() == option.query_value.as_str() %} selected{% endif %}{% endif %}>
+            {{ option.label }}
+          </option>
+          {% endfor %}
+        </select>
+      </form>
     </div>
 
     <div class="space-y-2">


### PR DESCRIPTION
### Motivation

- Use the canonical language table for the metadata movie primary-language filter instead of deriving options from movie rows to ensure a stable, human-readable set of languages.
- Replace the many small language buttons with a compact combobox to improve UI affordance and avoid layout clutter.

### Description

- Replaced the movie-derived language helper with a call to `mk_lib_database::mk_lib_database_language::mk_lib_database_language_read` and mapped rows to `FilterOption` with `label = language` and `query_value = code.to_lowercase()` in `docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs`.
- Replaced the inline button links UI with a `GET` form containing a submit-on-change `<select name="primary_language">` in `docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html` and preserved active `starts_with`, `genre`, and `status` filters via hidden inputs.
- Kept existing behavior for `status` filter and pagination; the language selection now submits and composes the same filter query suffix as before.

### Testing

- Ran `cargo fmt` in `docker/core/mkwebaxum` which completed successfully.
- Ran `cargo check` in this environment which failed due to a private registry fetching error (HTTP 403) unrelated to the code changes.
- Ran `cargo clippy -- -D warnings` which could not complete for the same private registry HTTP 403 error in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c333abb0748321bd3bed00c585c439)