### PR TITLE
Fix locale fallback type mismatch in user preferences

### DIFF
--- a/docker/core/mkwebaxum/src/admin/bp_home.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_home.rs
@@ -1,13 +1,13 @@
-use crate::AppState;
 use crate::axum_custom_filters::filters;
 use crate::mk_lib_database;
 use crate::user_preferences;
+use crate::AppState;
 use askama::Template;
 use axum::extract::State;
 use axum::{
-    Extension,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
+    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
@@ -16,8 +16,8 @@ use mk_lib_common;
 use mk_lib_network;
 use num_format::ToFormattedString;
 use serde::{Deserialize, Serialize};
-use sqlx::Row;
 use sqlx::postgres::PgPool;
+use sqlx::Row;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_403.html")]
@@ -132,19 +132,19 @@ pub async fn admin_home(
                 &mk_lib_database::database_media::mk_lib_database_media::mk_lib_database_media_known_count(&state.sqlx_pool_ro)
                     .await
                     .unwrap()
-                    .to_formatted_string(locale),
+                    .to_formatted_string(&locale),
             template_data_count_matched_media:
                 &mk_lib_database::database_media::mk_lib_database_media::mk_lib_database_media_matched_count(&state.sqlx_pool_ro)
                     .await
                     .unwrap()
-                    .to_formatted_string(locale),
+                    .to_formatted_string(&locale),
             template_data_count_meta_fetch:
                 &mk_lib_database::database_metadata::mk_lib_database_metadata_download_queue::mk_lib_database_metadata_download_count(
                    &state.sqlx_pool_ro,
                 )
                 .await
                 .unwrap()
-                .to_formatted_string(locale),
+                .to_formatted_string(&locale),
             template_data_count_streamed_media: &"0".to_string(),
             template_server_notifications: &notification_list,
             template_server_streams: &server_streams,

--- a/docker/core/mkwebaxum/src/user_preferences.rs
+++ b/docker/core/mkwebaxum/src/user_preferences.rs
@@ -1,6 +1,6 @@
 use num_format::Locale;
-use serde_json::{Value, json};
-use sqlx::{FromRow, postgres::PgPool};
+use serde_json::{json, Value};
+use sqlx::{postgres::PgPool, FromRow};
 
 pub const DEFAULT_PAGINATION_COUNT: i64 = 30;
 pub const MIN_PAGINATION_COUNT: i64 = 5;
@@ -25,9 +25,9 @@ pub fn normalize_number_format_language(value: &str) -> String {
     }
 }
 
-pub fn number_format_locale_for_language(language: &str) -> &'static Locale {
+pub fn number_format_locale_for_language(language: &str) -> Locale {
     let normalized = normalize_number_format_language(language);
-    Locale::from_name(&normalized).unwrap_or(&Locale::en)
+    Locale::from_name(&normalized).unwrap_or(Locale::en)
 }
 
 pub async fn load_user_pagination_count(


### PR DESCRIPTION
### Motivation
- Resolve a compiler error E0308 caused by a type mismatch between `Locale::from_name` (returns `Locale`) and the fallback being passed as a `&Locale`, leading to incorrect `unwrap_or` usage. 
- Make the minimal changes necessary to keep numeric formatting behavior stable while fixing types and keeping call-sites consistent. 

### Description
- Change `number_format_locale_for_language` to return `Locale` (owned) instead of `&'static Locale` and use `unwrap_or(Locale::en)` for the fallback. 
- Update formatting call sites in `admin/bp_home.rs` to pass `&locale` into `to_formatted_string(...)` after the helper now returns an owned `Locale`. 
- Apply minor import reordering/formatting in `user_preferences.rs` for consistency. 

### Testing
- Ran `rustfmt --edition 2021 docker/core/mkwebaxum/src/user_preferences.rs docker/core/mkwebaxum/src/admin/bp_home.rs`, which succeeded. 
- Attempted `cargo check --manifest-path docker/core/mkwebaxum/Cargo.toml`, but it failed in this environment due to a missing private registry (`kellnr`) configuration. 
- Attempted `cargo clippy --manifest-path docker/core/mkwebaxum/Cargo.toml -- -D warnings`, but it likewise failed due to the same missing registry configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cef357d7448321a340607651242a99)