### PR TITLE
Populate movie detail cast from metadata credits

### DIFF
--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
@@ -37,6 +37,12 @@ pub struct FilterOption {
     pub query_value: String,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+struct MovieCastMember {
+    pub name: String,
+    pub character: String,
+}
+
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
 struct TemplateError401Context {}
@@ -473,6 +479,7 @@ struct TemplateMetaMovieDetailContext<'a> {
     template_metadata_tagline: Option<String>,
     template_metadata_photo_updated: DateTime<Utc>,
     template_metadata_genre: Vec<Genre>,
+    template_metadata_cast: Vec<MovieCastMember>,
     template_metadata_user_watched: serde_json::Value,
     template_metadata_user_rating: serde_json::Value,
     template_metadata_user_request: serde_json::Value,
@@ -540,6 +547,24 @@ pub async fn user_metadata_movie_detail(
             })
             .collect();
 
+        let cast_members: Vec<MovieCastMember> =
+            movie_metadata.mm_metadata_movie_json["credits"]["cast"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|cast_member| {
+                    let name = cast_member.get("name").and_then(|value| value.as_str())?;
+                    let character = cast_member
+                        .get("character")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or_default();
+                    Some(MovieCastMember {
+                        name: name.to_string(),
+                        character: character.to_string(),
+                    })
+                })
+                .collect();
+
         let template = TemplateMetaMovieDetailContext {
             template_data_json: &movie_metadata.mm_metadata_movie_json,
             template_metadata_name_alt: movie_metadata.mm_metadata_movie_name_alt.clone(),
@@ -552,6 +577,7 @@ pub async fn user_metadata_movie_detail(
             template_metadata_tagline: movie_metadata.mm_metadata_tagline.clone(),
             template_metadata_photo_updated: movie_metadata.photo_updated.clone(),
             template_metadata_genre: genres,
+            template_metadata_cast: cast_members,
             template_metadata_user_watched: watched_status,
             template_metadata_user_rating: rating_status,
             template_metadata_user_request: request_status,

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail.html
@@ -95,12 +95,16 @@
             </button>
 
             <div class="flex gap-4 overflow-x-auto scroll-smooth px-10" x-ref="cast">
-                <template x-for="person in cast" :key="person.name">
-                    <a href="#" class="min-w-[120px] text-center">
-                        <img :src="person.img" class="mx-auto h-28 w-28 rounded-full object-cover">
-                        <p class="mt-2 text-sm font-medium text-zinc-800 dark:text-zinc-200" x-text="person.name"></p>
-                    </a>
-                </template>
+                {% for person in template_metadata_cast %}
+                <a href="#" class="min-w-[140px] text-center">
+                    <div
+                        class="mx-auto flex h-28 w-28 items-center justify-center rounded-full bg-zinc-100 text-3xl font-semibold text-zinc-500 dark:bg-zinc-800 dark:text-zinc-300">
+                        {{ person.name.chars().next().unwrap_or('?') }}
+                    </div>
+                    <p class="mt-2 text-sm font-medium text-zinc-800 dark:text-zinc-200">{{ person.name }}</p>
+                    <p class="text-xs text-zinc-500 dark:text-zinc-400">{{ person.character }}</p>
+                </a>
+                {% endfor %}
             </div>
 
             <button @click="scroll('cast', 1)" aria-label="Scroll cast right"
@@ -172,12 +176,6 @@
 
             genres: ['Action', 'Drama', 'Sci-Fi', 'Thriller'],
             activeGenres: [],
-
-            cast: [
-                { name: 'Actor One', img: 'https://via.placeholder.com/150' },
-                { name: 'Actor Two', img: 'https://via.placeholder.com/150' },
-                { name: 'Actor Three', img: 'https://via.placeholder.com/150' }
-            ],
 
             crew: [
                 { name: 'Director One', role: 'Director', img: 'https://via.placeholder.com/150' },


### PR DESCRIPTION
### Motivation
- Ensure the movie detail page renders real cast data (name + character) from stored metadata instead of placeholder client-side mock data.

### Description
- Add a `MovieCastMember` view model and a `template_metadata_cast: Vec<MovieCastMember>` field to the Askama context `TemplateMetaMovieDetailContext` to carry parsed cast entries.
- Parse `mm_metadata_movie_json["credits"]["cast"]` in `user_metadata_movie_detail` and populate `MovieCastMember { name, character }` entries from JSON values `name` and `character`.
- Update the Askama template `bss_user/metadata/bss_user_metadata_movie_detail.html` to iterate `template_metadata_cast` and render each person’s `name` and `character`, and remove the previous hardcoded `cast` mock data from the client-side `moviePage()` Alpine data.
- Changes affect `docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs` and `docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail.html` only.

### Testing
- Ran `cargo fmt` in `docker/core/mkwebaxum` and it completed successfully. 
- Ran `cargo check` in `docker/core/mkwebaxum` and it failed due to private registry access returning HTTP 403 (external registry configuration), so compilation could not be fully validated in this environment. 
- Ran `cargo clippy -- -D warnings` in `docker/core/mkwebaxum` and it failed for the same private registry access reason.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c99b0b239883218981bb5e66c4466c)