### PR TITLE
Fix TV metadata starts-with SQL filtering to avoid unsupported operator

### DIFF
--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_tv.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_tv.rs
@@ -26,18 +26,29 @@ pub struct DBMetaTVShowList {
 
 pub async fn mk_lib_database_metadata_tv_read(
     sqlx_pool: &sqlx::PgPool,
-    search_value: String,
+    starts_with: String,
     offset: i64,
     limit: i64,
 ) -> Result<Vec<DBMetaTVShowList>, sqlx::Error> {
-    if !search_value.is_empty() {
-        // doing union so exact matches show on top
+    if !starts_with.is_empty() {
         sqlx::query_as(
-            r#"select mm_metadata_tvshow_guid, mm_metadata_tvshow_name, mm_metadata_tvshow_name_alt, mm_metadata_tvshow_json->'first_air_date' as air_date, mm_metadata_tvshow_localimage_json->'Poster' as image_json from mm_metadata_tvshow where mm_metadata_tvshow_name &@ $1 or mm_metadata_tvshow_name_alt &@ $2
-            offset $3 limit $4"#,
+            r#"select mm_metadata_tvshow_guid,
+            mm_metadata_tvshow_name,
+            mm_metadata_tvshow_name_alt,
+            mm_metadata_tvshow_json->'first_air_date' as air_date,
+            mm_metadata_tvshow_localimage_json->'Poster' as image_json
+            from mm_metadata_tvshow
+            where (
+                ($1 = '#' AND left(lower(mm_metadata_tvshow_name), 1) !~ '^[a-z0-9]$')
+                OR ($1 <> '#' AND (
+                    lower(mm_metadata_tvshow_name) LIKE lower($1) || '%'
+                    OR lower(coalesce(mm_metadata_tvshow_name_alt, '')) LIKE lower($1) || '%'
+                ))
+            )
+            order by lower(mm_metadata_tvshow_name), mm_metadata_tvshow_json->'first_air_date'
+            offset $2 limit $3"#,
         )
-        .bind(&search_value)
-        .bind(&search_value)
+        .bind(&starts_with)
         .bind(offset)
         .bind(limit)
         .fetch_all(sqlx_pool)
@@ -55,13 +66,21 @@ pub async fn mk_lib_database_metadata_tv_read(
 
 pub async fn mk_lib_database_metadata_tv_count(
     sqlx_pool: &sqlx::PgPool,
-    search_value: String,
+    starts_with: String,
 ) -> Result<i64, sqlx::Error> {
-    if !search_value.is_empty() {
+    if !starts_with.is_empty() {
         let row: (i64,) = sqlx::query_as(
-            r#"select count(*) from mm_metadata_tvshow where mm_metadata_tvshow_name &@ $1"#,
+            r#"select count(*)
+            from mm_metadata_tvshow
+            where (
+                ($1 = '#' AND left(lower(mm_metadata_tvshow_name), 1) !~ '^[a-z0-9]$')
+                OR ($1 <> '#' AND (
+                    lower(mm_metadata_tvshow_name) LIKE lower($1) || '%'
+                    OR lower(coalesce(mm_metadata_tvshow_name_alt, '')) LIKE lower($1) || '%'
+                ))
+            )"#,
         )
-        .bind(search_value)
+        .bind(starts_with)
         .fetch_one(sqlx_pool)
         .await?;
         Ok(row.0)


### PR DESCRIPTION
### Motivation
- A request to `/user/metadata/tv` could panic with Postgres error `operator does not exist: text &@ text` when the database does not provide the `&@` operator. 
- The intent is to make `starts_with` filtering work reliably on standard Postgres installs without requiring extra operators.

### Description
- Replaced use of the unsupported `&@` operator in TV queries with explicit `starts_with` logic and a `#` special-case, and updated the function signatures to accept `starts_with` (`src/mk_lib_database/src/metadata/mk_lib_database_metadata_tv.rs`).
- Implemented prefix matching against both `mm_metadata_tvshow_name` and `mm_metadata_tvshow_name_alt` for non-`#` filters and preserved the `#` semantics for non-alphanumeric leading characters. 
- Added deterministic ordering to filtered results and made the `count` query use the same `starts_with` semantics so list/count remain consistent.

### Testing
- Ran `rustfmt --edition 2021 src/mk_lib_database/src/metadata/mk_lib_database_metadata_tv.rs` successfully to format the change. 
- Attempted `cargo check --manifest-path src/mk_lib_database/Cargo.toml` but it was blocked in this environment due to a missing configured registry index (`kellnr`). 
- Attempted `cargo clippy --manifest-path src/mk_lib_database/Cargo.toml -- -D warnings` but it was blocked for the same registry configuration issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d313f3c4a08321a77a1ab74177707c)