### PR TITLE
Add movie overview below status actions in metadata detail

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail.html
@@ -75,6 +75,11 @@
                         {% include "icons/trash.svg" %}
                     </button>
                 </div>
+                {% if template_data_json["overiew"] != "" %}
+                <p class="mt-3 text-sm text-zinc-600 dark:text-zinc-400">
+                    {{ template_data_json["overiew"] }}
+                </p>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Motivation
- Display the movie "overview" text in the movie metadata detail view under the status action buttons by reading it from `template_data_json["overiew"]` as requested.

### Description
- Updated the Askama/HTML template `docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail.html` to render `template_data_json["overiew"]` directly beneath the status action buttons inside the status panel, guarded by a check that the value is not empty.

### Testing
- Ran `cargo fmt` in `docker/core/mkwebaxum` and it completed successfully. 
- Ran `cargo check` in `docker/core/mkwebaxum` which failed due to private registry dependency resolution returning HTTP 403. 
- Ran `cargo clippy -- -D warnings` in `docker/core/mkwebaxum` which failed for the same private registry HTTP 403 dependency-resolution issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9978766f08321b63394e0b25ccdda)