### PR TITLE
Use metadata movie primary language column for filtering

### DIFF
--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs
@@ -78,7 +78,7 @@ pub async fn mk_lib_database_metadata_movie_read(
              )
              AND (
                 $5 = ''
-                OR lower(mm_metadata_movie_json->>'original_language') = lower($5)
+                OR lower(mm_metadata_movie_primary_lang) = lower($5)
              )
              AND (
                 $6 = ''
@@ -134,7 +134,7 @@ pub async fn mk_lib_database_metadata_movie_read(
             )
             AND (
                 $4 = ''
-                OR lower(mm_metadata_movie_json->>'original_language') = lower($4)
+                OR lower(mm_metadata_movie_primary_lang) = lower($4)
             )
             AND (
                 $5 = ''
@@ -171,9 +171,9 @@ pub async fn mk_lib_database_metadata_movie_languages(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<DBMetaMoviePrimaryLanguage>, sqlx::Error> {
     sqlx::query_as(
-        r#"select lower(mm_metadata_movie_json->>'original_language') as primary_language
+        r#"select lower(mm_metadata_movie_primary_lang) as primary_language
         from mm_metadata_movie
-        where coalesce(mm_metadata_movie_json->>'original_language', '') <> ''
+        where coalesce(mm_metadata_movie_primary_lang, '') <> ''
         group by 1
         order by 1"#,
     )
@@ -207,7 +207,7 @@ pub async fn mk_lib_database_metadata_movie_count(
             )
             AND (
                 $4 = ''
-                OR lower(mm_metadata_movie_json->>'original_language') = lower($4)
+                OR lower(mm_metadata_movie_primary_lang) = lower($4)
             )
             AND (
                 $5 = ''
@@ -249,7 +249,7 @@ pub async fn mk_lib_database_metadata_movie_count(
             )
             AND (
                 $4 = ''
-                OR lower(mm_metadata_movie_json->>'original_language') = lower($4)
+                OR lower(mm_metadata_movie_primary_lang) = lower($4)
             )
             AND (
                 $5 = ''


### PR DESCRIPTION
### Motivation
- Switch movie language filtering to the dedicated column to avoid reading language from JSON and to allow indexable lookups.
- Preserve existing matching behavior and casing by continuing to use `lower(...)` comparisons.

### Description
- Updated SQL filters in `mk_lib_database_metadata_movie::mk_lib_database_metadata_movie_read` to use `mm_metadata_movie_primary_lang` instead of `mm_metadata_movie_json->>'original_language'` for both search and non-search code paths.
- Changed the primary-language options query in `mk_lib_database_metadata_movie::mk_lib_database_metadata_movie_languages` to select distinct values from `mm_metadata_movie_primary_lang` and to filter empty values from that column.
- Updated `mk_lib_database_metadata_movie::mk_lib_database_metadata_movie_count` to use `mm_metadata_movie_primary_lang` for counting logic so list and count endpoints remain consistent (file: `src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs`).

### Testing
- Ran `rustfmt --edition 2021 src/mk_lib_database/src/metadata/mk_lib_database_metadata_movie.rs`, which succeeded.
- Attempted `cargo check --manifest-path src/mk_lib_database/Cargo.toml`, but it failed in this environment due to a missing `kellnr` registry configuration.
- Attempted `cargo clippy --manifest-path src/mk_lib_database/Cargo.toml -- -D warnings`, but it also failed for the same missing registry reason.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43a747a348321a73c48b81a7e9881)