### PR TITLE
Fix Vimeo playback page width to match user content pane

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_vimeo_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/internet/bss_user_internet_vimeo_detail.html
@@ -1,7 +1,7 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<main class="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+<div class="w-full px-4 py-6 sm:px-6 lg:px-8">
         <a href="/user/internet/vimeo" class="mb-4 inline-flex rounded-lg border border-slate-600 px-3 py-2 text-sm hover:border-slate-400 hover:bg-slate-800" aria-label="Back to Vimeo browse">← Back to Vimeo</a>
 
         <article class="rounded-xl border border-slate-800 bg-slate-900 p-4 sm:p-6">
@@ -26,5 +26,5 @@
                 ></iframe>
             </div>
         </article>
-    </main>
+    </div>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- The Vimeo detail view was wrapped in a centered max-width container and nested `<main>`, causing the embedded player to not size to the active user content pane.

### Description
- Replace the nested `<main class="mx-auto w-full max-w-6xl ...">` wrapper with a full-width `<div class="w-full ...">` so the Vimeo player fills the right-hand content area, while preserving the existing `aspect-video` iframe layout.

### Testing
- Ran `cargo fmt --all` in `docker/core/mkwebaxum` which succeeded.
- Ran `cargo check` in `docker/core/mkwebaxum` which failed due to a private registry returning HTTP 403, blocking full compilation verification.
- Ran `cargo clippy -- -D warnings` in `docker/core/mkwebaxum` which also failed for the same private registry 403 issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c491447a64832191bb0daa9392a13a)