### PR TITLE
mkcron: only dispatch enabled cron jobs

### DIFF
--- a/docker/core/mkcron/src/main.rs
+++ b/docker/core/mkcron/src/main.rs
@@ -38,6 +38,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let now = Utc::now();
 
         for row_data in cron_rows {
+            if !row_data.mm_cron_enabled {
+                continue;
+            }
+
             let time_delta = cron_schedule_to_duration(
                 row_data.mm_cron_schedule_type.as_str(),
                 row_data.mm_cron_schedule_time,


### PR DESCRIPTION
### Motivation
- Prevent disabled cron entries from being evaluated or published by `mkcron` so only entries with `mm_cron_enabled == true` are dispatched.

### Description
- Add an explicit guard `if !row_data.mm_cron_enabled { continue; }` in the scheduling loop in `docker/core/mkcron/src/main.rs`, skipping disabled rows before schedule and `route_key` checks.

### Testing
- Ran `cargo fmt` (completed with a workspace config warning), `cargo check -p mkcron` (failed in this environment due to the private registry returning HTTP 403), `cargo clippy -p mkcron -- -D warnings` (failed due to the same registry 403), and `cargo fmt --check` (reported pre-existing formatting diffs in unrelated workspace files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1e6d2250083219a61a463654abd56)