### PR TITLE
Fix Askama comparison error in admin library template

### DIFF
--- a/docker/core/mkwebaxum/src/admin/bp_library.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_library.rs
@@ -1,19 +1,19 @@
+use crate::AppState;
 use crate::mk_lib_database;
 use askama::Template;
+use axum::extract::State;
 use axum::{
+    Extension,
     extract::Path,
     http::{Method, StatusCode},
     response::{Html, IntoResponse, Redirect},
-    Extension,
 };
 use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_rabbitmq;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use sqlx::postgres::PgPool;
-use axum::extract::State;
-use crate::AppState;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_403.html")]
@@ -28,6 +28,19 @@ struct TemplateAdminLibraryContext<'a> {
         &'a Vec<mk_lib_database::mk_lib_database_network_share::DBShareAuthUserList>,
     template_data_exists: &'a bool,
     page_title: Option<String>,
+}
+
+impl TemplateAdminLibraryContext<'_> {
+    fn share_user_matches(
+        &self,
+        share: &mk_lib_database::mk_lib_database_network_share::DBShareList,
+        auth_user: &mk_lib_database::mk_lib_database_network_share::DBShareAuthUserList,
+    ) -> bool {
+        matches!(
+            share.mm_share_auth_user.as_deref(),
+            Some(user) if user == auth_user.mm_share_auth_user
+        )
+    }
 }
 
 pub async fn admin_library(
@@ -50,13 +63,13 @@ pub async fn admin_library(
     } else {
         let share_list =
             mk_lib_database::mk_lib_database_network_share::mk_lib_database_network_share_read(
-               &state.sqlx_pool_ro,
+                &state.sqlx_pool_ro,
             )
             .await
             .unwrap();
         let library_list =
             mk_lib_database::mk_lib_database_library::mk_lib_database_library_path_audit_read(
-               &state.sqlx_pool_ro,
+                &state.sqlx_pool_ro,
             )
             .await
             .unwrap();

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
@@ -60,7 +60,7 @@
                     {% for auth_row in template_data_share_user %}
                       <option
                         value="{{ auth_row.mm_share_auth_guid }}"
-                        {% if auth_row.mm_share_auth_user == row_data.mm_share_auth_user %}selected{% endif %}>
+                        {% if self.share_user_matches(row_data, auth_row) %}selected{% endif %}>
                         {{ auth_row.mm_share_auth_user }}
                       </option>
                     {% endfor %}


### PR DESCRIPTION
### Motivation
- The Askama template comparison attempted to compare a `String` to an `Option<String>` which caused a compile-time type error. 
- Make the comparison safe and explicit so templates render without generating invalid Rust equality checks.

### Description
- Added a helper method `share_user_matches` on `TemplateAdminLibraryContext` in `docker/core/mkwebaxum/src/admin/bp_library.rs` that safely compares `share.mm_share_auth_user: Option<String>` with an auth-row `String` using `as_deref()` and `matches!`.
- Updated the Askama template `docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html` to use `self.share_user_matches(row_data, auth_row)` for the `<option selected>` condition instead of a direct `==` comparison.
- Changes are minimal and localized to template logic and its small helper; no public interfaces or database schemas were modified.

### Testing
- Ran `cargo fmt` in `docker/core/mkwebaxum`, which completed successfully.
- Ran `cargo check` in `docker/core/mkwebaxum`, which failed due to external registry access (`403 Forbidden`) from the environment and not due to the code change.
- Ran `cargo clippy -- -D warnings` in `docker/core/mkwebaxum`, which also failed for the same external registry access reason and not because of the patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5b87e1fe88321a7613ea0bba485be)