### PR TITLE
mkiradio: upsert RadioBrowser stations into mm_radio

### DIFF
--- a/docker/core/mkiradio/src/main.rs
+++ b/docker/core/mkiradio/src/main.rs
@@ -62,6 +62,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     return Ok(());
                 }
 
+                let mut upsert_count: usize = 0;
                 for (idx, station) in stations.iter().enumerate() {
                     println!("{}. {}", idx + 1, station.name);
                     println!("   Station UUID: {}", station.stationuuid);
@@ -80,7 +81,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
                     println!("   Stream URL: {}", station.url_resolved);
                     println!();
+
+                    mk_lib_database::media::mk_lib_database_media_iradio::mk_lib_database_media_iradio_upsert(
+                        &sqlx_pool_rw,
+                        station.stationuuid.as_ref(),
+                        station.name.as_ref(),
+                        station.url.as_ref(),
+                        station.country.as_deref(),
+                        station.language.as_deref(),
+                        station.tags.as_deref(),
+                        station.url_resolved.as_ref(),
+                    )
+                    .await?;
+                    upsert_count += 1;
                 }
+                println!("Upserted {} stations into mm_radio.", upsert_count);
             }
             let _result = mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_ack(
                 &rabbit_channel,

--- a/src/mk_lib_database/src/media/mk_lib_database_media_iradio.rs
+++ b/src/mk_lib_database/src/media/mk_lib_database_media_iradio.rs
@@ -30,6 +30,52 @@ pub async fn mk_lib_database_media_iradio_insert(
     Ok(row.map(|(radio_guid,)| radio_guid))
 }
 
+pub async fn mk_lib_database_media_iradio_upsert(
+    sqlx_pool: &sqlx::PgPool,
+    station_uuid: &str,
+    station_name: &str,
+    station_address: &str,
+    station_country: Option<&str>,
+    station_language: Option<&str>,
+    station_tags: Option<&str>,
+    station_url_resolved: &str,
+) -> Result<uuid::Uuid, sqlx::Error> {
+    let row: (uuid::Uuid,) = sqlx::query_as(
+        r#"insert into mm_radio (
+            mm_radio_guid,
+            mm_radio_stationuuid,
+            mm_radio_name,
+            mm_radio_address,
+            mm_radio_country,
+            mm_radio_language,
+            mm_radio_tags,
+            mm_radio_url_resolved,
+            mm_radio_active
+        ) values ($1, $2, $3, $4, $5, $6, $7, $8, true)
+        on conflict (mm_radio_address) do update set
+            mm_radio_stationuuid = excluded.mm_radio_stationuuid,
+            mm_radio_name = excluded.mm_radio_name,
+            mm_radio_country = excluded.mm_radio_country,
+            mm_radio_language = excluded.mm_radio_language,
+            mm_radio_tags = excluded.mm_radio_tags,
+            mm_radio_url_resolved = excluded.mm_radio_url_resolved,
+            mm_radio_active = true
+        returning mm_radio_guid"#,
+    )
+    .bind(uuid::Uuid::new_v7())
+    .bind(station_uuid)
+    .bind(station_name)
+    .bind(station_address)
+    .bind(station_country)
+    .bind(station_language)
+    .bind(station_tags)
+    .bind(station_url_resolved)
+    .fetch_one(sqlx_pool)
+    .await?;
+
+    Ok(row.0)
+}
+
 pub async fn mk_lib_database_media_iradio_read(
     sqlx_pool: &sqlx::PgPool,
     offset: i64,


### PR DESCRIPTION
### Motivation
- Persist RadioBrowser station metadata into the central `mm_radio` table so station results discovered by `mkiradio` are stored and kept up-to-date.
- Provide an idempotent database operation that inserts new stations and updates existing rows keyed by `mm_radio_address`.

### Description
- Added `mk_lib_database_media_iradio_upsert` which performs an `INSERT ... ON CONFLICT (mm_radio_address) DO UPDATE` and returns the `mm_radio_guid`, writing `stationuuid`, `name`, `country`, `language`, `tags`, `url_resolved`, and setting `mm_radio_active = true` on conflict (file: `src/mk_lib_database/src/media/mk_lib_database_media_iradio.rs`).
- Updated `mkiradio` to call the new upsert helper for every RadioBrowser station in the `radiobrowser` message flow and added a counter/log of how many stations were upserted (file: `docker/core/mkiradio/src/main.rs`).
- The SQL is fully parameterized and preserves existing non-destructive behavior by targeting conflicts on `mm_radio_address`.

### Testing
- Ran `cargo fmt` in `docker/core/mkiradio` and `src/mk_lib_database` which completed successfully.
- Attempted `cargo check` in both `docker/core/mkiradio` and `src/mk_lib_database` but they failed in this environment due to a `403 Forbidden` when fetching from the internal Kellnr registry (external registry access issue), so full type-check/compile could not be verified.
- Attempted `cargo clippy -- -D warnings` but it also failed due to the same internal registry 403 error, so linting was not completed.
- Running `rustfmt` directly reported an edition-related error in this environment; the code changes themselves are limited and follow existing async/SQLx patterns in the project.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c465e54d5883219c21149089bab2d5)