### PR TITLE
mkwebaxum: make user sidenav scroll with page content

### DIFF
--- a/docker/core/mkwebaxum/templates/layouts/base_user.html
+++ b/docker/core/mkwebaxum/templates/layouts/base_user.html
@@ -69,10 +69,10 @@
     
     {% include "partials/topnavbar.html" %}
     
-    <div class="flex flex-1 overflow-hidden">
+    <div class="flex flex-1">
         {% include "partials/sidebar_user.html" %}
         
-        <main id="main-content" class="flex-1 overflow-y-auto">
+        <main id="main-content" class="flex-1">
             {% block content %}{% endblock %}
         </main>
     </div>


### PR DESCRIPTION
### Motivation
- Use a single document scroll so the user sidenav scrolls naturally with the main content instead of being clipped by an independent scroll container.

### Description
- In `docker/core/mkwebaxum/templates/layouts/base_user.html` remove the wrapper `overflow-hidden` and the `overflow-y-auto` on `#main-content` so the page uses the browser/document scroll (sidebar remains in the layout and will scroll with page content).

### Testing
- Ran `cargo check` in `docker/core/mkwebaxum` which could not complete in this environment due to the private cargo registry returning HTTP 403 for `config.json` (registry error), so compile check could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c48e7f11c88321b97a63e4b3807456)