### PR TITLE
Populate movie detail crew entries from metadata credits

### DIFF
--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_movie.rs
@@ -43,6 +43,12 @@ struct MovieCastMember {
     pub character: String,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+struct MovieCrewMember {
+    pub name: String,
+    pub job: String,
+}
+
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_401.html")]
 struct TemplateError401Context {}
@@ -480,6 +486,7 @@ struct TemplateMetaMovieDetailContext<'a> {
     template_metadata_photo_updated: DateTime<Utc>,
     template_metadata_genre: Vec<Genre>,
     template_metadata_cast: Vec<MovieCastMember>,
+    template_metadata_crew: Vec<MovieCrewMember>,
     template_metadata_user_watched: serde_json::Value,
     template_metadata_user_rating: serde_json::Value,
     template_metadata_user_request: serde_json::Value,
@@ -565,6 +572,24 @@ pub async fn user_metadata_movie_detail(
                 })
                 .collect();
 
+        let crew_members: Vec<MovieCrewMember> =
+            movie_metadata.mm_metadata_movie_json["credits"]["crew"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|crew_member| {
+                    let name = crew_member.get("name").and_then(|value| value.as_str())?;
+                    let job = crew_member
+                        .get("job")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or_default();
+                    Some(MovieCrewMember {
+                        name: name.to_string(),
+                        job: job.to_string(),
+                    })
+                })
+                .collect();
+
         let template = TemplateMetaMovieDetailContext {
             template_data_json: &movie_metadata.mm_metadata_movie_json,
             template_metadata_name_alt: movie_metadata.mm_metadata_movie_name_alt.clone(),
@@ -578,6 +603,7 @@ pub async fn user_metadata_movie_detail(
             template_metadata_photo_updated: movie_metadata.photo_updated.clone(),
             template_metadata_genre: genres,
             template_metadata_cast: cast_members,
+            template_metadata_crew: crew_members,
             template_metadata_user_watched: watched_status,
             template_metadata_user_rating: rating_status,
             template_metadata_user_request: request_status,

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_movie_detail.html
@@ -125,13 +125,16 @@
             </button>
 
             <div class="flex gap-4 overflow-x-auto scroll-smooth px-10" x-ref="crew">
-                <template x-for="person in crew" :key="person.name">
-                    <a href="#" class="min-w-[140px] text-center">
-                        <img :src="person.img" class="mx-auto h-28 w-28 rounded-full object-cover">
-                        <p class="mt-2 text-sm font-medium text-zinc-800 dark:text-zinc-200" x-text="person.name"></p>
-                        <p class="text-xs text-zinc-500 dark:text-zinc-400" x-text="person.role"></p>
-                    </a>
-                </template>
+                {% for person in template_metadata_crew %}
+                <a href="#" class="min-w-[140px] text-center">
+                    <div
+                        class="mx-auto flex h-28 w-28 items-center justify-center rounded-full bg-zinc-100 text-3xl font-semibold text-zinc-500 dark:bg-zinc-800 dark:text-zinc-300">
+                        {{ person.name.chars().next().unwrap_or('?') }}
+                    </div>
+                    <p class="mt-2 text-sm font-medium text-zinc-800 dark:text-zinc-200">{{ person.name }}</p>
+                    <p class="text-xs text-zinc-500 dark:text-zinc-400">{{ person.job }}</p>
+                </a>
+                {% endfor %}
             </div>
 
             <button @click="scroll('crew', 1)" aria-label="Scroll crew right"
@@ -176,11 +179,6 @@
 
             genres: ['Action', 'Drama', 'Sci-Fi', 'Thriller'],
             activeGenres: [],
-
-            crew: [
-                { name: 'Director One', role: 'Director', img: 'https://via.placeholder.com/150' },
-                { name: 'Writer One', role: 'Writer', img: 'https://via.placeholder.com/150' }
-            ],
 
             reviews: [
                 { user: 'Alice', text: 'Amazing cinematography and story.' },


### PR DESCRIPTION
### Motivation
- Surface crew information on the metadata movie detail page by using the provider-supplied `credits->crew` so each crew entry shows `job` and `name` in the UI.

### Description
- Add a `MovieCrewMember` struct and a `template_metadata_crew: Vec<MovieCrewMember>` field on `TemplateMetaMovieDetailContext` to carry crew data to the template.
- Parse `movie_metadata.mm_metadata_movie_json["credits"]["crew"]` into `Vec<MovieCrewMember>` in `user_metadata_movie_detail` and pass it into the Askama template context.
- Update `bss_user_metadata_movie_detail.html` to render the Crew carousel from server-side `template_metadata_crew` (name + job) and remove the hardcoded Alpine placeholder crew entries.
- Keep the change minimal and non-breaking to existing public interfaces and template contexts.

### Testing
- `cargo fmt` (run in `docker/core/mkwebaxum`) completed successfully.
- `cargo check` (run in `docker/core/mkwebaxum`) could not complete due to a private registry endpoint returning HTTP 403 in this environment, so compilation couldn't be fully verified.
- `cargo clippy -- -D warnings` could not complete for the same private registry HTTP 403 reason, so linting couldn't be fully verified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9a9b3b86483218cf427aadb05dbc3)