### PR TITLE
Retry on TMDB rate-limit (status_code 25) for all TMDB fetches

### DIFF
--- a/src/mk_lib_metadata/src/provider/tmdb.rs
+++ b/src/mk_lib_metadata/src/provider/tmdb.rs
@@ -7,8 +7,36 @@ use mk_lib_image;
 use mk_lib_network::mk_lib_network;
 use serde_json::json;
 use sqlx::types::Uuid;
-use torrent_name_parser::Metadata;
 use std::env;
+use tokio::time::{sleep, Duration};
+use torrent_name_parser::Metadata;
+
+const TMDB_RATE_LIMIT_STATUS_CODE: i64 = 25;
+const TMDB_RATE_LIMIT_RETRY_ATTEMPTS: u8 = 5;
+const TMDB_RATE_LIMIT_RETRY_DELAY_SECONDS: u64 = 2;
+
+async fn tmdb_fetch_json_with_retry(
+    url: String,
+) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    for attempt in 0..TMDB_RATE_LIMIT_RETRY_ATTEMPTS {
+        let response = mk_lib_network::mk_data_from_url_to_json(url.clone()).await?;
+        let is_rate_limited = response
+            .get("status_code")
+            .and_then(serde_json::Value::as_i64)
+            .map(|code| code == TMDB_RATE_LIMIT_STATUS_CODE)
+            .unwrap_or(false);
+
+        if !is_rate_limited {
+            return Ok(response);
+        }
+
+        if attempt + 1 < TMDB_RATE_LIMIT_RETRY_ATTEMPTS {
+            sleep(Duration::from_secs(TMDB_RATE_LIMIT_RETRY_DELAY_SECONDS)).await;
+        }
+    }
+
+    Err("TMDB rate limit persisted after retries".into())
+}
 
 pub async fn provider_tmdb_movie_fetch(
     sqlx_pool: &sqlx::PgPool,
@@ -63,25 +91,23 @@ pub async fn provider_tmdb_person_fetch(
     let result_json = provider_tmdb_person_fetch_by_id(tmdb_id, tmdb_api_key)
         .await
         .unwrap();
-    if env::var("DEBUG").unwrap() == "true"
-    {
+    if env::var("DEBUG").unwrap() == "true" {
         mk_lib_logging::mk_lib_logging_loki::mk_logging_loki_push(
             json!({ "Type": "Person", "Module": std::module_path!(), "Result": result_json }),
-            )
-            .await
-            .unwrap();
+        )
+        .await
+        .unwrap();
     }
     if result_json.get("success").is_some() && result_json["success"] == false {
         println!("Skip Person: {}", tmdb_id);
         return;
     }
-    if env::var("DEBUG").unwrap() == "true"
-    {
+    if env::var("DEBUG").unwrap() == "true" {
         mk_lib_logging::mk_lib_logging_loki::mk_logging_loki_push(
             json!({ "Type": "Person After", "Module": std::module_path!() }),
-            )
-            .await
-            .unwrap();
+        )
+        .await
+        .unwrap();
     }
     let image_json: serde_json::Value = provider_tmdb_meta_info_build(&result_json).await.unwrap();
     let _result = mk_lib_database::database_metadata::mk_lib_database_metadata_person::mk_lib_database_metadata_person_insert(
@@ -107,7 +133,7 @@ pub async fn provider_tmdb_tv_fetch(
     if result_json.get("success").is_some() && result_json["success"] == false {
         println!("Skip TV: {}", tmdb_id);
         return;
-    }    
+    }
     let image_json: serde_json::Value = provider_tmdb_meta_info_build(&result_json).await.unwrap();
     let _result = mk_lib_database::database_metadata::mk_lib_database_metadata_tv::mk_lib_database_metadata_tv_insert(
         sqlx_pool,
@@ -140,7 +166,7 @@ pub async fn provider_tmdb_tv_fetch(
 pub async fn provider_tmdb_movie_id_max(
     api_key: &String,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let url_result = mk_lib_network::mk_data_from_url_to_json(format!(
+    let url_result = tmdb_fetch_json_with_retry(format!(
         "https://api.themoviedb.org/3/movie/latest?api_key={}",
         api_key
     ))
@@ -152,7 +178,7 @@ pub async fn provider_tmdb_movie_id_max(
 pub async fn provider_tmdb_person_id_max(
     api_key: &String,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let url_result = mk_lib_network::mk_data_from_url_to_json(format!(
+    let url_result = tmdb_fetch_json_with_retry(format!(
         "https://api.themoviedb.org/3/person/latest?api_key={}",
         api_key
     ))
@@ -164,7 +190,7 @@ pub async fn provider_tmdb_person_id_max(
 pub async fn provider_tmdb_tv_id_max(
     api_key: &String,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let url_result = mk_lib_network::mk_data_from_url_to_json(format!(
+    let url_result = tmdb_fetch_json_with_retry(format!(
         "https://api.themoviedb.org/3/tv/latest?api_key={}",
         api_key
     ))
@@ -177,7 +203,7 @@ pub async fn provider_tmdb_collection_fetch_by_id(
     tmdb_id: i32,
     api_key: &String,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let url_result = mk_lib_network::mk_data_from_url_to_json(format!(
+    let url_result = tmdb_fetch_json_with_retry(format!(
         "https://api.themoviedb.org/3/collection/{}?api_key={}",
         tmdb_id, api_key
     ))
@@ -190,7 +216,7 @@ pub async fn provider_tmdb_movie_fetch_by_id(
     tmdb_id: i32,
     api_key: &str,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let url_result = mk_lib_network::mk_data_from_url_to_json(format!(
+    let url_result = tmdb_fetch_json_with_retry(format!(
         "https://api.themoviedb.org/3/movie/{}?api_key={}\
         &append_to_response=credits,reviews,release_dates,videos",
         tmdb_id, api_key
@@ -203,7 +229,7 @@ pub async fn provider_tmdb_movie_fetch_by_id(
 pub async fn provider_tmdb_person_changes(
     api_key: &str,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let url_result = mk_lib_network::mk_data_from_url_to_json(format!(
+    let url_result = tmdb_fetch_json_with_retry(format!(
         "https://api.themoviedb.org/3/person/changes?api_key={}",
         api_key
     ))
@@ -216,7 +242,7 @@ pub async fn provider_tmdb_person_fetch_by_id(
     tmdb_id: i32,
     api_key: &str,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let url_result = mk_lib_network::mk_data_from_url_to_json(format!(
+    let url_result = tmdb_fetch_json_with_retry(format!(
         "https://api.themoviedb.org/3/person/{}?api_key={}\
         &append_to_response=combined_credits,external_ids,images",
         tmdb_id, api_key
@@ -230,7 +256,7 @@ pub async fn provider_tmdb_review_fetch_by_id(
     tmdb_id: i32,
     api_key: &str,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let url_result = mk_lib_network::mk_data_from_url_to_json(format!(
+    let url_result = tmdb_fetch_json_with_retry(format!(
         "https://api.themoviedb.org/3/review/{}?api_key={}",
         tmdb_id, api_key
     ))
@@ -243,7 +269,7 @@ pub async fn provider_tmdb_tv_fetch_by_id(
     tmdb_id: i32,
     api_key: &str,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let url_result = mk_lib_network::mk_data_from_url_to_json(format!(
+    let url_result = tmdb_fetch_json_with_retry(format!(
         "https://api.themoviedb.org/3/tv/{}?api_key={}\
         &append_to_response=credits,reviews,release_dates,videos",
         tmdb_id, api_key
@@ -274,15 +300,23 @@ pub async fn provider_tmdb_meta_info_build(
         .await;
         let _result = mk_lib_image::mk_lib_image::mk_image_file_thumb(&image_file_path);
         poster_file_path = image_file_path.clone();
-    }
-    else if result_json["images"]["profiles"][0].get("file_path").is_some() 
-            && !result_json["images"]["profiles"][0]["file_path"].is_null() {
-        image_file_path += &result_json["images"]["profiles"][0]["file_path"].as_str().unwrap().to_string();
+    } else if result_json["images"]["profiles"][0]
+        .get("file_path")
+        .is_some()
+        && !result_json["images"]["profiles"][0]["file_path"].is_null()
+    {
+        image_file_path += &result_json["images"]["profiles"][0]["file_path"]
+            .as_str()
+            .unwrap()
+            .to_string();
         //println!("ifilepath {}", image_file_path);
         let _result = mk_lib_network::mk_download_file_from_url(
             format!(
                 "https://image.tmdb.org/t/p/original{}",
-                &result_json["images"]["profiles"][0]["file_path"].as_str().unwrap().to_string()
+                &result_json["images"]["profiles"][0]["file_path"]
+                    .as_str()
+                    .unwrap()
+                    .to_string()
             ),
             &image_file_path,
         )
@@ -337,7 +371,7 @@ pub async fn provider_tmdb_search(guessit_data: Metadata, media_type: i16, tmdb_
         | mk_lib_common_enum_media_type::DLMediaType::MOVIE_SUBTITLE
         | mk_lib_common_enum_media_type::DLMediaType::MOVIE_THEME
         | mk_lib_common_enum_media_type::DLMediaType::MOVIE_TRAILER => {
-            let _url_result = mk_lib_network::mk_data_from_url_to_json(format!(
+            let _url_result = tmdb_fetch_json_with_retry(format!(
                 "https://api.themoviedb.org/3/search/movie\
                 ?api_key={}&include_adult=1&query={}",
                 search_text, tmdb_api_key
@@ -352,7 +386,7 @@ pub async fn provider_tmdb_search(guessit_data: Metadata, media_type: i16, tmdb_
         | mk_lib_common_enum_media_type::DLMediaType::TV_SUBTITLE
         | mk_lib_common_enum_media_type::DLMediaType::TV_THEME
         | mk_lib_common_enum_media_type::DLMediaType::TV_TRAILER => {
-            let _url_result = mk_lib_network::mk_data_from_url_to_json(format!(
+            let _url_result = tmdb_fetch_json_with_retry(format!(
                 "https://api.themoviedb.org/3/search/tv\
                 ?api_key={}&include_adult=1&query={}",
                 search_text, tmdb_api_key
@@ -361,7 +395,7 @@ pub async fn provider_tmdb_search(guessit_data: Metadata, media_type: i16, tmdb_
             .unwrap();
         }
         mk_lib_common_enum_media_type::DLMediaType::PERSON => {
-            let _url_result = mk_lib_network::mk_data_from_url_to_json(format!(
+            let _url_result = tmdb_fetch_json_with_retry(format!(
                 "https://api.themoviedb.org/3/search/person\
                 ?api_key={}&include_adult=1&query={}",
                 search_text, tmdb_api_key


### PR DESCRIPTION
### Motivation
- TMDB sometimes returns a rate-limit JSON response (status code `25`) that should be retried instead of treated as a permanent error.
- Centralize and standardize retry behavior for all TMDB-related fetches to reduce transient failures during metadata pulls.

### Description
- Added a helper `tmdb_fetch_json_with_retry(url: String)` that calls `mk_lib_network::mk_data_from_url_to_json`, inspects `status_code` in the JSON for `25`, and retries up to `5` attempts with a `2` second delay before failing.
- Introduced constants `TMDB_RATE_LIMIT_STATUS_CODE`, `TMDB_RATE_LIMIT_RETRY_ATTEMPTS`, and `TMDB_RATE_LIMIT_RETRY_DELAY_SECONDS` to make retry behavior explicit and configurable in the file.
- Replaced direct `mk_data_from_url_to_json(...)` calls with `tmdb_fetch_json_with_retry(...)` across TMDB functions in `src/mk_lib_metadata/src/provider/tmdb.rs`, including latest/id fetches, collection/review endpoints, and search paths so all TMDB JSON fetches share the same retry logic.
- Minor formatting/whitespace adjustments in `tmdb.rs` while applying the changes.

### Testing
- Ran `rustfmt --edition 2021 src/mk_lib_metadata/src/provider/tmdb.rs` which completed successfully.
- Attempted `cargo fmt` and `cargo fmt --manifest-path src/mk_lib_metadata/Cargo.toml`, but these failed in this environment due to manifest/registry configuration issues (registry `kellnr` not found).
- Attempted `cargo check --manifest-path src/mk_lib_metadata/Cargo.toml` and `cargo clippy --manifest-path src/mk_lib_metadata/Cargo.toml -- -D warnings`, both of which failed in this environment for the same missing registry configuration, so full crate-level validation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c81c13dc4c8321a4cd22001b7663e2)