### PR TITLE
Fix locale parsing helper to return owned Locale

### DIFF
--- a/src/mk_lib_common/src/mk_lib_common_internationalization.rs
+++ b/src/mk_lib_common/src/mk_lib_common_internationalization.rs
@@ -11,7 +11,7 @@ fn prefers_fallback_locale() -> bool {
         .any(|value| value == "C" || value.starts_with("C.") || value == "POSIX")
 }
 
-fn locale_from_name(locale_name: &str) -> Option<&'static Locale> {
+fn locale_from_name(locale_name: &str) -> Option<Locale> {
     let trimmed = locale_name.trim();
     if trimmed.is_empty() {
         return None;
@@ -49,7 +49,7 @@ pub fn mk_lib_common_internationalization_number_format_locale(
     locale_name: Option<&str>,
 ) -> String {
     if let Some(locale) = locale_name.and_then(locale_from_name) {
-        return number_for_format.to_formatted_string(locale);
+        return number_for_format.to_formatted_string(&locale);
     }
 
     mk_lib_common_internationalization_number_format(number_for_format)


### PR DESCRIPTION
### Motivation
- Fix a type mismatch where `locale_from_name` returned `Option<&'static Locale>` but `Locale::from_name(...).ok()` yields `Option<Locale>`, which caused a compilation error.

### Description
- Change `locale_from_name` to `fn locale_from_name(locale_name: &str) -> Option<Locale>` and update the call site in `mk_lib_common_internationalization_number_format_locale` to pass a reference (`&locale`) to `to_formatted_string`.

### Testing
- Ran `cargo fmt` in `src/mk_lib_common` (passed); attempted `cargo check` and `cargo clippy -- -D warnings` in `src/mk_lib_common` but both failed due to a private registry HTTP 403 error when fetching dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d16aa71a008321986f28b7bfbc1088)