### PR TITLE
Wire theater_controller_pi to control theater_thin via HTTP API

### DIFF
--- a/src_app/theater_controller_pi/src/main.rs
+++ b/src_app/theater_controller_pi/src/main.rs
@@ -1,12 +1,29 @@
 use crossbeam_channel::unbounded;
-use fltk::{app, button::Button, prelude::*, window::Window};
+use fltk::{
+    app,
+    button::Button,
+    dialog::{FileDialogType, NativeFileChooser, alert_default, message_default},
+    prelude::*,
+    window::Window,
+};
 use fltk_theme::{SchemeType, WidgetScheme};
-use std::error::Error;
+use std::{
+    error::Error,
+    io::{Read, Write},
+    net::TcpStream,
+    path::Path,
+};
+
+const THEATER_THIN_API_ADDR: &str = "127.0.0.1:7878";
 
 #[derive(Debug, Clone, Copy)]
 enum UiMsg {
     ShowSettings,
     ShowMenu,
+    PlaySelected,
+    Pause,
+    Resume,
+    Stop,
 }
 
 fn make_image_button(
@@ -27,8 +44,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Load images
     let bytes_image_rectangle =
         include_bytes!("../../../docker/core/mkwebaxum/static/image/rectangles_black.png");
-    let bytes_image_new =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/new.png");
+    let bytes_image_new = include_bytes!("../../../docker/core/mkwebaxum/static/image/new.png");
     let bytes_image_movie_ticket =
         include_bytes!("../../../docker/core/mkwebaxum/static/image/movie_ticket.png");
     let bytes_image_television =
@@ -43,17 +59,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         include_bytes!("../../../docker/core/mkwebaxum/static/image/television_live.png");
     let bytes_image_vid_camera =
         include_bytes!("../../../docker/core/mkwebaxum/static/image/vid_camera.png");
-    let bytes_image_earth =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/earth.png");
+    let bytes_image_earth = include_bytes!("../../../docker/core/mkwebaxum/static/image/earth.png");
     let bytes_image_music_video = include_bytes!(
         "../../../docker/core/mkwebaxum/static/image/listening-music-video-clip-with-auricular.png"
     );
-    let bytes_image_photo =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/photo.png");
-    let bytes_image_radio =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/radio.png");
-    let bytes_image_books =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/books.png");
+    let bytes_image_photo = include_bytes!("../../../docker/core/mkwebaxum/static/image/photo.png");
+    let bytes_image_radio = include_bytes!("../../../docker/core/mkwebaxum/static/image/radio.png");
+    let bytes_image_books = include_bytes!("../../../docker/core/mkwebaxum/static/image/books.png");
     let bytes_image_settings =
         include_bytes!("../../../docker/core/mkwebaxum/static/image/settings.png");
     let bytes_image_return =
@@ -72,39 +84,24 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Menu window
     let mut window_menu = Window::default().with_size(800, 480);
 
-    let _button_in_progress =
-        make_image_button(0, 0, 133, 96, bytes_image_rectangle)?;
-    let _button_new =
-        make_image_button(0, 96, 133, 96, bytes_image_new)?;
-    let _button_movie =
-        make_image_button(0, 192, 133, 96, bytes_image_movie_ticket)?;
-    let _button_tv =
-        make_image_button(0, 288, 133, 96, bytes_image_television)?;
-    let _button_game =
-        make_image_button(0, 384, 133, 96, bytes_image_vid_game)?;
+    let _button_in_progress = make_image_button(0, 0, 133, 96, bytes_image_rectangle)?;
+    let _button_new = make_image_button(0, 96, 133, 96, bytes_image_new)?;
+    let _button_movie = make_image_button(0, 192, 133, 96, bytes_image_movie_ticket)?;
+    let _button_tv = make_image_button(0, 288, 133, 96, bytes_image_television)?;
+    let _button_game = make_image_button(0, 384, 133, 96, bytes_image_vid_game)?;
 
-    let _button_demo =
-        make_image_button(133, 0, 532, 384, bytes_image_theater)?;
+    let mut button_demo = make_image_button(133, 0, 532, 384, bytes_image_theater)?;
 
-    let _button_music =
-        make_image_button(133, 384, 133, 96, bytes_image_headphone)?;
-    let _button_live_tv =
-        make_image_button(266, 384, 133, 96, bytes_image_television_live)?;
-    let _button_home_video =
-        make_image_button(399, 384, 133, 96, bytes_image_vid_camera)?;
-    let _button_internet =
-        make_image_button(532, 384, 133, 96, bytes_image_earth)?;
+    let _button_music = make_image_button(133, 384, 133, 96, bytes_image_headphone)?;
+    let _button_live_tv = make_image_button(266, 384, 133, 96, bytes_image_television_live)?;
+    let _button_home_video = make_image_button(399, 384, 133, 96, bytes_image_vid_camera)?;
+    let _button_internet = make_image_button(532, 384, 133, 96, bytes_image_earth)?;
 
-    let _button_music_video =
-        make_image_button(666, 0, 133, 96, bytes_image_music_video)?;
-    let _button_pictures =
-        make_image_button(666, 96, 133, 96, bytes_image_photo)?;
-    let _button_radio =
-        make_image_button(666, 192, 133, 96, bytes_image_radio)?;
-    let _button_books =
-        make_image_button(666, 288, 133, 96, bytes_image_books)?;
-    let mut button_settings =
-        make_image_button(666, 384, 133, 96, bytes_image_settings)?;
+    let _button_music_video = make_image_button(666, 0, 133, 96, bytes_image_music_video)?;
+    let _button_pictures = make_image_button(666, 96, 133, 96, bytes_image_photo)?;
+    let _button_radio = make_image_button(666, 192, 133, 96, bytes_image_radio)?;
+    let _button_books = make_image_button(666, 288, 133, 96, bytes_image_books)?;
+    let mut button_settings = make_image_button(666, 384, 133, 96, bytes_image_settings)?;
 
     window_menu.end();
     window_menu.make_resizable(true);
@@ -113,8 +110,14 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Settings window
     let mut window_settings = Window::default().with_size(800, 480);
-    let mut button_settings_back =
-        make_image_button(666, 384, 133, 96, bytes_image_return)?;
+    let mut button_pause = Button::new(133, 96, 532, 64, "Pause");
+    let mut button_resume = Button::new(133, 192, 532, 64, "Resume");
+    let mut button_stop = Button::new(133, 288, 532, 64, "Stop");
+    let mut button_settings_back = make_image_button(666, 384, 133, 96, bytes_image_return)?;
+
+    button_pause.set_tooltip("Pause playback on theater_thin");
+    button_resume.set_tooltip("Resume playback on theater_thin");
+    button_stop.set_tooltip("Stop playback on theater_thin");
 
     window_settings.end();
     window_settings.make_resizable(true);
@@ -125,6 +128,34 @@ fn main() -> Result<(), Box<dyn Error>> {
         let sender = sender.clone();
         button_settings.set_callback(move |_| {
             let _ = sender.send(UiMsg::ShowSettings);
+        });
+    }
+
+    {
+        let sender = sender.clone();
+        button_demo.set_callback(move |_| {
+            let _ = sender.send(UiMsg::PlaySelected);
+        });
+    }
+
+    {
+        let sender = sender.clone();
+        button_pause.set_callback(move |_| {
+            let _ = sender.send(UiMsg::Pause);
+        });
+    }
+
+    {
+        let sender = sender.clone();
+        button_resume.set_callback(move |_| {
+            let _ = sender.send(UiMsg::Resume);
+        });
+    }
+
+    {
+        let sender = sender.clone();
+        button_stop.set_callback(move |_| {
+            let _ = sender.send(UiMsg::Stop);
         });
     }
 
@@ -146,9 +177,112 @@ fn main() -> Result<(), Box<dyn Error>> {
                     window_settings.hide();
                     window_menu.show();
                 }
+                UiMsg::PlaySelected => {
+                    if let Some(path) = pick_media_file() {
+                        if Path::new(&path).exists() {
+                            let encoded_path = url_encode(&path);
+                            let endpoint = format!("/api/play?path={encoded_path}");
+                            match send_theater_thin_post(&endpoint) {
+                                Ok((status, body)) if status.starts_with("HTTP/1.1 200") => {
+                                    message_default(&format!("theater_thin playing:\n{path}"));
+                                }
+                                Ok((status, body)) => {
+                                    alert_default(&format!(
+                                        "theater_thin play failed:\n{status}\n{body}"
+                                    ));
+                                }
+                                Err(error) => {
+                                    alert_default(&format!(
+                                        "Unable to reach theater_thin API:\n{error}"
+                                    ));
+                                }
+                            }
+                        } else {
+                            alert_default("Selected file does not exist.");
+                        }
+                    }
+                }
+                UiMsg::Pause => handle_simple_api("/api/pause", "Paused", "pause"),
+                UiMsg::Resume => handle_simple_api("/api/resume", "Resumed", "resume"),
+                UiMsg::Stop => handle_simple_api("/api/stop", "Stopped", "stop"),
             }
         }
     }
 
     Ok(())
+}
+
+fn pick_media_file() -> Option<String> {
+    let mut chooser = NativeFileChooser::new(FileDialogType::BrowseFile);
+    chooser.set_title("Select media file to play in theater_thin");
+    chooser.set_filter("*.*");
+    chooser.show();
+
+    let selected = chooser.filename();
+    if selected.as_os_str().is_empty() {
+        None
+    } else {
+        Some(selected.to_string_lossy().into_owned())
+    }
+}
+
+fn handle_simple_api(endpoint: &str, success_title: &str, action_name: &str) {
+    match send_theater_thin_post(endpoint) {
+        Ok((status, body)) if status.starts_with("HTTP/1.1 200") => {
+            message_default(&format!("{success_title} theater_thin playback."));
+        }
+        Ok((status, body)) => {
+            alert_default(&format!(
+                "Failed to {action_name} on theater_thin:\n{status}\n{body}"
+            ));
+        }
+        Err(error) => {
+            alert_default(&format!("Unable to reach theater_thin API:\n{error}"));
+        }
+    }
+}
+
+fn send_theater_thin_post(endpoint: &str) -> Result<(String, String), String> {
+    let mut stream = TcpStream::connect(THEATER_THIN_API_ADDR)
+        .map_err(|error| format!("connect {THEATER_THIN_API_ADDR} failed: {error}"))?;
+
+    let request = format!(
+        "POST {endpoint} HTTP/1.1\r\nHost: {THEATER_THIN_API_ADDR}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
+    );
+
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|error| format!("write request failed: {error}"))?;
+
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .map_err(|error| format!("read response failed: {error}"))?;
+
+    let mut sections = response.splitn(2, "\r\n\r\n");
+    let header = sections.next().unwrap_or_default();
+    let body = sections.next().unwrap_or_default().to_string();
+    let status_line = header
+        .lines()
+        .next()
+        .unwrap_or("HTTP/1.1 500 Invalid response");
+
+    Ok((status_line.to_string(), body))
+}
+
+fn url_encode(input: &str) -> String {
+    let mut encoded = String::new();
+    for byte in input.bytes() {
+        let is_unreserved = matches!(
+            byte,
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~'
+        );
+
+        if is_unreserved {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
 }


### PR DESCRIPTION
### Motivation
- Connect the existing `theater_controller_pi` UI to the `theater_thin` service using the freshly-added HTTP API so the controller can start/pause/resume/stop playback remotely.

### Description
- Added new UI message variants (`PlaySelected`, `Pause`, `Resume`, `Stop`) and wired the main theater tile to open a native file picker and trigger `POST /api/play?path=...` on `theater_thin`.
- Added playback control buttons (`Pause`, `Resume`, `Stop`) in the settings window and wired them to `POST /api/pause`, `POST /api/resume`, and `POST /api/stop` respectively.
- Implemented a minimal HTTP client over `TcpStream`, a `url_encode` helper, and result handling that shows user dialogs using FLTK (`message_default` / `alert_default`).
- Introduced `THEATER_THIN_API_ADDR` constant and required imports for file chooser, dialogs, and I/O primitives in `src_app/theater_controller_pi/src/main.rs`.

### Testing
- Ran `rustfmt --edition 2024 src_app/theater_controller_pi/src/main.rs` and it completed successfully.
- Ran `cargo check --manifest-path src_app/theater_controller_pi/Cargo.toml` which failed in this environment due to missing registry configuration for `kellnr`.
- Ran `cargo clippy --manifest-path src_app/theater_controller_pi/Cargo.toml -- -D warnings` which also failed for the same `kellnr` registry resolution issue in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2edc7867c8321a0a8de4061954341)