### PR TITLE
Fix mksharescanner share comment type mismatch

### DIFF
--- a/docker/core/mksharescanner/src/main.rs
+++ b/docker/core/mksharescanner/src/main.rs
@@ -28,6 +28,7 @@ async fn process_message(
         let Some(share_path) = share_info.mm_share_path.as_str() else {
             continue;
         };
+        let share_comment = share_info.mm_share_comment.as_str().unwrap_or("");
 
         let normalized_share_path = share_path.to_owned();
         if !seen_shares.insert((share_info.mm_share_ip, normalized_share_path.clone())) {
@@ -46,7 +47,7 @@ async fn process_message(
                 sqlx_pool_rw,
                 share_info.mm_share_ip,
                 share_path,
-                share_info.mm_share_comment.clone(),
+                share_comment,
             )
             .await?;
         }


### PR DESCRIPTION
### Motivation
- Calling `mk_lib_database_network_share_insert` with `share_info.mm_share_comment` (a `serde_json::Value`) caused a compile-time type mismatch because the function expects `&str`.

### Description
- Convert `mm_share_comment` to a `&str` using `as_str().unwrap_or("")` and pass the resulting `share_comment` to `mk_lib_database_network_share_insert` in `docker/core/mksharescanner/src/main.rs` to resolve the type mismatch.

### Testing
- Ran `cargo fmt` in `docker/core/mksharescanner` which succeeded.
- Attempted `cargo check` and `cargo clippy -- -D warnings` in `docker/core/mksharescanner` but both were blocked by a private registry returning HTTP 403 during dependency resolution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d46a3518508321bc45f3ca0dc809d7)