### PR TITLE
Fix SMB credential Option handling

### DIFF
--- a/src/mk_lib_file/src/mk_lib_smb.rs
+++ b/src/mk_lib_file/src/mk_lib_smb.rs
@@ -18,8 +18,18 @@ pub fn mk_file_smb_client_connect(
         SmbCredentials::default()
             .server(format!("smb://{}", share_to_mount.mm_network_share_ip))
             .share(format!("/{}", share_to_mount.mm_network_share_path))
-            .username(share_to_mount.mm_share_auth_user)
-            .password(share_to_mount.mm_share_auth_password.unwrap())
+            .username(
+                share_to_mount
+                    .mm_share_auth_user
+                    .as_deref()
+                    .unwrap_or_default(),
+            )
+            .password(
+                share_to_mount
+                    .mm_share_auth_password
+                    .as_deref()
+                    .unwrap_or_default(),
+            )
             .workgroup(smb_workgroup),
         SmbOptions::default().one_share_per_server(true),
     )


### PR DESCRIPTION
### Motivation
- Fix build error `E0277` where `SmbCredentials::username` required `AsRef<str>` but was being passed `Option<String>` from the DB model.

### Description
- Convert `mm_share_auth_user` and `mm_share_auth_password` to `&str` with `as_deref().unwrap_or_default()` when constructing `SmbCredentials` in `src/mk_lib_file/src/mk_lib_smb.rs` to avoid the type mismatch and remove an unsafe `unwrap()`.

### Testing
- Ran `rustfmt src/mk_lib_file/src/mk_lib_smb.rs` which completed successfully.
- Attempted `cargo check --manifest-path src/mk_lib_file/Cargo.toml` and `cargo clippy --manifest-path src/mk_lib_file/Cargo.toml -- -D warnings` but both failed due to a missing private registry index `kellnr`, so full compile/lint could not be validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6efa6307883219c79f51986af525a)