### PR TITLE
Use local Loki for admin logging page

### DIFF
--- a/docker/core/mkwebaxum/src/admin/bp_logging.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_logging.rs
@@ -1,17 +1,34 @@
 use crate::mk_lib_logging;
 use askama::Template;
 use axum::{
-    extract::Path,
     http::{Method, StatusCode},
-    response::{Html, IntoResponse, Redirect},
-    Extension,
+    response::{Html, IntoResponse},
 };
-use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
+use reqwest::Client;
+use serde::Deserialize;
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
+use std::collections::HashMap;
+use std::env;
+
+const LOCAL_LOKI_QUERY_URL_DEFAULT: &str = "http://127.0.0.1:3100/loki/api/v1/query_range";
+
+#[derive(Debug, Deserialize)]
+struct LokiResponse {
+    data: LokiData,
+}
+
+#[derive(Debug, Deserialize)]
+struct LokiData {
+    result: Vec<LokiStream>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LokiStream {
+    stream: HashMap<String, String>,
+    values: Vec<[String; 2]>,
+}
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_403.html")]
@@ -23,6 +40,67 @@ struct TemplateLogContext<'a> {
     template_data: &'a Vec<mk_lib_logging::mk_lib_logging_loki::LokiLog>,
     template_data_exists: &'a bool,
     page_title: Option<String>,
+}
+
+fn stream_labels_to_string(labels: &HashMap<String, String>) -> String {
+    let mut pairs: Vec<_> = labels.iter().collect();
+    pairs.sort_by_key(|(k, _)| *k);
+    pairs
+        .into_iter()
+        .map(|(k, v)| format!(r#"{k}="{v}""#))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn stream_to_logql(labels: &HashMap<String, String>) -> String {
+    format!("{{{}}}", stream_labels_to_string(labels))
+}
+
+async fn read_local_loki_logs(
+    message_type: &str,
+) -> Result<Vec<mk_lib_logging::mk_lib_logging_loki::LokiLog>, Box<dyn std::error::Error>> {
+    let query = if message_type.is_empty() {
+        r#"{job="mediakraken"}"#.to_string()
+    } else {
+        format!(r#"{{job="mediakraken"}} |= "{}""#, message_type)
+    };
+
+    let local_loki_query_url = env::var("LOCAL_LOKI_QUERY_URL")
+        .unwrap_or_else(|_| LOCAL_LOKI_QUERY_URL_DEFAULT.to_string());
+
+    let response: LokiResponse = Client::new()
+        .get(local_loki_query_url)
+        .query(&[
+            ("query", query.as_str()),
+            ("limit", "100"),
+            ("direction", "backward"),
+        ])
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    let capacity = response
+        .data
+        .result
+        .iter()
+        .map(|stream| stream.values.len())
+        .sum::<usize>();
+    let mut logs = Vec::with_capacity(capacity);
+
+    for stream in response.data.result {
+        let stream_labels = stream_to_logql(&stream.stream);
+        for [timestamp, line] in stream.values {
+            logs.push(mk_lib_logging::mk_lib_logging_loki::LokiLog {
+                timestamp_ns: timestamp.parse()?,
+                labels: stream_labels.clone(),
+                line,
+            });
+        }
+    }
+
+    Ok(logs)
 }
 
 pub async fn admin_logging(
@@ -39,22 +117,17 @@ pub async fn admin_logging(
     .await
     {
         let template = TemplateError403Context {};
-        let reply_html = template.render().unwrap();
+        let reply_html = template.render().unwrap_or_default();
         (StatusCode::UNAUTHORIZED, Html(reply_html).into_response())
     } else {
-        let logging_list = mk_lib_logging::mk_lib_logging_loki::mk_logging_loki_read("fake_query")
-            .await
-            .unwrap();
-        let mut logging_data: bool = false;
-        if logging_list.len() > 0 {
-            logging_data = true;
-        }
+        let logging_list = read_local_loki_logs("").await.unwrap_or_default();
+        let logging_data = !logging_list.is_empty();
         let template = TemplateLogContext {
             template_data: &logging_list,
             template_data_exists: &logging_data,
             page_title: Some("MediaKraken Admin Logging".to_string()),
         };
-        let reply_html = template.render().unwrap();
+        let reply_html = template.render().unwrap_or_default();
         (StatusCode::OK, Html(reply_html).into_response())
     }
 }


### PR DESCRIPTION
### Motivation
- The admin logging page should read logs from a local Loki instance rather than the previous shared/query helper so operators can view local cluster logs directly.

### Description
- Added a local Loki query helper `read_local_loki_logs` in `bp_logging.rs` that requests `http://127.0.0.1:3100/loki/api/v1/query_range` by default and supports override via the `LOCAL_LOKI_QUERY_URL` environment variable.
- Added `LokiResponse`/`LokiData`/`LokiStream` deserialization structs and conversion logic that maps Loki stream results into the existing `mk_lib_logging::mk_lib_logging_loki::LokiLog` used by the Askama template.
- Updated `admin_logging` to call the new local reader and to use safe fallbacks (`unwrap_or_default`) when rendering or when the local Loki call fails, avoiding panics in the handler path.
- Removed several unused imports and small cleanup to keep the change minimal and focused on the data source swap.

### Testing
- Ran `cargo fmt` in `docker/core/mkwebaxum` which completed successfully.
- Ran `cargo check` in this environment but dependency resolution failed due to the private Kellnr registry returning HTTP 403, so full type-level checks could not complete.
- Ran `cargo clippy -- -D warnings` in this environment but it also failed for the same private registry resolution error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d31c06368c83219ac442b1fd7a23c2)