### PR TITLE
Handle null mm_cron_last_run values on admin cron page

### DIFF
--- a/docker/core/mkcron/src/main.rs
+++ b/docker/core/mkcron/src/main.rs
@@ -44,7 +44,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             );
             let date_check: DateTime<Utc> = now - time_delta;
 
-            if row_data.mm_cron_last_run >= date_check {
+            if let Some(last_run) = row_data.mm_cron_last_run
+                && last_run >= date_check
+            {
                 continue;
             }
 

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_cron.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_cron.html
@@ -56,7 +56,12 @@
                 {{ format!("{} {}", row_data.mm_cron_schedule_time, row_data.mm_cron_schedule_type) }}
               </td>
               <td class="px-3 py-2">
-                {{ row_data.mm_cron_last_run }}
+                {% match row_data.mm_cron_last_run %}
+                  {% when Some with (last_run) %}
+                    {{ last_run }}
+                  {% when None %}
+                    Never
+                {% endmatch %}
               </td>
               <td class="px-3 py-2 text-center">
                 <button

--- a/src/mk_lib_database/src/mk_lib_database_cron.rs
+++ b/src/mk_lib_database/src/mk_lib_database_cron.rs
@@ -1,7 +1,7 @@
 use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
-use sqlx::types::Uuid;
 use sqlx::FromRow;
+use sqlx::types::Uuid;
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
 pub struct DBCronList {
@@ -11,7 +11,7 @@ pub struct DBCronList {
     pub mm_cron_enabled: bool,
     pub mm_cron_schedule_type: String,
     pub mm_cron_schedule_time: i16,
-    pub mm_cron_last_run: DateTime<Utc>,
+    pub mm_cron_last_run: Option<DateTime<Utc>>,
     pub mm_cron_json: serde_json::Value,
 }
 


### PR DESCRIPTION
### Motivation
- The admin cron page and the cron scheduler assumed `mm_cron_last_run` is always populated which caused issues when the DB contains `NULL` values, so null-safe handling is required.

### Description
- Made the DB model field `mm_cron_last_run` nullable by changing its type to `Option<DateTime<Utc>>` in `DBCronList` (`src/mk_lib_database/src/mk_lib_database_cron.rs`).
- Updated the cron scheduler loop to only skip a job when `mm_cron_last_run` is `Some` and still within the schedule window (checks `if let Some(last_run) = row_data.mm_cron_last_run && last_run >= date_check`) (`docker/core/mkcron/src/main.rs`).
- Updated the admin template to render `Never` when `mm_cron_last_run` is `None` instead of assuming a timestamp (`docker/core/mkwebaxum/templates/bss_admin/bss_admin_cron.html`).

### Testing
- Ran `rustfmt --edition 2024` on the modified Rust files and it completed successfully for the changed files.
- Attempted `cargo fmt`, `cargo check`, and `cargo clippy` for the workspace crates but these failed in this environment due to a missing private registry (`kellnr`) configuration and thus could not be completed here.
- Verified template rendering logic and scheduler condition locally by inspecting the updated code paths for correct null handling (static review).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1dbf19a448321aef5e612b52fe1a4)