### PR TITLE
Fix nav search filter query deserialization (accept single string or array)

### DIFF
--- a/docker/core/mkwebaxum/src/user/bp_search.rs
+++ b/docker/core/mkwebaxum/src/user/bp_search.rs
@@ -1,16 +1,17 @@
-use crate::mk_lib_database;
 use crate::AppState;
+use crate::mk_lib_database;
 use askama::Template;
 use axum::extract::Query;
 use axum::extract::State;
 use axum::{
+    Extension,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
+use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPool;
 
@@ -53,8 +54,26 @@ pub async fn user_search(
 #[derive(Deserialize)]
 pub struct SearchParams {
     pub q: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_filter")]
     pub filter: Vec<String>,
+}
+
+fn deserialize_filter<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(String),
+        Many(Vec<String>),
+    }
+
+    match Option::<OneOrMany>::deserialize(deserializer)? {
+        Some(OneOrMany::One(value)) => Ok(vec![value]),
+        Some(OneOrMany::Many(values)) => Ok(values),
+        None => Ok(Vec::new()),
+    }
 }
 
 pub struct MyMediaType {


### PR DESCRIPTION
### Motivation
- The navbar search sometimes sends `filter` as a single string (e.g. `filter=available`) while the handler expected a sequence, causing deserialization failures like `invalid type: string "available", expected a sequence`.

### Description
- Updated `docker/core/mkwebaxum/src/user/bp_search.rs` to apply `#[serde(default, deserialize_with = "deserialize_filter")]` to `SearchParams.filter` so the field is normalized into `Vec<String>`.
- Added a `deserialize_filter` helper that uses an untagged enum `OneOrMany` to accept either a single `String` or a `Vec<String>` and return a `Vec<String>` (empty when absent).

### Testing
- Ran `cargo fmt` in `docker/core/mkwebaxum`, which completed successfully.
- Attempted `cargo check` and `cargo clippy -- -D warnings` in `docker/core/mkwebaxum`, but both were blocked by external registry access returning `403 Forbidden` (internal Kellnr registry), so full compile/lint verification could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c97b10b0848321aa6113131cb1c016)