### PR TITLE
Add unaccent extension and rebuild FTS indexes in migration to version 82

### DIFF
--- a/src/mk_lib_database/src/mk_lib_database_version_schema.rs
+++ b/src/mk_lib_database/src/mk_lib_database_version_schema.rs
@@ -1154,6 +1154,31 @@ pub async fn mk_lib_database_update_schema(
         mk_lib_database_version_update(&sqlx_pool, 81).await?;
     }
 
+    if version_no < 82 {
+        let mut transaction = sqlx_pool.begin().await?;
+        sqlx::query(r#"CREATE EXTENSION IF NOT EXISTS unaccent;"#)
+            .execute(&mut *transaction)
+            .await?;
+        sqlx::query(r#"DROP INDEX IF EXISTS mm_metadata_movie_fts_ndx;"#)
+            .execute(&mut *transaction)
+            .await?;
+        sqlx::query(r#"DROP INDEX IF EXISTS mm_metadata_tvshow_fts_ndx;"#)
+            .execute(&mut *transaction)
+            .await?;
+        sqlx::query(
+            r#"CREATE INDEX IF NOT EXISTS mm_metadata_movie_fts_ndx ON mm_metadata_movie USING gin (( setweight(to_tsvector('simple', unaccent(coalesce(mm_metadata_movie_name, ''))), 'A') || ' ' || setweight(to_tsvector('simple', unaccent(coalesce(mm_metadata_movie_name_alt, ''))), 'B') :: tsvector ));"#,
+        )
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(
+            r#"CREATE INDEX IF NOT EXISTS mm_metadata_tvshow_fts_ndx ON mm_metadata_tvshow USING gin (( setweight(to_tsvector('simple', unaccent(coalesce(mm_metadata_tvshow_name, ''))), 'A') || ' ' || setweight(to_tsvector('simple', unaccent(coalesce(mm_metadata_tvshow_name_alt, ''))), 'B') :: tsvector ));"#,
+        )
+        .execute(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+        mk_lib_database_version_update(&sqlx_pool, 82).await?;
+    }
+
     // TODO, movie alt name, tv alt name and person alt name cleanup
 
     Ok(true)


### PR DESCRIPTION
### Motivation

- Improve full-text search accuracy by removing accents and applying consistent weights to primary and alternate names, and record this change as schema version `82`.

### Description

- Add a migration block that runs when `version_no < 82` which creates the `unaccent` extension with `CREATE EXTENSION IF NOT EXISTS unaccent;`.
- Drop the old FTS indexes `mm_metadata_movie_fts_ndx` and `mm_metadata_tvshow_fts_ndx` and recreate them as GIN indexes using `to_tsvector('simple', unaccent(...))` with weighted name and alt-name components.
- Commit the transaction and call `mk_lib_database_version_update(&sqlx_pool, 82).await?;` to update the stored schema version.

### Testing

- Ran `cargo test` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c463c794788321ba8caf5f1b492c67)