### PR TITLE
Fix type mismatch when saving profile number format language

### DIFF
--- a/docker/core/mkwebaxum/src/user/bp_profile.rs
+++ b/docker/core/mkwebaxum/src/user/bp_profile.rs
@@ -309,7 +309,7 @@ pub async fn user_profile_number_format_language_post(
     if user_preferences::upsert_user_number_format_language(
         &state.sqlx_pool_rw,
         current_user.id,
-        normalized_language,
+        &normalized_language,
     )
     .await
     .is_err()


### PR DESCRIPTION
### Motivation
- Fix a compile error (E0308) in the profile handler where a `String` was passed to a function expecting a `&str` when persisting the user number format language.

### Description
- Borrow `normalized_language` when calling `upsert_user_number_format_language` in `docker/core/mkwebaxum/src/user/bp_profile.rs` by changing the argument to `&normalized_language`, leaving behavior unchanged.

### Testing
- Ran `cargo fmt --all` which completed (formatting applied); `cargo fmt -- --check` reported pre-existing formatting diffs across the repo; `cargo check` and `cargo clippy -- -D warnings` were attempted but failed due to a 403 when fetching the replaced crates registry config from `http://mkdevkellnrapi.mediakraken.media`, so full verification could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cef607bd1c832190c725f298c30291)