### PR TITLE
Use UPSERT for iRadio insert

### DIFF
--- a/src/mk_lib_database/src/media/mk_lib_database_media_iradio.rs
+++ b/src/mk_lib_database/src/media/mk_lib_database_media_iradio.rs
@@ -12,31 +12,22 @@ pub async fn mk_lib_database_media_iradio_insert(
     sqlx_pool: &sqlx::PgPool,
     radio_channel: &str,
 ) -> Result<Option<uuid::Uuid>, sqlx::Error> {
-    let row: (i64,) = sqlx::query_as(
-        r#"select count(*) from mm_radio
-        where mm_radio_address = $1"#,
+    let new_guid = uuid::Uuid::new_v4();
+    let row: Option<(uuid::Uuid,)> = sqlx::query_as(
+        r#"insert into mm_radio (
+            mm_radio_guid,
+            mm_radio_address,
+            mm_radio_active
+        ) values ($1, $2, true)
+        on conflict (mm_radio_address) do nothing
+        returning mm_radio_guid"#,
     )
+    .bind(new_guid)
     .bind(radio_channel)
-    .fetch_one(sqlx_pool)
+    .fetch_optional(sqlx_pool)
     .await?;
 
-    if row.0 == 0 {
-        let new_guid = uuid::Uuid::new_v4();
-        sqlx::query(
-            r#"insert into mm_radio (
-                mm_radio_guid,
-                mm_radio_address,
-                mm_radio_active
-            ) values ($1, $2, true)"#,
-        )
-        .bind(new_guid)
-        .bind(radio_channel)
-        .execute(sqlx_pool)
-        .await?;
-        Ok(Some(new_guid))
-    } else {
-        Ok(None)
-    }
+    Ok(row.map(|(radio_guid,)| radio_guid))
 }
 
 pub async fn mk_lib_database_media_iradio_read(


### PR DESCRIPTION
### Motivation
- Replace the separate existence `SELECT` + conditional `INSERT` with a single DB-level upsert to remove a race window and reduce round-trips.

### Description
- Updated `mk_lib_database_media_iradio_insert` to use `INSERT ... ON CONFLICT (mm_radio_address) DO NOTHING RETURNING mm_radio_guid`, returning `Some(uuid)` when an insert occurs and `None` when the address already exists.

### Testing
- Ran `cargo fmt` in `src/mk_lib_database`, which succeeded.
- Running `cargo check` in `src/mk_lib_database` failed due to registry access errors (`403 Forbidden` from configured Kellnr registry), so full compile verification was blocked.
- Running `cargo clippy -- -D warnings` in `src/mk_lib_database` was also blocked by the same registry access issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c446c1d0248321bd3a3c966c86790e)