### PR TITLE
Fix locale fallback closure type mismatch

### DIFF
--- a/src/mk_lib_common/src/mk_lib_common_internationalization.rs
+++ b/src/mk_lib_common/src/mk_lib_common_internationalization.rs
@@ -18,7 +18,8 @@ fn locale_from_name(locale_name: &str) -> Option<&'static Locale> {
     }
 
     Locale::from_name(trimmed)
-        .or_else(|| Locale::from_name(&trimmed.replace('-', "_")))
+        .ok()
+        .or_else(|| Locale::from_name(&trimmed.replace('-', "_")).ok())
         .or_else(|| {
             let mut parts = trimmed.split(['-', '_']);
             let language = parts.next()?;
@@ -28,7 +29,7 @@ fn locale_from_name(locale_name: &str) -> Option<&'static Locale> {
                 language.to_ascii_lowercase(),
                 region.to_ascii_uppercase()
             );
-            Locale::from_name(&normalized)
+            Locale::from_name(&normalized).ok()
         })
 }
 


### PR DESCRIPTION
### Motivation
- Fix a type/closure mismatch that caused `E0593` by ensuring the locale fallback chain yields `Option<&'static Locale>` so `.or_else(...)` closures have the expected zero-argument signature.

### Description
- Convert `Locale::from_name(...)` results to `Option` with `.ok()` and update the fallback chain in `src/mk_lib_common/src/mk_lib_common_internationalization.rs`, preserving the `-`→`_` and language/region normalization behavior.

### Testing
- Ran `rustfmt src/mk_lib_common/src/mk_lib_common_internationalization.rs` which succeeded; attempts to run `cargo check --manifest-path src/mk_lib_common/Cargo.toml` and `cargo clippy --manifest-path src/mk_lib_common/Cargo.toml -- -D warnings` were performed but failed in this environment due to a missing private registry configuration (`kellnr`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d168fe882c832182752b906b307744)