### PR TITLE
mkwebaxum: add OpenLibrary link under Periodical metadata nav

### DIFF
--- a/docker/core/mkwebaxum/templates/partials/topnavbar.html
+++ b/docker/core/mkwebaxum/templates/partials/topnavbar.html
@@ -82,6 +82,9 @@
                                             <li><a href="/user/metadata/book/1?starts_with=#" class="text-sm text-gray-600 dark:text-zinc-300
                                                           hover:text-indigo-600 dark:hover:text-indigo-400">
                                                     Periodical</a></li>
+                                            <li><a href="/user/metadata/openlibrary/1" class="text-sm text-gray-600 dark:text-zinc-300
+                                                          hover:text-indigo-600 dark:hover:text-indigo-400">
+                                                    OpenLibrary</a></li>
                                             <li><a href="/user/metadata/person/1?starts_with=#" class="text-sm text-gray-600 dark:text-zinc-300
                                                           hover:text-indigo-600 dark:hover:text-indigo-400">
                                                     Person</a></li>


### PR DESCRIPTION
### Motivation
- Provide a direct entry point to the OpenLibrary metadata browse page from the top Metadata menu so users can reach OpenLibrary metadata quickly from the navbar.

### Description
- Inserted an `OpenLibrary` menu item linking to `/user/metadata/openlibrary/1` in `docker/core/mkwebaxum/templates/partials/topnavbar.html` immediately below the existing `Periodical` entry as a minimal, UI-only change.

### Testing
- Ran `cargo fmt --check`, `cargo check`, and `cargo clippy -- -D warnings` from `docker/core/mkwebaxum`; `cargo fmt --check` reported workspace formatting diffs unrelated to this HTML change, and `cargo check`/`clippy` could not complete due to an HTTP 403 from the configured crates registry at `http://mkdevkellnrapi.mediakraken.media`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c857579a508321ba26d47b4516eb95)