### PR TITLE
Fix admin user template panic when email is null

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_user.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_user.html
@@ -48,7 +48,7 @@
                                     <a href="/admin/bss_admin_user_detail/{{ row_data.id }}"
                                        class="text-blue-600 hover:underline">{{ row_data.username }}</a>
                                 </td>
-                                <td class="px-4 py-2 border-b">{{ row_data.email.as_ref().unwrap() }}</td>
+                                <td class="px-4 py-2 border-b">{% match row_data.email %}{% when Some with (email) %}{{ email }}{% when None %}-{% endmatch %}</td>
                                 <td class="px-4 py-2 border-b">FAKE</td>
                                 <td class="px-4 py-2 border-b">FAKE</td>
                                 <td class="px-4 py-2 border-b">FAKE</td>


### PR DESCRIPTION
### Motivation
- Prevent a runtime panic on the admin user list page caused by an `Option::unwrap()` on `email` when a user row has `NULL` email.

### Description
- Replace the unsafe `{{ row_data.email.as_ref().unwrap() }}` expression in the Askama template at `docker/core/mkwebaxum/templates/bss_admin/bss_admin_user.html` with a safe `{% match row_data.email %}{% when Some with (email) %}{{ email }}{% when None %}-{% endmatch %}` that renders `-` when email is missing.

### Testing
- Ran `cargo fmt`, `cargo check`, and `cargo clippy -- -D warnings` against the crate but they failed in this environment due to a missing `kellnr` registry index; the template change itself was committed and the file was validated as updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d05575013c8321bc96ea116aef52c3)