### PR TITLE
Make YouTube detail player fill right content pane

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_youtube_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_youtube_detail.html
@@ -1,12 +1,21 @@
 {% extends "layouts/base_user.html" %}
 
+{% block extra_head %}
+<style>
+    .youtube-player-shell {
+        height: calc(100vh - 10rem);
+        min-height: 420px;
+    }
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="space-y-4">
     <a href="/user/internet/youtube" class="inline-flex text-sm text-blue-700 hover:underline" aria-label="Back to YouTube browse page">
         ← Back to YouTube browse
     </a>
 
-    <div class="aspect-video w-full rounded-lg overflow-hidden border border-gray-200 bg-black">
+    <div class="youtube-player-shell w-full rounded-lg overflow-hidden border border-gray-200 bg-black">
         <iframe
             src="{{ template_embed_url }}"
             title="YouTube player for {{ template_youtube_video_guid }}"


### PR DESCRIPTION
### Motivation
- Ensure the YouTube playback iframe uses the full right-hand content area instead of being constrained to a small fixed 16:9 box so video playback is larger and matches the surrounding layout.

### Description
- Update `docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_youtube_detail.html` to add a `.youtube-player-shell` container (CSS in a new `extra_head` block) sized with `height: calc(100vh - 10rem)` and `min-height: 420px`, and replace the previous `aspect-video` wrapper with this container while keeping the iframe at `h-full w-full` and preserving accessibility and `allow` attributes.

### Testing
- Ran formatting and build checks (`cargo fmt`, `cargo check`, `cargo clippy`) against the crate manifest at `docker/core/mkwebaxum/Cargo.toml`, and all attempted automated checks failed due to the environment missing the custom registry index `kellnr` (so no successful Rust verification could be completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4901908048321b647831b001659eb)