### PR TITLE
Add schema update for persisted movie primary language

### DIFF
--- a/src/mk_lib_database/src/mk_lib_database_version.rs
+++ b/src/mk_lib_database/src/mk_lib_database_version.rs
@@ -1,8 +1,8 @@
 use crate::mk_lib_database_postgresql;
 use crate::mk_lib_database_version_schema;
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 
-pub static DATABASE_VERSION: i32 = 80;
+pub static DATABASE_VERSION: i32 = 81;
 
 pub async fn mk_lib_database_postgresql_version(
     sqlx_pool: &sqlx::PgPool,

--- a/src/mk_lib_database/src/mk_lib_database_version_schema.rs
+++ b/src/mk_lib_database/src/mk_lib_database_version_schema.rs
@@ -1,6 +1,6 @@
 use crate::mk_lib_database_option_status;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 pub async fn mk_lib_database_update_schema(
     sqlx_pool: &sqlx::PgPool,
@@ -1075,6 +1075,68 @@ pub async fn mk_lib_database_update_schema(
         .await?;
         transaction.commit().await?;
         mk_lib_database_version_update(&sqlx_pool, 80).await?;
+    }
+
+    if version_no < 81 {
+        let mut transaction = sqlx_pool.begin().await?;
+        sqlx::query(
+            r#"ALTER TABLE mm_metadata_movie
+            ADD COLUMN mm_metadata_movie_primary_lang text;"#,
+        )
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(
+            r#"CREATE OR REPLACE FUNCTION mm_metadata_movie_primary_lang_sync()
+            RETURNS trigger AS $$
+            BEGIN
+                NEW.mm_metadata_movie_primary_lang =
+                    lower(
+                        coalesce(
+                            NEW.mm_metadata_movie_json->>'primary_language',
+                            NEW.mm_metadata_movie_json->>'original_language',
+                            ''
+                        )
+                    );
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;"#,
+        )
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(r#"DROP TRIGGER IF EXISTS mm_metadata_movie_primary_lang_sync_trigger ON mm_metadata_movie;"#)
+            .execute(&mut *transaction)
+            .await?;
+        sqlx::query(
+            r#"CREATE TRIGGER mm_metadata_movie_primary_lang_sync_trigger
+            BEFORE INSERT OR UPDATE OF mm_metadata_movie_json
+            ON mm_metadata_movie
+            FOR EACH ROW
+            EXECUTE PROCEDURE mm_metadata_movie_primary_lang_sync();"#,
+        )
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(
+            r#"UPDATE mm_metadata_movie
+            SET mm_metadata_movie_primary_lang =
+                lower(
+                    coalesce(
+                        mm_metadata_movie_json->>'primary_language',
+                        mm_metadata_movie_json->>'original_language',
+                        ''
+                    )
+                );"#,
+        )
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(
+            r#"CREATE INDEX IF NOT EXISTS mm_metadata_movie_primary_lang_ndx
+            ON mm_metadata_movie USING btree (mm_metadata_movie_primary_lang)
+            WHERE mm_metadata_movie_primary_lang <> '';"#,
+        )
+        .execute(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+        mk_lib_database_version_update(&sqlx_pool, 81).await?;
     }
 
     // TODO, movie alt name, tv alt name and person alt name cleanup


### PR DESCRIPTION
### Motivation
- Persist the movie metadata `primary_language` from JSON into a dedicated column for faster querying and indexing.
- Ensure the persisted value is automatically kept in sync when `mm_metadata_movie_json` is inserted or updated.

### Description
- Bumped the database target version from `80` to `81` by updating `DATABASE_VERSION` in `mk_lib_database_version` (`src/mk_lib_database/src/mk_lib_database_version.rs`).
- Added a schema migration block for version `81` in `mk_lib_database_update_schema` (`src/mk_lib_database/src/mk_lib_database_version_schema.rs`) that adds `mm_metadata_movie_primary_lang text` to `mm_metadata_movie`.
- Created a `PL/pgSQL` trigger function `mm_metadata_movie_primary_lang_sync()` that sets `mm_metadata_movie_primary_lang` to the lowercase of `primary_language` from the JSON, falling back to `original_language` when `primary_language` is missing, and returns `NEW`.
- Added a trigger `mm_metadata_movie_primary_lang_sync_trigger` to run `BEFORE INSERT OR UPDATE OF mm_metadata_movie_json` so the column auto-updates on JSON insert or update, backfilled existing rows from JSON, and created a partial btree index `mm_metadata_movie_primary_lang_ndx` for non-empty values.

### Testing
- Ran `cargo fmt` in `src/mk_lib_database` successfully.
- Ran `cargo check` in `src/mk_lib_database` but it failed in this environment due to a private registry HTTP 403 (could not fetch `serde` from the replaced registry), so schema compilation could not be fully verified here.
- Ran `cargo clippy -- -D warnings` which also failed for the same private registry access error in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c34a01d8a48321b4d8b87ec182a626)