### PR TITLE
Fix moved bucket capture in mkopenlibrarynetfetchbulk upload task

### DIFF
--- a/docker/core/mkopenlibrarynetfetchbulk/src/main.rs
+++ b/docker/core/mkopenlibrarynetfetchbulk/src/main.rs
@@ -139,6 +139,7 @@ async fn run_bulk_cover_archive_upload(options: BulkImageCoverLoadOptions) -> an
     let s3_prefix = options.s3_prefix.trim_matches('/').to_string();
     let add_json = options.add_json;
     let archive_url = options.archive_url.clone();
+    let upload_bucket = bucket.clone();
 
     let uploaded = tokio::task::spawn_blocking(move || -> anyhow::Result<usize> {
         let mut uploaded_count: usize = 0;
@@ -174,7 +175,7 @@ async fn run_bulk_cover_archive_upload(options: BulkImageCoverLoadOptions) -> an
 
             rt.block_on(upload_s3_object(
                 s3_client.clone(),
-                &bucket,
+                &upload_bucket,
                 &object_key,
                 payload,
                 content_type,
@@ -192,7 +193,7 @@ async fn run_bulk_cover_archive_upload(options: BulkImageCoverLoadOptions) -> an
                 });
                 rt.block_on(upload_s3_object(
                     s3_client.clone(),
-                    &bucket,
+                    &upload_bucket,
                     &json_key,
                     serde_json::to_vec(&metadata)?,
                     "application/json",


### PR DESCRIPTION
### Motivation
- Address a Rust `E0382` borrow/move error that occurred when `bucket` was captured into a `spawn_blocking` closure and later needed for post-upload logging in `run_bulk_cover_archive_upload`.

### Description
- Clone `bucket` into a new `upload_bucket` before the `spawn_blocking` call and update S3 upload calls inside the blocking closure to use `upload_bucket` to avoid moving the original `bucket` out of scope in `docker/core/mkopenlibrarynetfetchbulk/src/main.rs`.
- Change is localized to `run_bulk_cover_archive_upload` and the calls to `upload_s3_object`, preserving the original `bucket` for the final log line.

### Testing
- Ran `rustfmt --edition 2024 docker/core/mkopenlibrarynetfetchbulk/src/main.rs`, which completed successfully.
- Attempted `cargo fmt --manifest-path docker/core/Cargo.toml --package mkopenlibrarynetfetchbulk --all`, which was blocked by missing private `kellnr` registry configuration in the environment.
- Attempted `cargo check --manifest-path docker/core/mkopenlibrarynetfetchbulk/Cargo.toml`, which was blocked by the same missing `kellnr` registry and therefore could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d188e9b11883219f2193b64f322382)