### PR TITLE
Metadata game page: selector layout with genre and user-status filters

### DIFF
--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_game.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_game.rs
@@ -134,8 +134,9 @@ fn build_game_pagination(
     );
 
     let suffix = build_filter_query_suffix(starts_with, genre, status_filter);
+    let current_page = page.max(1).min(total_pages) as usize;
     let paginator = Paginator::builder(total_pages as usize)
-        .current_page(page.max(1) as usize)
+        .current_page(current_page)
         .build_paginator()
         .map_err(|_| std::fmt::Error)?;
 

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_game.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_game.rs
@@ -1,19 +1,22 @@
-use crate::AppState;
 use crate::mk_lib_database;
 use crate::user_preferences;
+use crate::AppState;
 use askama::Template;
+use axum::extract::Query;
 use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
-    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
+    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
-use mk_lib_common::mk_lib_common_pagination;
+use core::fmt::Write;
+use paginator::{PageItem, Paginator};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sqlx::postgres::PgPool;
 
@@ -30,6 +33,155 @@ struct TemplateMetaGameContext<'a> {
     pagination_bar: &'a String,
     page: &'a usize,
     page_title: Option<String>,
+    pub current: Option<String>,
+    pub genre_filter: Option<String>,
+    pub genre_filter_query: Option<String>,
+    pub status_filter: Option<String>,
+    pub status_options: &'a Vec<FilterOption>,
+    pub genre_options: &'a Vec<FilterOption>,
+    pub base_path: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FilterOption {
+    pub label: String,
+    pub query_value: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FilterQuery {
+    pub starts_with: Option<String>,
+    pub genre: Option<String>,
+    pub status: Option<String>,
+}
+
+fn normalize_starts_with(raw: Option<&str>) -> Option<String> {
+    let value = raw.map(str::trim).filter(|value| !value.is_empty())?;
+    let first_char = value.chars().next()?;
+
+    if first_char == '#' {
+        return Some("#".to_string());
+    }
+
+    if first_char.is_ascii_alphanumeric() {
+        return Some(first_char.to_ascii_uppercase().to_string());
+    }
+
+    Some("#".to_string())
+}
+
+fn normalize_string_filter(raw: Option<&str>) -> Option<String> {
+    raw.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn normalize_status_filter(raw: Option<&str>) -> Option<String> {
+    let value = raw.map(str::trim).filter(|value| !value.is_empty())?;
+    match value {
+        "favorite" | "watched" | "unwatched" | "good" | "bad" | "trash" => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn build_filter_query_suffix(
+    starts_with: Option<&str>,
+    genre: Option<&str>,
+    status_filter: Option<&str>,
+) -> String {
+    let mut query_params: Vec<String> = Vec::new();
+    if let Some(sw) = starts_with.filter(|sw| !sw.is_empty()) {
+        if sw == "#" {
+            query_params.push("starts_with=%23".to_string());
+        } else {
+            query_params.push(format!("starts_with={sw}"));
+        }
+    }
+    if let Some(genre_name) = genre.filter(|genre_name| !genre_name.is_empty()) {
+        query_params.push(format!("genre={}", urlencoding::encode(genre_name)));
+    }
+    if let Some(status) = status_filter.filter(|status| !status.is_empty()) {
+        query_params.push(format!("status={}", urlencoding::encode(status)));
+    }
+    if query_params.is_empty() {
+        String::new()
+    } else {
+        format!("?{}", query_params.join("&"))
+    }
+}
+
+fn build_game_pagination(
+    total_items: i64,
+    page: i64,
+    pagination_count: i64,
+    starts_with: Option<&str>,
+    genre: Option<&str>,
+    status_filter: Option<&str>,
+) -> Result<String, std::fmt::Error> {
+    let total_pages = if total_items > 0 {
+        (total_items + pagination_count - 1) / pagination_count
+    } else {
+        0
+    };
+
+    if total_pages <= 0 {
+        return Ok(String::new());
+    }
+
+    let mut pagination_html = String::from(
+        r#"<nav class="mt-6 flex justify-center" aria-label="Pagination">
+<ul class="flex items-center gap-1 whitespace-nowrap text-sm">"#,
+    );
+
+    let suffix = build_filter_query_suffix(starts_with, genre, status_filter);
+    let paginator = Paginator::builder(total_pages as usize)
+        .current_page(page.max(1) as usize)
+        .build_paginator()
+        .map_err(|_| std::fmt::Error)?;
+
+    for item in paginator.paginate() {
+        match item {
+            PageItem::Prev(p) => {
+                write!(
+                    pagination_html,
+                    r#"<li><a href="/user/metadata/game/{p}{suffix}"
+class="px-3 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-200"
+aria-label="Previous">&laquo;</a></li>"#,
+                )?;
+            }
+            PageItem::Page(p) => {
+                write!(
+                    pagination_html,
+                    r#"<li><a href="/user/metadata/game/{p}{suffix}"
+class="px-3 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-200">{p}</a></li>"#,
+                )?;
+            }
+            PageItem::CurrentPage(p) => {
+                write!(
+                    pagination_html,
+                    r#"<li><a href="/user/metadata/game/{p}{suffix}"
+class="px-3 py-2 rounded-md bg-indigo-600 text-white font-semibold border border-indigo-600"
+aria-current="page">{p}</a></li>"#,
+                )?;
+            }
+            PageItem::Ignore => {
+                pagination_html
+                    .push_str(r#"<li><span class="px-3 py-2 text-gray-400">…</span></li>"#);
+            }
+            PageItem::Next(p) => {
+                write!(
+                    pagination_html,
+                    r#"<li><a href="/user/metadata/game/{p}{suffix}"
+class="px-3 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-200"
+aria-label="Next">&raquo;</a></li>"#,
+                )?;
+            }
+            _ => {}
+        }
+    }
+
+    pagination_html.push_str("</ul></nav>");
+    Ok(pagination_html)
 }
 
 pub async fn user_metadata_game(
@@ -37,7 +189,11 @@ pub async fn user_metadata_game(
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
     Path(page): Path<i64>,
+    Query(params): Query<FilterQuery>,
 ) -> impl IntoResponse {
+    let starts_with = normalize_starts_with(params.starts_with.as_deref());
+    let genre = normalize_string_filter(params.genre.as_deref());
+    let status_filter = normalize_status_filter(params.status.as_deref());
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
         [Method::GET],
@@ -60,27 +216,71 @@ pub async fn user_metadata_game(
         mk_lib_database::database_metadata::mk_lib_database_metadata_game::mk_lib_database_metadata_game_count(
            &state.sqlx_pool_ro,
             String::new(),
+            starts_with.clone().unwrap_or_default(),
+            genre.clone().unwrap_or_default(),
+            status_filter.clone().unwrap_or_default(),
         )
         .await
         .unwrap();
-        let pagination_html = mk_lib_common_pagination::mk_lib_common_paginate(
+        let pagination_html = build_game_pagination(
             total_pages,
             page,
-            "/user/metadata/game".to_string(),
-            None,
             pagination_count,
+            starts_with.as_deref(),
+            genre.as_deref(),
+            status_filter.as_deref(),
         )
-        .await
         .unwrap();
         let game_list =
         mk_lib_database::database_metadata::mk_lib_database_metadata_game::mk_lib_database_metadata_game_read(
            &state.sqlx_pool_ro,
             String::new(),
+            starts_with.clone().unwrap_or_default(),
+            genre.clone().unwrap_or_default(),
+            status_filter.clone().unwrap_or_default(),
             db_offset,
             pagination_count,
         )
         .await
         .unwrap();
+        let status_options = vec![
+            FilterOption {
+                label: "Favorite".to_string(),
+                query_value: "favorite".to_string(),
+            },
+            FilterOption {
+                label: "Watched".to_string(),
+                query_value: "watched".to_string(),
+            },
+            FilterOption {
+                label: "Unwatched".to_string(),
+                query_value: "unwatched".to_string(),
+            },
+            FilterOption {
+                label: "Good".to_string(),
+                query_value: "good".to_string(),
+            },
+            FilterOption {
+                label: "Bad".to_string(),
+                query_value: "bad".to_string(),
+            },
+            FilterOption {
+                label: "Trash".to_string(),
+                query_value: "trash".to_string(),
+            },
+        ];
+        let genre_options: Vec<FilterOption> =
+            mk_lib_database::database_metadata::mk_lib_database_metadata_game::mk_lib_database_metadata_game_genres(
+                &state.sqlx_pool_ro,
+            )
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|value| FilterOption {
+                label: value.clone(),
+                query_value: value,
+            })
+            .collect();
         let mut template_data_exists = false;
         if game_list.len() > 0 {
             template_data_exists = true;
@@ -92,6 +292,15 @@ pub async fn user_metadata_game(
             pagination_bar: &pagination_html,
             page: &page_usize,
             page_title: Some("MediaKraken Metadata Games".to_string()),
+            current: starts_with.clone(),
+            genre_filter: genre.clone(),
+            genre_filter_query: genre
+                .as_ref()
+                .map(|value| urlencoding::encode(value).into_owned()),
+            status_filter: status_filter.clone(),
+            status_options: &status_options,
+            genre_options: &genre_options,
+            base_path: "/user/metadata/game".to_string(),
         };
         let reply_html = template.render().unwrap();
         (StatusCode::OK, Html(reply_html).into_response())

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_game.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_game.html
@@ -1,40 +1,104 @@
 {% extends "layouts/base_user.html" %}
 
 {% block content %}
-<div>
-                {% if template_data_exists %}
-                {% if pagination_bar != "" %}
-                {{ pagination_bar|safe }}
-                {% endif %}
-                <div class="table-responsive">
-                    <table class="table table-striped table-hover">
-                        <thead>
-                            <tr>
-                                <th>#</th>
-                                <th>Game Name</th>
-                                <th>Year</th>
-                                <th>System</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for row_data in template_data %}
-                            <tr>
-                                <td>{{ loop.index + (page - 1) * 30 }}</td>
-                                <td><a href="/user/metadata/game_detail/{{row_data.gi_game_info_id}}">{{
-                                        row_data.gi_game_info_name
-                                        }}</a></td>
-                                <td>{{ "{:?}"|format(row_data.gi_year) }}</td>
-                                <td>{{ row_data.gs_game_system_name }}</td>
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-                {% if pagination_bar != "" %}
-                {{ pagination_bar|safe }}
-                {% endif %}
-                {% else %}
-                <p id="general_text">No game metadata found.</p>
-                {% endif %}
-            </div>
+<section class="w-full px-0 py-4 text-zinc-900 dark:text-zinc-100">
+  <h1 class="sr-only">Game list</h1>
+
+  <nav class="w-full border-b border-zinc-200 dark:border-zinc-800 py-3" aria-label="Alphabetical Pagination">
+    <ul class="flex flex-wrap gap-1 justify-center text-sm font-medium">
+      <li>
+        <a href="{{ base_path }}/1?starts_with=%23{% if let Some(genre_name) = genre_filter_query %}&genre={{ genre_name }}{% endif %}{% if let Some(status_value) = status_filter %}&status={{ status_value }}{% endif %}"
+           class="px-2 py-1.5 rounded-md transition-colors {% if current == Some("#".to_string()) %}bg-indigo-600 text-white{% else %}text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800{% endif %}">
+          #
+        </a>
+      </li>
+      {% for n in 0..10 %}
+      <li>
+        <a href="{{ base_path }}/1?starts_with={{ n }}{% if let Some(genre_name) = genre_filter_query %}&genre={{ genre_name }}{% endif %}{% if let Some(status_value) = status_filter %}&status={{ status_value }}{% endif %}"
+           class="px-2 py-1.5 rounded-md transition-colors {% if current == Some(n.to_string()) %}bg-indigo-600 text-white{% else %}text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800{% endif %}">
+          {{ n }}
+        </a>
+      </li>
+      {% endfor %}
+      {% for c in 'A'..='Z' %}
+      <li>
+        <a href="{{ base_path }}/1?starts_with={{ c }}{% if let Some(genre_name) = genre_filter_query %}&genre={{ genre_name }}{% endif %}{% if let Some(status_value) = status_filter %}&status={{ status_value }}{% endif %}"
+           class="px-2 py-1.5 rounded-md transition-colors {% if current == Some(c.to_string()) %}bg-indigo-600 text-white{% else %}text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800{% endif %}">
+          {{ c }}
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+  </nav>
+
+  <div class="mt-4 grid gap-4 rounded-xl border border-zinc-200 bg-white/70 p-4 shadow-sm md:grid-cols-2 dark:border-zinc-800 dark:bg-zinc-900/70">
+    <div class="space-y-2">
+      <h2 class="text-sm font-semibold tracking-wide text-zinc-700 dark:text-zinc-200">Genre</h2>
+      <form method="get" action="{{ base_path }}/1" class="max-w-xs">
+        {% if let Some(current_filter) = current %}
+        <input type="hidden" name="starts_with" value="{{ current_filter }}">
+        {% endif %}
+        {% if let Some(status_value) = status_filter %}
+        <input type="hidden" name="status" value="{{ status_value }}">
+        {% endif %}
+        <select name="genre" class="block w-full rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100" onchange="this.form.submit()">
+          <option value="">All genres</option>
+          {% for option in genre_options %}
+          <option value="{{ option.query_value }}"{% if let Some(active_genre) = genre_filter %}{% if active_genre.as_str() == option.query_value.as_str() %} selected{% endif %}{% endif %}>{{ option.label }}</option>
+          {% endfor %}
+        </select>
+      </form>
+    </div>
+    <div class="space-y-2">
+      <h2 class="text-sm font-semibold tracking-wide text-zinc-700 dark:text-zinc-200">User status</h2>
+      <div class="flex flex-wrap gap-2">
+        {% for option in status_options %}
+        <a href="{{ base_path }}/1?{% if let Some(current_filter) = current %}starts_with={% if current_filter == "#" %}%23{% else %}{{ current_filter }}{% endif %}&{% endif %}{% if let Some(genre_name) = genre_filter_query %}genre={{ genre_name }}&{% endif %}status={{ option.query_value }}"
+           class="inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium capitalize transition-colors {% if let Some(active_status) = status_filter %}{% if active_status.as_str() == option.query_value.as_str() %}border-indigo-600 bg-indigo-600 text-white{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}{% else %}border-zinc-300 text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800{% endif %}">
+          {{ option.label }}
+        </a>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+
+  {% if current.is_some() || genre_filter.is_some() || status_filter.is_some() %}
+  <div class="mt-3 flex justify-center">
+    <a href="{{ base_path }}/1"
+       class="inline-flex items-center rounded-md border border-zinc-300 px-3 py-1.5 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800">
+      Clear filters
+    </a>
+  </div>
+  {% endif %}
+
+  {% if template_data_exists %}
+  {% if pagination_bar != "" %}
+  {{ pagination_bar|safe }}
+  {% endif %}
+  <ul role="list" class="grid gap-4 sm:gap-5 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+    {% for row_data in template_data %}
+    <li class="rounded-xl border border-zinc-200 bg-white/80 p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-900/80">
+      <div class="flex items-start justify-between gap-3">
+        <h2 class="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+          <a href="/user/metadata/game_detail/{{row_data.gi_game_info_id}}" class="hover:underline">{{ row_data.gi_game_info_name }}</a>
+        </h2>
+        {% if let Some(game_genre) = row_data.gi_gc_category %}
+        <a href="{{ base_path }}/1?genre={{ game_genre }}{% if let Some(current_filter) = current %}&starts_with={% if current_filter == "#" %}%23{% else %}{{ current_filter }}{% endif %}{% endif %}{% if let Some(status_value) = status_filter %}&status={{ status_value }}{% endif %}"
+           class="rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+          {{ game_genre }}
+        </a>
+        {% endif %}
+      </div>
+      <p class="mt-2 text-xs text-zinc-500 dark:text-zinc-400">System: {{ row_data.gs_game_system_name }}</p>
+      <p class="text-xs text-zinc-500 dark:text-zinc-400">Year: {% if let Some(game_year) = row_data.gi_year %}{{ game_year }}{% else %}Unknown{% endif %}</p>
+    </li>
+    {% endfor %}
+  </ul>
+  {% if pagination_bar != "" %}
+  {{ pagination_bar|safe }}
+  {% endif %}
+  {% else %}
+  <p class="text-sm text-zinc-500 dark:text-zinc-400">No game metadata found.</p>
+  {% endif %}
+</section>
 {% endblock %}

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_game.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_game.rs
@@ -45,21 +45,38 @@ pub async fn mk_lib_database_metadata_game_by_blake3(
 pub async fn mk_lib_database_metadata_game_count(
     sqlx_pool: &sqlx::PgPool,
     search_value: String,
+    starts_with: String,
+    genre: String,
+    status_filter: String,
 ) -> Result<i64, sqlx::Error> {
-    if !search_value.is_empty() {
-        let row: (i64,) = sqlx::query_as(
-            r#"select count(*) from mm_metadata_game_software_info where gi_game_info_name &@ $1"#,
-        )
-        .bind(search_value)
-        .fetch_one(sqlx_pool)
-        .await?;
-        Ok(row.0)
-    } else {
-        let row: (i64,) = sqlx::query_as(r#"select count(*) from mm_metadata_game_software_info"#)
-            .fetch_one(sqlx_pool)
-            .await?;
-        Ok(row.0)
-    }
+    let row: (i64,) = sqlx::query_as(
+        r#"select count(*)
+           from mm_metadata_game_software_info
+           where
+             ($1 = '' or gi_game_info_name &@ $1)
+             and (
+               $2 = ''
+               or ($2 = '#' and left(lower(gi_game_info_name), 1) !~ '^[a-z0-9]$')
+               or ($2 <> '#' and lower(gi_game_info_name) like lower($2) || '%')
+             )
+             and ($3 = '' or lower(coalesce(gi_gc_category, '')) = lower($3))
+             and (
+               $4 = ''
+               or ($4 = 'favorite' and coalesce((gi_game_info_json->'user_status'->>'favorite')::boolean, false))
+               or ($4 = 'watched' and coalesce((gi_game_info_json->'user_status'->>'watched')::boolean, false))
+               or ($4 = 'unwatched' and not coalesce((gi_game_info_json->'user_status'->>'watched')::boolean, false))
+               or ($4 = 'good' and coalesce((gi_game_info_json->'user_status'->>'good')::boolean, false))
+               or ($4 = 'bad' and coalesce((gi_game_info_json->'user_status'->>'bad')::boolean, false))
+               or ($4 = 'trash' and coalesce((gi_game_info_json->'user_status'->>'trash')::boolean, false))
+             )"#,
+    )
+    .bind(search_value)
+    .bind(starts_with)
+    .bind(genre)
+    .bind(status_filter)
+    .fetch_one(sqlx_pool)
+    .await?;
+    Ok(row.0)
 }
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
@@ -70,32 +87,71 @@ pub struct DBMetaGameList {
     pub gi_year: Option<String>,
     pub gi_game_info_localimage: Option<serde_json::Value>,
     pub gs_game_system_name: String,
+    pub gi_gc_category: Option<String>,
 }
 
 pub async fn mk_lib_database_metadata_game_read(
     sqlx_pool: &sqlx::PgPool,
     search_value: String,
+    starts_with: String,
+    genre: String,
+    status_filter: String,
     offset: i64,
     limit: i64,
 ) -> Result<Vec<DBMetaGameList>, sqlx::Error> {
-    if !search_value.is_empty() {
-        sqlx::query_as(
-            r#"select gi_game_info_id, gi_game_info_short_name, gi_game_info_name, gi_game_info_json->'machine'->>'year' as gi_year, gi_game_info_localimage, gs_game_system_name from mm_metadata_game_software_info, mm_metadata_game_systems_info where gi_game_info_system_id = gs_game_system_id and gi_game_info_name &@ $1 offset $2 limit $3"#,
-        )
-        .bind(search_value)
-        .bind(offset)
-        .bind(limit)
-        .fetch_all(sqlx_pool)
-        .await
-    } else {
-        sqlx::query_as(
-            r#"select gi_game_info_id, gi_game_info_short_name, gi_game_info_name, gi_game_info_json->'machine'->>'year' as gi_year, gi_game_info_localimage, gs_game_system_name from mm_metadata_game_software_info, mm_metadata_game_systems_info where gi_game_info_system_id = gs_game_system_id order by gi_game_info_name, gi_year offset $1 limit $2"#,
-        )
-        .bind(offset)
-        .bind(limit)
-        .fetch_all(sqlx_pool)
-        .await
-    }
+    sqlx::query_as(
+        r#"select gi_game_info_id,
+           gi_game_info_short_name,
+           gi_game_info_name,
+           gi_game_info_json->'machine'->>'year' as gi_year,
+           gi_game_info_localimage,
+           gs_game_system_name,
+           gi_gc_category
+           from mm_metadata_game_software_info, mm_metadata_game_systems_info
+           where gi_game_info_system_id = gs_game_system_id
+           and ($1 = '' or gi_game_info_name &@ $1)
+           and (
+               $2 = ''
+               or ($2 = '#' and left(lower(gi_game_info_name), 1) !~ '^[a-z0-9]$')
+               or ($2 <> '#' and lower(gi_game_info_name) like lower($2) || '%')
+           )
+           and ($3 = '' or lower(coalesce(gi_gc_category, '')) = lower($3))
+           and (
+               $4 = ''
+               or ($4 = 'favorite' and coalesce((gi_game_info_json->'user_status'->>'favorite')::boolean, false))
+               or ($4 = 'watched' and coalesce((gi_game_info_json->'user_status'->>'watched')::boolean, false))
+               or ($4 = 'unwatched' and not coalesce((gi_game_info_json->'user_status'->>'watched')::boolean, false))
+               or ($4 = 'good' and coalesce((gi_game_info_json->'user_status'->>'good')::boolean, false))
+               or ($4 = 'bad' and coalesce((gi_game_info_json->'user_status'->>'bad')::boolean, false))
+               or ($4 = 'trash' and coalesce((gi_game_info_json->'user_status'->>'trash')::boolean, false))
+           )
+           order by gi_game_info_name, gi_year
+           offset $5
+           limit $6"#,
+    )
+    .bind(search_value)
+    .bind(starts_with)
+    .bind(genre)
+    .bind(status_filter)
+    .bind(offset)
+    .bind(limit)
+    .fetch_all(sqlx_pool)
+    .await
+}
+
+pub async fn mk_lib_database_metadata_game_genres(
+    sqlx_pool: &sqlx::PgPool,
+) -> Result<Vec<String>, sqlx::Error> {
+    let rows: Vec<(String,)> = sqlx::query_as(
+        r#"select distinct gi_gc_category
+           from mm_metadata_game_software_info
+           where coalesce(gi_gc_category, '') <> ''
+           order by gi_gc_category"#,
+    )
+    .fetch_all(sqlx_pool)
+    .await?;
+
+    Ok(rows.into_iter().map(|row| row.0).collect())
 }
 
 pub async fn mk_lib_database_metadata_game_uuid_by_name_and_system(


### PR DESCRIPTION
### Motivation

- Bring the game metadata listing UX in line with the movie metadata selector (alphabetical selector + cards) for consistency. 
- Allow users to filter games by starting character, genre, and personal status (favorite/watched/unwatched/good/bad/trash). 
- Support server-side filtering so pagination and counts reflect the selected filters.

### Description

- Converted the game listing page from a table to a selector/card-style layout with alphabetical navigation, a genre dropdown, user-status chips, and a clear-filters control in `docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_game.html`. 
- Added query parsing/normalization for `starts_with`, `genre`, and `status`, filter suffix building, and filter-aware pagination generation in `docker/core/mkwebaxum/src/user/metadata/bp_meta_game.rs`. 
- Extended DB APIs in `src/mk_lib_database/src/metadata/mk_lib_database_metadata_game.rs` to accept `starts_with`, `genre` (mapped to `gi_gc_category`), and `status` and apply them in `mk_lib_database_metadata_game_count` and `mk_lib_database_metadata_game_read`, and added `mk_lib_database_metadata_game_genres` to fetch distinct genres. 
- Added template context fields for current filters, `status_options` and `genre_options`, and plumbed the data through to the template so active states and filter links render correctly; key modified files: `bp_meta_game.rs`, `bss_user_metadata_game.html`, and `mk_lib_database_metadata_game.rs`.

### Testing

- Ran `rustfmt` on the modified files locally with `rustfmt --edition 2021 docker/core/mkwebaxum/src/user/metadata/bp_meta_game.rs src/mk_lib_database/src/metadata/mk_lib_database_metadata_game.rs` which succeeded. 
- Attempted `cargo fmt`, `cargo check`, and `cargo clippy` for the `mkwebaxum` crate but execution was blocked in this environment due to a missing private registry configuration (`kellnr`), so full compilation/lint validation could not be completed here. 
- To verify locally or in CI run: `cargo fmt`, `cargo check --manifest-path docker/core/mkwebaxum/Cargo.toml`, and `cargo clippy --manifest-path docker/core/mkwebaxum/Cargo.toml -- -D warnings` and load `/user/metadata/game/1` to confirm the selector UI, filters, and pagination behave as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d072dee39083218e7443f2ed0c6e10)