### PR TITLE
mkwebaxum: align movie primary language and user status filters

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html
@@ -6,7 +6,7 @@
   <h1 id="movie-grid-heading" class="sr-only">Movie list</h1>
   {% include "filters/pagination_letters.html" %}
 
-  <div class="mt-4 space-y-4 rounded-xl border border-zinc-200 bg-white/70 p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900/70">
+  <div class="mt-4 grid gap-4 rounded-xl border border-zinc-200 bg-white/70 p-4 shadow-sm md:grid-cols-2 dark:border-zinc-800 dark:bg-zinc-900/70">
     <div class="space-y-2">
       <h2 class="text-sm font-semibold tracking-wide text-zinc-700 dark:text-zinc-200">Primary language</h2>
       <form method="get" action="{{ base_path }}/1" class="max-w-xs">


### PR DESCRIPTION
### Motivation
- Place the **Primary language** and **User status** filters on the same horizontal plane for medium+ screens while keeping the stacked layout on small screens.

### Description
- Updated `docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie.html` to replace the filter wrapper `class="mt-4 space-y-4 ..."` with `class="mt-4 grid gap-4 ... md:grid-cols-2 ..."`, creating a responsive two-column grid.

### Testing
- Ran `cargo fmt --all` in `docker/core/mkwebaxum` (succeeded); ran `cargo check` and `cargo clippy -- -D warnings` in `docker/core/mkwebaxum` but both failed due to an external crate registry returning HTTP 403 from `mkdevkellnrapi.mediakraken.media`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c48eb19a9c8321aef7dc6f0b97c05a)