### PR TITLE
mkwebaxum: wire admin torrent page to mk_lib_network torrent data

### DIFF
--- a/docker/core/mkwebaxum/src/admin/bp_torrent.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_torrent.rs
@@ -1,24 +1,13 @@
-use crate::axum_custom_filters::filters;
+use crate::mk_lib_database;
 use askama::Template;
 use axum::{
-    extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
-    routing::{get, post},
-    Extension,
 };
-use axum_session::{SessionConfig, SessionLayer};
-use axum_session_sqlx::{SessionPgPool};
 use axum_session_auth::*;
-use bytesize::ByteSize;
-use core::fmt::Write;
-use mk_lib_common;
-use crate::mk_lib_database;
+use axum_session_sqlx::SessionPgPool;
 use mk_lib_network;
-use serde_json::json;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_403.html")]
@@ -27,13 +16,12 @@ struct TemplateError403Context {}
 #[derive(Template)]
 #[template(path = "bss_admin/bss_admin_torrent.html")]
 struct AdminTorrentTemplate<'a> {
-    template_data: &'a Vec<mk_lib_network::mk_lib_network_transmission::TorrentList>,
-        page_title: Option<String>,
-
+    template_data_json: &'a str,
+    page_title: Option<String>,
 }
 
 pub async fn admin_torrent(
-     method: Method,
+    method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
 ) -> impl IntoResponse {
     let current_user = auth.current_user.clone().unwrap_or_default();
@@ -59,10 +47,13 @@ pub async fn admin_torrent(
             )
             .await
             .unwrap();
+        let transmission_torrents_json = match serde_json::to_string(&transmission_torrents) {
+            Ok(value) => value,
+            Err(_) => "[]".to_string(),
+        };
         let template = AdminTorrentTemplate {
-            template_data: &transmission_torrents,
-                        page_title: Some("MediaKraken Admin Torrent".to_string()),
-
+            template_data_json: &transmission_torrents_json,
+            page_title: Some("MediaKraken Admin Torrent".to_string()),
         };
         let reply_html = template.render().unwrap();
         (StatusCode::OK, Html(reply_html).into_response())

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_torrent.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_torrent.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" x-data="torrentPage({{ template_data_json|safe }})" x-cloak>
+<html lang="en" x-data="torrentPage()" x-cloak>
 {% include "bss_include_header.html" %}
 <body class="bg-gray-100 text-gray-800">
 
@@ -76,9 +76,20 @@
     </main>
   <script src="/static/js/alpinejs_3.15.3.min.js" defer></script>
   <script src="/static/js/base_webapp.js" defer></script>
+  <script id="torrent-data" type="application/json">{{ template_data_json|safe }}</script>
     <!-- Alpine.js data -->
     <script>
-        function torrentPage(initialTorrents) {
+        function torrentPage() {
+            const torrentDataElement = document.getElementById("torrent-data");
+            let initialTorrents = [];
+            if (torrentDataElement) {
+                try {
+                    initialTorrents = JSON.parse(torrentDataElement.textContent || "[]");
+                } catch (_error) {
+                    initialTorrents = [];
+                }
+            }
+
             return {
                 torrents: initialTorrents.map((torrent) => ({
                     id: torrent.mm_torrent_id,

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_torrent.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_torrent.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" x-data="torrentPage()" x-cloak>
+<html lang="en" x-data="torrentPage({{ template_data_json|safe }})" x-cloak>
 {% include "bss_include_header.html" %}
 <body class="bg-gray-100 text-gray-800">
 
@@ -78,13 +78,15 @@
   <script src="/static/js/base_webapp.js" defer></script>
     <!-- Alpine.js data -->
     <script>
-        function torrentPage() {
+        function torrentPage(initialTorrents) {
             return {
-                torrents: [
-                    // Example data; replace with server-side JSON
-                    { id: 1, name: "Ubuntu.iso", status: "Downloading", percent_done: 0.45, size: 2147483648 },
-                    { id: 2, name: "Fedora.iso", status: "Seeding", percent_done: 1, size: 3221225472 },
-                ],
+                torrents: initialTorrents.map((torrent) => ({
+                    id: torrent.mm_torrent_id,
+                    name: torrent.mm_torrent_name,
+                    status: torrent.mm_torrent_status,
+                    percent_done: torrent.mm_torrent_percent_done,
+                    size: torrent.mm_torrent_size,
+                })),
                 showDeleteModal: false,
                 torrentToDelete: null,
 


### PR DESCRIPTION
### Motivation

- The admin torrent page should display live transmission state rather than hardcoded example rows by sourcing data from the existing `mk_lib_network` torrent API.

### Description

- Serialize the results from `mk_lib_network::mk_lib_network_transmission::mk_network_transmission_list_torrents` into JSON with `serde_json::to_string` and pass it to the Askama template via a new `template_data_json` field in `admin_torrent` (`docker/core/mkwebaxum/src/admin/bp_torrent.rs`).
- Update the template `bss_admin_torrent.html` to initialize the Alpine component with `torrentPage({{ template_data_json|safe }})` and map `mm_torrent_*` fields into the UI model (`id`, `name`, `status`, `percent_done`, `size`).
- Remove a few unused imports/fields from `bp_torrent.rs` so the handler only provides the JSON payload needed by the template, keeping existing table, modal and edit/delete UI behaviour unchanged.
- Files changed: `docker/core/mkwebaxum/src/admin/bp_torrent.rs` and `docker/core/mkwebaxum/templates/bss_admin/bss_admin_torrent.html`.

### Testing

- Ran `cargo fmt` in `docker/core/mkwebaxum` and it completed successfully.
- Attempted `cargo check` but it failed due to an external private registry mirror returning HTTP 403 when fetching crate index metadata, so compilation could not be fully validated.
- Attempted `cargo clippy -- -D warnings` but it also failed for the same external registry HTTP 403 error before linting could complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d05a08fb7c83219cc54e3064485660)