### PR TITLE
Move Play button before description in iRadio list and enable description wrapping

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_iradio.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_iradio.html
@@ -30,25 +30,25 @@
     <div class="mt-4 overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
         <ul role="list" class="divide-y divide-zinc-200 dark:divide-zinc-800">
             {% for station in template_data %}
-            <li class="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
-                <div class="min-w-0">
-                    <p class="truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+            <li class="flex flex-col gap-3 p-4">
+                <div class="flex items-center justify-between gap-3">
+                    <p class="min-w-0 flex-1 truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">
                         {% if let Some(station_name) = station.mm_radio_name %}
                         {{ station_name }}
                         {% else %}
                         Unnamed Station
                         {% endif %}
                     </p>
-                    <p class="truncate text-xs text-zinc-500 dark:text-zinc-400">{{ station.mm_radio_address }}</p>
+                    <button
+                        type="button"
+                        class="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                        aria-label="Play station"
+                        @click="currentUrl='{{ station.mm_radio_address }}'; currentName='{% if let Some(station_name) = station.mm_radio_name %}{{ station_name }}{% else %}Unnamed Station{% endif %}'; $refs.player.load(); $refs.player.play().catch(() => {})"
+                    >
+                        Play
+                    </button>
                 </div>
-                <button
-                    type="button"
-                    class="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-                    aria-label="Play station"
-                    @click="currentUrl='{{ station.mm_radio_address }}'; currentName='{% if let Some(station_name) = station.mm_radio_name %}{{ station_name }}{% else %}Unnamed Station{% endif %}'; $refs.player.load(); $refs.player.play().catch(() => {})"
-                >
-                    Play
-                </button>
+                <p class="text-xs break-words text-zinc-500 dark:text-zinc-400">{{ station.mm_radio_address }}</p>
             </li>
             {% endfor %}
         </ul>


### PR DESCRIPTION
### Motivation
- Improve the iRadio station list UX by placing the station action (Play) alongside the station title so the description/address appears below and can wrap to the available width.
- Prevent long station addresses from being truncated so they remain readable on narrow windows/devices.

### Description
- Updated the iRadio template at `docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_iradio.html` to change each station row layout. 
- Replaced the previous two-column `sm:flex-row` item with a stacked layout where the top row is a flex container containing the station title and the `Play` button (`button` kept `aria-label="Play station"` and existing `@click` handler). 
- Moved the station address/description into its own paragraph below the header row and switched from truncation to wrapping by using the `break-words` utility class (`<p class="text-xs break-words ...">`).
- This is a minimal, template-only UI change and does not modify backend logic or DB queries.

### Testing
- Ran `cargo check -p mkwebaxum`, which failed in this environment due to the configured private crate registry mirror returning HTTP 403, so compilation could not be fully validated here.
- No other automated tests were executed in this environment; the change is limited to a template file only and should be safe to review visually in the running app.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4211956608321a2b7c867b5228647)