### PR TITLE
Prefer smbclient for SMB file discovery in mkmediascanner

### DIFF
--- a/docker/core/mkmediascanner/src/main.rs
+++ b/docker/core/mkmediascanner/src/main.rs
@@ -6,7 +6,7 @@ use mk_lib_database;
 use mk_lib_file;
 use mk_lib_rabbitmq;
 use num_format::{Locale, ToFormattedString};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::error::Error;
 use std::ffi::OsStr;
 use std::path::Path;
@@ -34,12 +34,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let stack_disc1 = Regex::new(r"(?i)-disc1(?!\d)").unwrap();
 
     // connect to db and do a version check
-    let (sqlx_pool_rw, sqlx_pool_ro) = mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120)
-        .await
-        .unwrap();
-    let _result =
-        mk_lib_database::mk_lib_database_version::mk_lib_database_version_check(&sqlx_pool_ro, false)
-            .await;
+    let (sqlx_pool_rw, sqlx_pool_ro) =
+        mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120)
+            .await
+            .unwrap();
+    let _result = mk_lib_database::mk_lib_database_version::mk_lib_database_version_check(
+        &sqlx_pool_ro,
+        false,
+    )
+    .await;
 
     let (_rabbit_connection, rabbit_channel) =
         mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_connect("mkmediascanner")
@@ -70,7 +73,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 .unwrap();
                 // TODO handle NFS shares as well
                 // log into share via smbclient
-                let smb_client = mk_lib_file::mk_lib_smb::mk_file_smb_client_connect(share_info);
+                let smb_client =
+                    mk_lib_file::mk_lib_smb::mk_file_smb_client_connect(share_info.clone());
                 match smb_client {
                     Ok(smb_client) => {
                         // make sure the path still exists
@@ -102,9 +106,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         )
                                         .await;
                                     let mut file_data =
-                                        mk_lib_file::mk_lib_smb::mk_file_smb_client_tree(
-                                            &smb_client,
+                                        mk_lib_file::mk_lib_smb::mk_file_smb_client_tree_smbclient(
+                                            &share_info,
                                             format!("/{}", row_data.mm_media_dir_path).as_str(),
+                                        )
+                                        .unwrap_or_else(
+                                            |_| {
+                                                mk_lib_file::mk_lib_smb::mk_file_smb_client_tree(
+                                                    &smb_client,
+                                                    format!("/{}", row_data.mm_media_dir_path)
+                                                        .as_str(),
+                                                )
+                                            },
                                         );
                                     let mut total_scanned: u64 = 0;
                                     let mut total_files: u64 = 0;
@@ -112,12 +125,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         let file_metadata = file_data[0].clone();
                                         println!("meta: {:?}", file_metadata);
                                         if file_metadata.directory == true {
-                                            file_data.append(
-                                        &mut mk_lib_file::mk_lib_smb::mk_file_smb_client_tree(
-                                            &smb_client,
-                                            format!("/{}", file_metadata.name).as_str(),
-                                        ),
-                                    );
+                                            let mut child_files = mk_lib_file::mk_lib_smb::mk_file_smb_client_tree_smbclient(
+                                                &share_info,
+                                                format!("/{}", file_metadata.name).as_str(),
+                                            )
+                                            .unwrap_or_else(|_| {
+                                                mk_lib_file::mk_lib_smb::mk_file_smb_client_tree(
+                                                    &smb_client,
+                                                    format!("/{}", file_metadata.name).as_str(),
+                                                )
+                                            });
+                                            file_data.append(&mut child_files);
                                         } else {
                                             if mk_lib_database::mk_lib_database_library::mk_lib_database_library_file_exists(&sqlx_pool_ro, &file_metadata.name).await.unwrap() == false {
                                         // set lower here so I can remove a lot of .lower() in the code below

--- a/src/mk_lib_database/src/mk_lib_database_network_share.rs
+++ b/src/mk_lib_database/src/mk_lib_database_network_share.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sqlx::types::Uuid;
 use sqlx::FromRow;
+use sqlx::types::Uuid;
 
 pub async fn mk_lib_database_network_share_exists(
     sqlx_pool: &sqlx::PgPool,
@@ -64,7 +64,7 @@ pub async fn mk_lib_database_network_share_detail(
     Ok(table_row)
 }
 
-#[derive(Debug, FromRow, Deserialize, Serialize)]
+#[derive(Clone, Debug, FromRow, Deserialize, Serialize)]
 pub struct DBShareList {
     pub mm_network_share_guid: uuid::Uuid,
     pub mm_network_share_ip: std::net::IpAddr,

--- a/src/mk_lib_file/src/mk_lib_smb.rs
+++ b/src/mk_lib_file/src/mk_lib_smb.rs
@@ -2,6 +2,7 @@ use mk_lib_database;
 use pavao::{SmbClient, SmbCredentials, SmbDirent, SmbDirentType, SmbOptions, SmbStat};
 use std::error::Error;
 use std::path::PathBuf;
+use std::process::Command;
 
 pub fn mk_file_smb_client_connect(
     share_to_mount: mk_lib_database::mk_lib_database_network_share::DBShareList,
@@ -50,13 +51,90 @@ pub fn mk_file_smb_client_tree(client: &SmbClient, uri: &str) -> Vec<File_Metada
     for entity in client.list_dir(uri).unwrap().into_iter() {
         let entity_uri = mk_file_smb_client_entity_uri(&entity, uri);
         let stat = client.stat(entity_uri.as_str()).unwrap();
-        let mut new_file = File_Metadata {name: entity_uri, directory: false};
+        let mut new_file = File_Metadata {
+            name: entity_uri,
+            directory: false,
+        };
         if entity.get_type() == SmbDirentType::Dir {
             new_file.directory = true;
         }
         file_list.push(new_file);
     }
     file_list
+}
+
+pub fn mk_file_smb_client_tree_smbclient(
+    share_to_mount: &mk_lib_database::mk_lib_database_network_share::DBShareList,
+    uri: &str,
+) -> Result<Vec<File_Metadata>, Box<dyn Error>> {
+    let mut smb_command = Command::new("smbclient");
+    let share_uri = format!(
+        "//{}/{}",
+        share_to_mount.mm_network_share_ip, share_to_mount.mm_network_share_path
+    );
+    let mut smb_commands: Vec<String> =
+        vec![String::from("recurse ON"), String::from("prompt OFF")];
+    let cleaned_uri = uri.trim_start_matches('/');
+    if cleaned_uri.is_empty() == false {
+        smb_commands.push(format!("cd \"{}\"", cleaned_uri));
+    }
+    smb_commands.push(String::from("ls"));
+    smb_command
+        .arg(share_uri)
+        .arg("-g")
+        .arg("-c")
+        .arg(smb_commands.join(";"));
+    if let Some(workgroup) = share_to_mount.mm_network_share_workgroup.as_deref() {
+        if workgroup.is_empty() == false {
+            smb_command.arg("-W").arg(workgroup);
+        }
+    }
+    if let Some(user) = share_to_mount.mm_share_auth_user.as_deref() {
+        let pass = share_to_mount
+            .mm_share_auth_password
+            .as_deref()
+            .unwrap_or_default();
+        smb_command.arg("-U").arg(format!("{}%{}", user, pass));
+    } else {
+        smb_command.arg("-N");
+    }
+    let smb_output = smb_command.output()?;
+    if smb_output.status.success() == false {
+        return Err(format!(
+            "smbclient failed with status {:?}",
+            smb_output.status.code()
+        )
+        .into());
+    }
+    let stdout_data = String::from_utf8(smb_output.stdout)?;
+    let mut file_list: Vec<File_Metadata> = vec![];
+    for line in stdout_data.lines() {
+        let parts: Vec<&str> = line.split('|').collect();
+        if parts.len() < 2 {
+            continue;
+        }
+        if parts[0] != "D" && parts[0] != "F" {
+            continue;
+        }
+        if parts[1] == "." || parts[1] == ".." {
+            continue;
+        }
+        let path_value = if parts[1].starts_with('/') {
+            parts[1].to_string()
+        } else if uri.ends_with('/') {
+            format!("{}{}", uri, parts[1])
+        } else {
+            format!("{}/{}", uri, parts[1])
+        };
+        file_list.push(File_Metadata {
+            name: path_value,
+            directory: parts[0] == "D",
+        });
+    }
+    if file_list.is_empty() {
+        return Err("smbclient returned no parsable entries".into());
+    }
+    Ok(file_list)
 }
 
 fn mk_file_smb_client_entity_uri(entity: &SmbDirent, path: &str) -> String {


### PR DESCRIPTION
### Motivation
- Improve reliability of discovering new files on SMB/CIFS shares by using the system `smbclient` tool where available, while keeping the existing pavao-based SMB client as a safe fallback.

### Description
- Add `mk_file_smb_client_tree_smbclient` in `src/mk_lib_file/src/mk_lib_smb.rs` that shells out to `smbclient -g` with recursive `ls`, parses the `|`-delimited output into the existing `File_Metadata` struct, and returns a `Result<Vec<File_Metadata>, Box<dyn Error>>`.
- Update `docker/core/mkmediascanner/src/main.rs` to try `mk_file_smb_client_tree_smbclient` first for top-level and nested directory listings and fall back to the existing `mk_file_smb_client_tree` when `smbclient` fails or its output is not parseable.
- Derive `Clone` for `DBShareList` in `src/mk_lib_database/src/mk_lib_database_network_share.rs` so share metadata/credentials can be reused for both the pavao client connection and the `smbclient` invocation.
- Add `use std::process::Command` and return explicit errors from the `smbclient` wrapper so failures are detectable and trigger fallback behavior.

### Testing
- Ran `cargo fmt -p mkmediascanner` (from `docker/core`) which completed successfully.
- Attempted `cargo check -p mkmediascanner` which failed in this environment due to a private registry endpoint returning HTTP 403 and therefore could not fully validate compile-time checks.
- Attempted `cargo clippy -p mkmediascanner -- -D warnings` which also failed for the same private registry access reason and could not complete lint checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6b0d143208321a7c551ff1abe5ed4)