### PR TITLE
Update mm_radio schema to align with mkiradio station payload

### DIFF
--- a/docker/core/mkinit/scripts/create_schema.sql
+++ b/docker/core/mkinit/scripts/create_schema.sql
@@ -530,8 +530,13 @@ ALTER TABLE public.mm_options_and_status OWNER TO postgres;
 
 CREATE TABLE public.mm_radio (
     mm_radio_guid uuid NOT NULL,
+    mm_radio_stationuuid text,
     mm_radio_name text,
     mm_radio_description text,
+    mm_radio_country text,
+    mm_radio_language text,
+    mm_radio_tags text,
+    mm_radio_url_resolved text,
     mm_radio_address text,
     mm_radio_active boolean
 );
@@ -4192,4 +4197,3 @@ CREATE INDEX mm_tv_schedule_ndx_station_id ON public.mm_tv_schedule USING btree 
 --
 -- PostgreSQL database dump complete
 --
-

--- a/src/mk_lib_database/src/mk_lib_database_version.rs
+++ b/src/mk_lib_database/src/mk_lib_database_version.rs
@@ -2,7 +2,7 @@ use crate::mk_lib_database_postgresql;
 use crate::mk_lib_database_version_schema;
 use tokio::time::{sleep, Duration};
 
-pub static DATABASE_VERSION: i32 = 80;
+pub static DATABASE_VERSION: i32 = 81;
 
 pub async fn mk_lib_database_postgresql_version(
     sqlx_pool: &sqlx::PgPool,

--- a/src/mk_lib_database/src/mk_lib_database_version_schema.rs
+++ b/src/mk_lib_database/src/mk_lib_database_version_schema.rs
@@ -1077,6 +1077,27 @@ pub async fn mk_lib_database_update_schema(
         mk_lib_database_version_update(&sqlx_pool, 80).await?;
     }
 
+    if version_no < 81 {
+        let mut transaction = sqlx_pool.begin().await?;
+        sqlx::query(r#"ALTER TABLE mm_radio ADD COLUMN IF NOT EXISTS mm_radio_stationuuid text;"#)
+            .execute(&mut *transaction)
+            .await?;
+        sqlx::query(r#"ALTER TABLE mm_radio ADD COLUMN IF NOT EXISTS mm_radio_country text;"#)
+            .execute(&mut *transaction)
+            .await?;
+        sqlx::query(r#"ALTER TABLE mm_radio ADD COLUMN IF NOT EXISTS mm_radio_language text;"#)
+            .execute(&mut *transaction)
+            .await?;
+        sqlx::query(r#"ALTER TABLE mm_radio ADD COLUMN IF NOT EXISTS mm_radio_tags text;"#)
+            .execute(&mut *transaction)
+            .await?;
+        sqlx::query(r#"ALTER TABLE mm_radio ADD COLUMN IF NOT EXISTS mm_radio_url_resolved text;"#)
+            .execute(&mut *transaction)
+            .await?;
+        transaction.commit().await?;
+        mk_lib_database_version_update(&sqlx_pool, 81).await?;
+    }
+
     // TODO, movie alt name, tv alt name and person alt name cleanup
 
     Ok(true)


### PR DESCRIPTION
### Motivation
- The mkiradio service returns station fields beyond the existing `mm_radio` columns (e.g. `stationuuid`, `country`, `language`, `tags`, `url_resolved`), so the database must be extended to store those values.

### Description
- Added new columns to the base SQL schema in `docker/core/mkinit/scripts/create_schema.sql`: `mm_radio_stationuuid`, `mm_radio_country`, `mm_radio_language`, `mm_radio_tags`, and `mm_radio_url_resolved`.
- Added a runtime schema upgrade step in `src/mk_lib_database/src/mk_lib_database_version_schema.rs` under `if version_no < 81` to `ALTER TABLE mm_radio ADD COLUMN IF NOT EXISTS` for each new column, and update the DB version to `81`.
- Bumped the expected database version from `80` to `81` in `src/mk_lib_database/src/mk_lib_database_version.rs`.

### Testing
- Ran `rustfmt --edition 2021` on the modified Rust files and it completed successfully.
- Attempted `cargo fmt` from the repo root and it failed because there is no `Cargo.toml` at `/workspace/MediaKraken` in this environment.
- Attempted `cargo fmt --manifest-path docker/core/Cargo.toml`, `cargo check --manifest-path docker/core/Cargo.toml`, and `cargo clippy --manifest-path docker/core/Cargo.toml -- -D warnings`, but workspace loading failed due to the private registry index `kellnr` being unavailable, so these checks could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43a2c08e48321ac6e00a0cb217134)