### PR TITLE
Fix moved `s3_prefix` borrow in mkopenlibrary bulk uploader

### DIFF
--- a/docker/core/mkopenlibrarynetfetchbulk/src/main.rs
+++ b/docker/core/mkopenlibrarynetfetchbulk/src/main.rs
@@ -137,6 +137,7 @@ async fn run_bulk_cover_archive_upload(options: BulkImageCoverLoadOptions) -> an
     let archive_bytes = response.bytes().await?;
 
     let s3_prefix = options.s3_prefix.trim_matches('/').to_string();
+    let upload_s3_prefix = s3_prefix.clone();
     let add_json = options.add_json;
     let archive_url = options.archive_url.clone();
     let upload_bucket = bucket.clone();
@@ -171,7 +172,7 @@ async fn run_bulk_cover_archive_upload(options: BulkImageCoverLoadOptions) -> an
             let mut payload = Vec::new();
             entry.read_to_end(&mut payload)?;
             let payload_len = payload.len();
-            let object_key = format!("{}/{}", s3_prefix, file_name);
+            let object_key = format!("{}/{}", upload_s3_prefix, file_name);
 
             rt.block_on(upload_s3_object(
                 s3_client.clone(),


### PR DESCRIPTION
### Motivation
- Resolve Rust E0382 borrow-of-moved-value for `s3_prefix` when spawning a blocking closure so the variable remains available after upload for logging.

### Description
- In `docker/core/mkopenlibrarynetfetchbulk/src/main.rs` clone `s3_prefix` into `upload_s3_prefix` before `tokio::task::spawn_blocking` and use `upload_s3_prefix` inside the closure when building object keys, leaving the original `s3_prefix` for post-upload `println!`.

### Testing
- Ran `cargo fmt` in `docker/core/mkopenlibrarynetfetchbulk` which succeeded.
- Attempted `cargo check` and `cargo clippy -- -D warnings` in the package but both were blocked by a private registry HTTP 403 when fetching dependencies.
- Running `cargo fmt --all` at the repository root reported no `Cargo.toml` at the root due to workspace layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d190c12be08321ad505edac144fdf1)