### PR TITLE
mkwebaxum: add starts_with filtering to metadata list pages

### DIFF
--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_book.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_book.rs
@@ -2,6 +2,7 @@ use crate::AppState;
 use crate::mk_lib_database;
 use crate::user_preferences;
 use askama::Template;
+use axum::extract::Query;
 use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
@@ -14,6 +15,7 @@ use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
+use serde::Deserialize;
 use sqlx::postgres::PgPool;
 
 #[derive(Template)]
@@ -29,6 +31,32 @@ struct TemplateMetaBookContext<'a> {
     pagination_bar: &'a String,
     page: &'a usize,
     page_title: Option<String>,
+    pub current: Option<String>,
+    pub genre_filter: Option<String>,
+    pub genre_filter_query: Option<String>,
+    pub primary_language_filter: Option<String>,
+    pub status_filter: Option<String>,
+    pub base_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FilterQuery {
+    pub starts_with: Option<String>,
+}
+
+fn normalize_starts_with(raw: Option<&str>) -> Option<String> {
+    let value = raw.map(str::trim).filter(|value| !value.is_empty())?;
+    let first_char = value.chars().next()?;
+
+    if first_char == '#' {
+        return Some("#".to_string());
+    }
+
+    if first_char.is_ascii_alphanumeric() {
+        return Some(first_char.to_ascii_uppercase().to_string());
+    }
+
+    Some("#".to_string())
 }
 
 pub async fn user_metadata_book(
@@ -36,7 +64,9 @@ pub async fn user_metadata_book(
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
     Path(page): Path<i64>,
+    Query(params): Query<FilterQuery>,
 ) -> impl IntoResponse {
+    let starts_with = normalize_starts_with(params.starts_with.as_deref());
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
         [Method::GET],
@@ -58,7 +88,7 @@ pub async fn user_metadata_book(
         let total_pages: i64 =
         mk_lib_database::database_metadata::mk_lib_database_metadata_book::mk_lib_database_metadata_book_count(
             &state.sqlx_pool_ro,
-            String::new(),
+            starts_with.clone().unwrap_or_default(),
         )
         .await
         .unwrap();
@@ -66,7 +96,7 @@ pub async fn user_metadata_book(
             total_pages,
             page,
             "/user/metadata/book".to_string(),
-            None,
+            starts_with.as_deref(),
             pagination_count,
         )
         .await
@@ -74,7 +104,7 @@ pub async fn user_metadata_book(
         let book_list =
         mk_lib_database::database_metadata::mk_lib_database_metadata_book::mk_lib_database_metadata_book_read(
            &state.sqlx_pool_ro,
-            String::new(),
+            starts_with.clone().unwrap_or_default(),
             db_offset,
             pagination_count,
         )
@@ -91,6 +121,12 @@ pub async fn user_metadata_book(
             pagination_bar: &pagination_html,
             page: &page_usize,
             page_title: Some("MediaKraken Metadata Books".to_string()),
+            current: starts_with,
+            genre_filter: None,
+            genre_filter_query: None,
+            primary_language_filter: None,
+            status_filter: None,
+            base_path: "/user/metadata/book".to_string(),
         };
         let reply_html = template.render().unwrap();
         (StatusCode::OK, Html(reply_html).into_response())

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_game_system.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_game_system.rs
@@ -2,6 +2,7 @@ use crate::AppState;
 use crate::mk_lib_database;
 use crate::user_preferences;
 use askama::Template;
+use axum::extract::Query;
 use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
@@ -14,6 +15,7 @@ use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
+use serde::Deserialize;
 use sqlx::postgres::PgPool;
 
 #[derive(Template)]
@@ -29,6 +31,30 @@ struct TemplateMetaGameSystemContext<'a> {
     pagination_bar: &'a String,
     page: &'a usize,
     page_title: Option<String>,
+    pub current: Option<String>,
+    pub genre_filter: Option<String>,
+    pub genre_filter_query: Option<String>,
+    pub primary_language_filter: Option<String>,
+    pub status_filter: Option<String>,
+    pub base_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FilterQuery {
+    pub starts_with: Option<String>,
+}
+
+fn normalize_starts_with(raw: Option<&str>) -> Option<String> {
+    let value = raw.map(str::trim).filter(|value| !value.is_empty())?;
+    let first_char = value.chars().next()?;
+
+    if first_char == '#' {
+        return Some("#".to_string());
+    }
+    if first_char.is_ascii_alphanumeric() {
+        return Some(first_char.to_ascii_uppercase().to_string());
+    }
+    Some("#".to_string())
 }
 
 pub async fn user_metadata_game_system(
@@ -36,7 +62,9 @@ pub async fn user_metadata_game_system(
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
     Path(page): Path<i64>,
+    Query(params): Query<FilterQuery>,
 ) -> impl IntoResponse {
+    let starts_with = normalize_starts_with(params.starts_with.as_deref());
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
         [Method::GET],
@@ -57,8 +85,8 @@ pub async fn user_metadata_game_system(
         let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 =
         mk_lib_database::database_metadata::mk_lib_database_metadata_game_system::mk_lib_database_metadata_game_system_count(
-           &state.sqlx_pool_ro,
-            String::new(),
+            &state.sqlx_pool_ro,
+            starts_with.clone().unwrap_or_default(),
         )
         .await
         .unwrap();
@@ -66,7 +94,7 @@ pub async fn user_metadata_game_system(
             total_pages,
             page,
             "/user/metadata/game_system".to_string(),
-            None,
+            starts_with.as_deref(),
             pagination_count,
         )
         .await
@@ -74,7 +102,7 @@ pub async fn user_metadata_game_system(
         let game_system_list =
         mk_lib_database::database_metadata::mk_lib_database_metadata_game_system::mk_lib_database_metadata_game_system_read(
             &state.sqlx_pool_ro,
-            String::new(),
+            starts_with.clone().unwrap_or_default(),
             db_offset,
             pagination_count,
         )
@@ -91,6 +119,12 @@ pub async fn user_metadata_game_system(
             pagination_bar: &pagination_html,
             page: &page_usize,
             page_title: Some("MediaKraken Metadata Game Systems".to_string()),
+            current: starts_with,
+            genre_filter: None,
+            genre_filter_query: None,
+            primary_language_filter: None,
+            status_filter: None,
+            base_path: "/user/metadata/game_system".to_string(),
         };
         let reply_html = template.render().unwrap();
         (StatusCode::OK, Html(reply_html).into_response())

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_music.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_music.rs
@@ -2,6 +2,7 @@ use crate::AppState;
 use crate::mk_lib_database;
 use crate::user_preferences;
 use askama::Template;
+use axum::extract::Query;
 use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
@@ -14,6 +15,7 @@ use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
+use serde::Deserialize;
 use serde_json::json;
 use sqlx::postgres::PgPool;
 
@@ -31,6 +33,30 @@ struct TemplateMetaMusicContext<'a> {
     pagination_bar: &'a String,
     page: &'a usize,
     page_title: Option<String>,
+    pub current: Option<String>,
+    pub genre_filter: Option<String>,
+    pub genre_filter_query: Option<String>,
+    pub primary_language_filter: Option<String>,
+    pub status_filter: Option<String>,
+    pub base_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FilterQuery {
+    pub starts_with: Option<String>,
+}
+
+fn normalize_starts_with(raw: Option<&str>) -> Option<String> {
+    let value = raw.map(str::trim).filter(|value| !value.is_empty())?;
+    let first_char = value.chars().next()?;
+
+    if first_char == '#' {
+        return Some("#".to_string());
+    }
+    if first_char.is_ascii_alphanumeric() {
+        return Some(first_char.to_ascii_uppercase().to_string());
+    }
+    Some("#".to_string())
 }
 
 pub async fn user_metadata_music(
@@ -38,7 +64,9 @@ pub async fn user_metadata_music(
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
     Path(page): Path<i64>,
+    Query(params): Query<FilterQuery>,
 ) -> impl IntoResponse {
+    let starts_with = normalize_starts_with(params.starts_with.as_deref());
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
         [Method::GET],
@@ -60,7 +88,7 @@ pub async fn user_metadata_music(
         let total_pages: i64 =
         mk_lib_database::database_metadata::mk_lib_database_metadata_music_brainz::mk_lib_database_metadata_music_album_count(
            &state.sqlx_pool_ro,
-            String::new(),
+            starts_with.clone().unwrap_or_default(),
         )
         .await
         .unwrap();
@@ -68,7 +96,7 @@ pub async fn user_metadata_music(
             total_pages,
             page,
             "/user/metadata/music".to_string(),
-            None,
+            starts_with.as_deref(),
             pagination_count,
         )
         .await
@@ -76,7 +104,7 @@ pub async fn user_metadata_music(
         let music_list =
         mk_lib_database::database_metadata::mk_lib_database_metadata_music_brainz::mk_lib_database_metadata_music_album_read(
            &state.sqlx_pool_ro,
-            String::new(),
+            starts_with.clone().unwrap_or_default(),
             db_offset,
             pagination_count,
         )
@@ -93,6 +121,12 @@ pub async fn user_metadata_music(
             pagination_bar: &pagination_html,
             page: &page_usize,
             page_title: Some("MediaKraken Metadata Music".to_string()),
+            current: starts_with,
+            genre_filter: None,
+            genre_filter_query: None,
+            primary_language_filter: None,
+            status_filter: None,
+            base_path: "/user/metadata/music".to_string(),
         };
         let reply_html = template.render().unwrap();
         (StatusCode::OK, Html(reply_html).into_response())

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_music_video.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_music_video.rs
@@ -2,6 +2,7 @@ use crate::AppState;
 use crate::mk_lib_database;
 use crate::user_preferences;
 use askama::Template;
+use axum::extract::Query;
 use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
@@ -14,6 +15,7 @@ use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
+use serde::Deserialize;
 use serde_json::json;
 use sqlx::postgres::PgPool;
 
@@ -29,7 +31,31 @@ struct TemplateMetaMusicVideoContext<'a> {
     template_data_exists: &'a bool,
     pagination_bar: &'a String,
     page: &'a usize,
-        page_title: Option<String>,
+    page_title: Option<String>,
+    pub current: Option<String>,
+    pub genre_filter: Option<String>,
+    pub genre_filter_query: Option<String>,
+    pub primary_language_filter: Option<String>,
+    pub status_filter: Option<String>,
+    pub base_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FilterQuery {
+    pub starts_with: Option<String>,
+}
+
+fn normalize_starts_with(raw: Option<&str>) -> Option<String> {
+    let value = raw.map(str::trim).filter(|value| !value.is_empty())?;
+    let first_char = value.chars().next()?;
+
+    if first_char == '#' {
+        return Some("#".to_string());
+    }
+    if first_char.is_ascii_alphanumeric() {
+        return Some(first_char.to_ascii_uppercase().to_string());
+    }
+    Some("#".to_string())
 }
 
 pub async fn user_metadata_music_video(
@@ -37,7 +63,9 @@ pub async fn user_metadata_music_video(
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
     Path(page): Path<i64>,
+    Query(params): Query<FilterQuery>,
 ) -> impl IntoResponse {
+    let starts_with = normalize_starts_with(params.starts_with.as_deref());
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
         [Method::GET],
@@ -59,7 +87,7 @@ pub async fn user_metadata_music_video(
         let total_pages: i64 =
         mk_lib_database::database_metadata::mk_lib_database_metadata_music_video::mk_lib_database_metadata_music_video_count(
            &state.sqlx_pool_ro,
-            String::new(),
+            starts_with.clone().unwrap_or_default(),
             0,
         )
         .await
@@ -68,7 +96,7 @@ pub async fn user_metadata_music_video(
             total_pages,
             page,
             "/user/metadata/music_video".to_string(),
-            None,
+            starts_with.as_deref(),
             pagination_count,
         )
         .await
@@ -76,7 +104,7 @@ pub async fn user_metadata_music_video(
         let music_video_list =
         mk_lib_database::database_metadata::mk_lib_database_metadata_music_video::mk_lib_database_metadata_music_video_read(
            &state.sqlx_pool_ro,
-            String::new(),
+            starts_with.clone().unwrap_or_default(),
             db_offset,
             pagination_count,
         )
@@ -93,6 +121,12 @@ pub async fn user_metadata_music_video(
             pagination_bar: &pagination_html,
             page: &page_usize,
             page_title: Some("MediaKraken Metadata Music Videos".to_string()),
+            current: starts_with,
+            genre_filter: None,
+            genre_filter_query: None,
+            primary_language_filter: None,
+            status_filter: None,
+            base_path: "/user/metadata/music_video".to_string(),
         };
         let reply_html = template.render().unwrap();
         (StatusCode::OK, Html(reply_html).into_response())

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_person.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_person.rs
@@ -2,7 +2,7 @@ use crate::AppState;
 use crate::user_preferences;
 use askama::Template;
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
 };
@@ -34,6 +34,30 @@ struct TemplateMetaPersonContext<'a> {
     pagination_bar: &'a String,
     page: &'a usize,
     page_title: Option<String>,
+    pub current: Option<String>,
+    pub genre_filter: Option<String>,
+    pub genre_filter_query: Option<String>,
+    pub primary_language_filter: Option<String>,
+    pub status_filter: Option<String>,
+    pub base_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FilterQuery {
+    pub starts_with: Option<String>,
+}
+
+fn normalize_starts_with(raw: Option<&str>) -> Option<String> {
+    let value = raw.map(str::trim).filter(|value| !value.is_empty())?;
+    let first_char = value.chars().next()?;
+
+    if first_char == '#' {
+        return Some("#".to_string());
+    }
+    if first_char.is_ascii_alphanumeric() {
+        return Some(first_char.to_ascii_uppercase().to_string());
+    }
+    Some("#".to_string())
 }
 
 pub async fn user_metadata_person(
@@ -41,7 +65,9 @@ pub async fn user_metadata_person(
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
     Path(page): Path<i64>,
+    Query(params): Query<FilterQuery>,
 ) -> impl IntoResponse {
+    let starts_with = normalize_starts_with(params.starts_with.as_deref());
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
         [Method::GET],
@@ -62,7 +88,7 @@ pub async fn user_metadata_person(
         let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages: i64 = mk_lib_database::database_metadata::mk_lib_database_metadata_person::mk_lib_database_metadata_person_count(
             &state.sqlx_pool_ro,
-            String::new(),
+            starts_with.clone().unwrap_or_default(),
         )
         .await
         .unwrap();
@@ -70,24 +96,27 @@ pub async fn user_metadata_person(
             total_pages,
             page,
             "/user/metadata/person".to_string(),
-            None,
+            starts_with.as_deref(),
             pagination_count,
         )
         .await
         .unwrap();
-        let person_list: Vec<TemplateMetaPersonList> = sqlx::query_as(
-            r#"select mm_metadata_person_guid,
-            mm_metadata_person_name,
-            COALESCE(mm_metadata_person_image, '') as mm_metadata_person_image
-            from mm_metadata_person
-            order by LOWER(mm_metadata_person_name)
-            offset $1 limit $2"#,
-        )
-        .bind(db_offset)
-        .bind(30_i64)
-        .fetch_all(&state.sqlx_pool_ro)
-        .await
-        .unwrap();
+        let person_list: Vec<TemplateMetaPersonList> =
+            mk_lib_database::database_metadata::mk_lib_database_metadata_person::mk_lib_database_metadata_person_read(
+                &state.sqlx_pool_ro,
+                starts_with.clone().unwrap_or_default(),
+                db_offset,
+                pagination_count,
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|row| TemplateMetaPersonList {
+                mm_metadata_person_guid: row.mm_metadata_person_guid,
+                mm_metadata_person_name: row.mm_metadata_person_name,
+                mm_metadata_person_image: row.mm_metadata_person_image,
+            })
+            .collect();
         let template_data_exists = !person_list.is_empty();
         let page_usize = page as usize;
         let template = TemplateMetaPersonContext {
@@ -96,6 +125,12 @@ pub async fn user_metadata_person(
             pagination_bar: &pagination_html,
             page: &page_usize,
             page_title: Some("MediaKraken Metadata Persons".to_string()),
+            current: starts_with,
+            genre_filter: None,
+            genre_filter_query: None,
+            primary_language_filter: None,
+            status_filter: None,
+            base_path: "/user/metadata/person".to_string(),
         };
         let reply_html = template.render().unwrap();
         (StatusCode::OK, Html(reply_html).into_response())

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_sports.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_sports.rs
@@ -3,13 +3,14 @@ use crate::mk_lib_database;
 use crate::user_preferences;
 use askama::Template;
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::{Method, StatusCode},
     response::{Html, IntoResponse},
 };
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
+use serde::Deserialize;
 use serde_json::json;
 use sqlx::postgres::PgPool;
 
@@ -31,6 +32,30 @@ struct TemplateMetaSportsContext<'a> {
     pagination_bar: &'a String,
     page: &'a usize,
     page_title: Option<String>,
+    pub current: Option<String>,
+    pub genre_filter: Option<String>,
+    pub genre_filter_query: Option<String>,
+    pub primary_language_filter: Option<String>,
+    pub status_filter: Option<String>,
+    pub base_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FilterQuery {
+    pub starts_with: Option<String>,
+}
+
+fn normalize_starts_with(raw: Option<&str>) -> Option<String> {
+    let value = raw.map(str::trim).filter(|value| !value.is_empty())?;
+    let first_char = value.chars().next()?;
+
+    if first_char == '#' {
+        return Some("#".to_string());
+    }
+    if first_char.is_ascii_alphanumeric() {
+        return Some(first_char.to_ascii_uppercase().to_string());
+    }
+    Some("#".to_string())
 }
 
 pub async fn user_metadata_sports(
@@ -38,7 +63,9 @@ pub async fn user_metadata_sports(
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
     Path(page): Path<i64>,
+    Query(params): Query<FilterQuery>,
 ) -> impl IntoResponse {
+    let starts_with = normalize_starts_with(params.starts_with.as_deref());
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
         [Method::GET],
@@ -59,7 +86,7 @@ pub async fn user_metadata_sports(
         let db_offset: i64 = (page * pagination_count) - pagination_count;
         let total_pages = match mk_lib_database::database_metadata::mk_lib_database_metadata_sports::mk_lib_database_metadata_sports_count(
             &state.sqlx_pool_ro,
-            String::new(),
+            starts_with.clone().unwrap_or_default(),
         )
         .await
         {
@@ -75,7 +102,7 @@ pub async fn user_metadata_sports(
             total_pages,
             page,
             "/user/metadata/sports".to_string(),
-            None,
+            starts_with.as_deref(),
             pagination_count,
         )
         .await
@@ -93,7 +120,7 @@ pub async fn user_metadata_sports(
         };
         let sports_list = match mk_lib_database::database_metadata::mk_lib_database_metadata_sports::mk_lib_database_metadata_sports_read(
             &state.sqlx_pool_ro,
-            String::new(),
+            starts_with.clone().unwrap_or_default(),
             db_offset,
             pagination_count,
         )
@@ -115,6 +142,12 @@ pub async fn user_metadata_sports(
             pagination_bar: &pagination_html,
             page: &page_usize,
             page_title: Some("MediaKraken Metadata Sports".to_string()),
+            current: starts_with,
+            genre_filter: None,
+            genre_filter_query: None,
+            primary_language_filter: None,
+            status_filter: None,
+            base_path: "/user/metadata/sports".to_string(),
         };
         match template.render() {
             Ok(reply_html) => (StatusCode::OK, Html(reply_html).into_response()),

--- a/docker/core/mkwebaxum/src/user/metadata/bp_meta_tv.rs
+++ b/docker/core/mkwebaxum/src/user/metadata/bp_meta_tv.rs
@@ -3,6 +3,7 @@ use crate::axum_custom_filters::filters;
 use crate::mk_lib_database;
 use crate::user_preferences;
 use askama::Template;
+use axum::extract::Query;
 use axum::extract::State;
 use axum::response::Redirect;
 use axum::{
@@ -15,6 +16,7 @@ use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_common::mk_lib_common_pagination;
+use serde::Deserialize;
 use serde_json::json;
 use sqlx::postgres::PgPool;
 
@@ -31,6 +33,30 @@ struct TemplateMetaTVContext<'a> {
     pagination_bar: &'a String,
     page: &'a usize,
     page_title: Option<String>,
+    pub current: Option<String>,
+    pub genre_filter: Option<String>,
+    pub genre_filter_query: Option<String>,
+    pub primary_language_filter: Option<String>,
+    pub status_filter: Option<String>,
+    pub base_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FilterQuery {
+    pub starts_with: Option<String>,
+}
+
+fn normalize_starts_with(raw: Option<&str>) -> Option<String> {
+    let value = raw.map(str::trim).filter(|value| !value.is_empty())?;
+    let first_char = value.chars().next()?;
+
+    if first_char == '#' {
+        return Some("#".to_string());
+    }
+    if first_char.is_ascii_alphanumeric() {
+        return Some(first_char.to_ascii_uppercase().to_string());
+    }
+    Some("#".to_string())
 }
 
 pub async fn user_metadata_tv(
@@ -38,7 +64,9 @@ pub async fn user_metadata_tv(
     method: Method,
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
     Path(page): Path<i64>,
+    Query(params): Query<FilterQuery>,
 ) -> impl IntoResponse {
+    let starts_with = normalize_starts_with(params.starts_with.as_deref());
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
         [Method::GET],
@@ -60,7 +88,7 @@ pub async fn user_metadata_tv(
         let total_pages: i64 =
         mk_lib_database::database_metadata::mk_lib_database_metadata_tv::mk_lib_database_metadata_tv_count(
            &state.sqlx_pool_ro,
-            String::new(),
+            starts_with.clone().unwrap_or_default(),
         )
         .await
         .unwrap();
@@ -68,14 +96,14 @@ pub async fn user_metadata_tv(
             total_pages,
             page,
             "/user/metadata/tv".to_string(),
-            None,
+            starts_with.as_deref(),
             pagination_count,
         )
         .await
         .unwrap();
         let tv_list = mk_lib_database::database_metadata::mk_lib_database_metadata_tv::mk_lib_database_metadata_tv_read(
            &state.sqlx_pool_ro,
-            String::new(),
+            starts_with.clone().unwrap_or_default(),
             db_offset,
             pagination_count,
         )
@@ -92,6 +120,12 @@ pub async fn user_metadata_tv(
             pagination_bar: &pagination_html,
             page: &page_usize,
             page_title: Some("MediaKraken Metadata TV Shows".to_string()),
+            current: starts_with,
+            genre_filter: None,
+            genre_filter_query: None,
+            primary_language_filter: None,
+            status_filter: None,
+            base_path: "/user/metadata/tv".to_string(),
         };
         let reply_html = template.render().unwrap();
         (StatusCode::OK, Html(reply_html).into_response())

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_book.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_book.html
@@ -2,6 +2,7 @@
 
 {% block content %}
 <div>
+                {% include "filters/pagination_letters.html" %}
                 {% if template_data_exists %}
                 {% if pagination_bar != "" %}
                 {{ pagination_bar|safe }}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_game_system.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_game_system.html
@@ -2,6 +2,7 @@
 
 {% block content %}
 <div>
+                {% include "filters/pagination_letters.html" %}
                 {% if template_data_exists %}
                 {% if pagination_bar != "" %}
                 {{ pagination_bar|safe }}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_music_album.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_music_album.html
@@ -3,6 +3,7 @@
 {% block content %}
 <section class="w-full px-0 py-4 text-zinc-900 dark:text-zinc-100">
   <h1 id="music-grid-heading" class="sr-only">Music album list</h1>
+  {% include "filters/pagination_letters.html" %}
 
   {% if template_data_exists %}
   {% if pagination_bar != "" %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_music_video.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_music_video.html
@@ -2,6 +2,7 @@
 
 {% block content %}
 <div>
+            {% include "filters/pagination_letters.html" %}
             {% if template_data_exists %}
             {% if pagination_bar != "" %}
             {{ pagination_bar|safe }}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_person.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_person.html
@@ -3,6 +3,7 @@
 {% block content %}
 <section class="w-full px-0 py-4 text-zinc-900 dark:text-zinc-100">
   <h1 id="person-grid-heading" class="sr-only">Person list</h1>
+  {% include "filters/pagination_letters.html" %}
 
   {% if template_data_exists %}
   {% if pagination_bar != "" %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_sports.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_sports.html
@@ -3,6 +3,7 @@
 {% block content %}
 <section class="w-full px-0 py-4 text-zinc-900 dark:text-zinc-100">
   <h1 id="sports-grid-heading" class="sr-only">Sports metadata list</h1>
+  {% include "filters/pagination_letters.html" %}
 
   {% if template_data_exists %}
   {% if pagination_bar != "" %}

--- a/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_tv.html
+++ b/docker/core/mkwebaxum/templates/bss_user/metadata/bss_user_metadata_tv.html
@@ -3,6 +3,7 @@
 {% block content %}
 <section class="w-full px-0 py-4 text-zinc-900 dark:text-zinc-100">
   <h1 id="tv-grid-heading" class="sr-only">TV show list</h1>
+  {% include "filters/pagination_letters.html" %}
 
   {% if template_data_exists %}
   {% if pagination_bar != "" %}


### PR DESCRIPTION
### Motivation
- Bring alphabetical "starts with" filtering to all metadata list pages so they behave like the existing movie metadata page and allow users to quickly jump to items by first character.

### Description
- Added a `FilterQuery` (`starts_with`) extractor and `normalize_starts_with` helper to each metadata list handler (books, game systems, music albums, music videos, people, sports, TV) and wired `Query(params)` into the handlers.
- Forwarded the normalized `starts_with` value into the DB count/read calls and into the pagination builder so pagination links preserve the filter.
- Extended Askama template context structs with `current`, filter fields, and `base_path` to match movie/game pages and included the shared `filters/pagination_letters.html` partial in the metadata list templates.
- Reworked the person list to use the DB read helper with pagination and `starts_with` filtering instead of the inline SQL query.

### Testing
- Ran `cargo fmt` in `docker/core/mkwebaxum` which completed successfully.
- Ran `cargo check` and `cargo clippy -- -D warnings` in `docker/core/mkwebaxum` which failed to complete due to private registry access errors (HTTP 403) when resolving workspace dependencies, so full compilation/lint verification could not be completed in this environment.
- Verified templates were updated and formatted, and local code modifications were staged for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1442bceb88321b60d9cbd42f6e33b)