### PR TITLE
Add Game System link under Metadata > Game menus

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_user/bss_user_include_menu.html
+++ b/docker/core/mkwebaxum/templates/bss_user/bss_user_include_menu.html
@@ -69,6 +69,9 @@
                                             <li><a href="/user/metadata/game/1"
                                                     class="text-sm text-gray-600 dark:text-zinc-300 hover:text-indigo-600 block">Game</a>
                                             </li>
+                                            <li><a href="/user/metadata/game_system/1"
+                                                    class="text-sm text-gray-600 dark:text-zinc-300 hover:text-indigo-600 block">Game System</a>
+                                            </li>
                                             <li><a href="/user/metadata/music/1"
                                                     class="text-sm text-gray-600 dark:text-zinc-300 hover:text-indigo-600 block">Music</a>
                                             </li>

--- a/docker/core/mkwebaxum/templates/partials/topnavbar.html
+++ b/docker/core/mkwebaxum/templates/partials/topnavbar.html
@@ -76,6 +76,9 @@
                                             <li><a href="/user/metadata/game/1?starts_with=#" class="text-sm text-gray-600 dark:text-zinc-300
                                                           hover:text-indigo-600 dark:hover:text-indigo-400">
                                                     Game</a></li>
+                                            <li><a href="/user/metadata/game_system/1" class="text-sm text-gray-600 dark:text-zinc-300
+                                                          hover:text-indigo-600 dark:hover:text-indigo-400">
+                                                    Game System</a></li>
                                             <li><a href="/user/metadata/music/1?starts_with=#" class="text-sm text-gray-600 dark:text-zinc-300
                                                           hover:text-indigo-600 dark:hover:text-indigo-400">
                                                     Music</a></li>


### PR DESCRIPTION
### Motivation
- Provide direct navigation to the Game System listing from the Metadata menu using the existing Axum route `/user/metadata/game_system/1` so users can easily access game system metadata pages.

### Description
- Inserted a new "Game System" menu item directly below "Game" in two templates: `docker/core/mkwebaxum/templates/partials/topnavbar.html` and `docker/core/mkwebaxum/templates/bss_user/bss_user_include_menu.html`, linking to `/user/metadata/game_system/1`.

### Testing
- Ran `cargo check -p mkwebaxum` in `docker/core/mkwebaxum`, which failed in this environment due to a private crate registry HTTP 403 error unrelated to the template-only changes, and no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0727153108321998bbdc055430f0e)