### PR TITLE
Avoid panic on unreadable ID3 tags

### DIFF
--- a/src/mk_lib_metadata/src/mk_lib_metadata_id3.rs
+++ b/src/mk_lib_metadata/src/mk_lib_metadata_id3.rs
@@ -3,7 +3,9 @@
 use id3::{Tag, TagLike};
 
 pub async fn mk_lib_metadata_id3_get_tag_info(file_name: String) {
-    let tag = Tag::read_from_path(file_name).unwrap();
+    let Ok(tag) = Tag::read_from_path(file_name) else {
+        return;
+    };
     if let Some(artist) = tag.artist() {
         #[cfg(debug_assertions)]
         {


### PR DESCRIPTION
### Motivation
- Prevent panics during metadata ingestion when audio files do not contain readable ID3 tags by making ID3 parsing resilient.

### Description
- Replace `Tag::read_from_path(...).unwrap()` with a guarded parse that returns early on error in `src/mk_lib_metadata/src/mk_lib_metadata_id3.rs` so unreadable or missing tags are skipped instead of causing a panic.

### Testing
- Ran `cargo fmt` in `src/mk_lib_metadata` which completed successfully. 
- Ran `cargo check` in `src/mk_lib_metadata` which failed due to the project's private registry returning HTTP 403 (not a code issue). 
- Ran `cargo clippy -- -D warnings` in `src/mk_lib_metadata` which also failed for the same private registry 403 reason.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d07320abc8832196c3d02d40bde2b8)