### PR TITLE
Add Kubernetes module to fetch worker node external IPs

### DIFF
--- a/src/mk_lib_network/src/lib.rs
+++ b/src/mk_lib_network/src/lib.rs
@@ -5,6 +5,7 @@ pub mod mk_lib_network_external_ip;
 pub mod mk_lib_network_ftp;
 #[cfg(feature = "infiniband")]
 pub mod mk_lib_network_ibverbs; // docker image, so, no infiniband
+pub mod mk_lib_network_kubernetes;
 pub mod mk_lib_network_ldap;
 pub mod mk_lib_network_limiter;
 pub mod mk_lib_network_mediakraken;

--- a/src/mk_lib_network/src/mk_lib_network_kubernetes.rs
+++ b/src/mk_lib_network/src/mk_lib_network_kubernetes.rs
@@ -1,0 +1,75 @@
+use reqwest::Client;
+use serde::Deserialize;
+use std::fs;
+
+const K8S_SERVICE_ACCOUNT_TOKEN_PATH: &str = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+const K8S_SERVICE_ACCOUNT_CA_PATH: &str = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
+const K8S_API_SERVER: &str = "https://kubernetes.default.svc";
+
+#[derive(Debug, Deserialize)]
+struct KubernetesNodeList {
+    items: Vec<KubernetesNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct KubernetesNode {
+    metadata: KubernetesNodeMetadata,
+    status: KubernetesNodeStatus,
+}
+
+#[derive(Debug, Deserialize)]
+struct KubernetesNodeMetadata {
+    #[serde(default)]
+    labels: std::collections::HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct KubernetesNodeStatus {
+    #[serde(default)]
+    addresses: Vec<KubernetesNodeAddress>,
+}
+
+#[derive(Debug, Deserialize)]
+struct KubernetesNodeAddress {
+    #[serde(rename = "type")]
+    address_type: String,
+    address: String,
+}
+
+fn is_worker_node(labels: &std::collections::HashMap<String, String>) -> bool {
+    !labels.contains_key("node-role.kubernetes.io/control-plane")
+        && !labels.contains_key("node-role.kubernetes.io/master")
+}
+
+fn find_external_ip(addresses: &[KubernetesNodeAddress]) -> Option<String> {
+    addresses
+        .iter()
+        .find(|address| address.address_type == "ExternalIP")
+        .map(|address| address.address.clone())
+}
+
+pub async fn mk_lib_network_kubernetes_worker_node_ips()
+-> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let token = fs::read_to_string(K8S_SERVICE_ACCOUNT_TOKEN_PATH)?;
+    let ca_cert_pem = fs::read(K8S_SERVICE_ACCOUNT_CA_PATH)?;
+    let ca_cert = reqwest::Certificate::from_pem(&ca_cert_pem)?;
+
+    let client = Client::builder().add_root_certificate(ca_cert).build()?;
+    let response = client
+        .get(format!("{K8S_API_SERVER}/api/v1/nodes"))
+        .bearer_auth(token.trim())
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let nodes = response.json::<KubernetesNodeList>().await?;
+
+    let worker_node_ips = nodes
+        .items
+        .into_iter()
+        .filter(|node| is_worker_node(&node.metadata.labels))
+        .filter_map(|node| find_external_ip(&node.status.addresses))
+        .collect();
+
+    Ok(worker_node_ips)
+}


### PR DESCRIPTION
### Motivation

- Provide a way for the network library to discover Kubernetes cluster worker node external IPs from inside a pod using the pod's service account credentials.

### Description

- Add a new module `mk_lib_network_kubernetes` and wire it into `lib.rs` via a `pub mod` declaration.
- Implement `mk_lib_network_kubernetes_worker_node_ips` which reads the service account token and CA from ` /var/run/secrets/kubernetes.io/serviceaccount`, calls the Kubernetes API at `https://kubernetes.default.svc`, and returns a `Vec<String>` of worker node `ExternalIP` addresses.
- Use `reqwest` for HTTP requests and TLS with the in-cluster CA, and `serde::Deserialize` to parse the Kubernetes `Node` list JSON, with helper functions `is_worker_node` and `find_external_ip` to filter nodes and extract IPs.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc658498e883219d9c4f291b04834d)