### PR TITLE
Add Browse directory picker to admin library form

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
@@ -72,6 +72,13 @@
                     name="subdirectory"
                     placeholder="Directory from share"
                     class="border rounded px-2 py-1 w-full md:w-56">
+                  <input
+                    type="file"
+                    data-directory-picker
+                    class="hidden"
+                    webkitdirectory
+                    directory
+                    @change="setSelectedDirectory($event)">
                   <select name="media_class" class="border rounded px-2 py-1 w-full md:w-44">
                     <option value="1">Movie</option>
                     <option value="2">TV</option>
@@ -83,6 +90,13 @@
                     <option value="8">Anime</option>
                     <option value="10">Adult</option>
                   </select>
+                  <button
+                    type="button"
+                    @click="openDirectoryPicker($event)"
+                    aria-label="Browse share directory"
+                    class="bg-gray-600 text-white px-3 py-1 rounded hover:bg-gray-700">
+                    Browse
+                  </button>
                   <button
                     type="submit"
                     aria-label="Add share directory as library"
@@ -215,6 +229,32 @@ function libraryPage() {
     confirmDelete(guid) {
       this.selectedGuid = guid
       this.showDelete = true
+    },
+
+    openDirectoryPicker(event) {
+      const form = event.currentTarget.closest('form')
+      const directoryInput = form?.querySelector('input[data-directory-picker]')
+      if (directoryInput) {
+        directoryInput.click()
+      }
+    },
+
+    setSelectedDirectory(event) {
+      const directoryInput = event.currentTarget
+      const selectedFiles = directoryInput.files
+      if (!selectedFiles || selectedFiles.length === 0) {
+        return
+      }
+
+      const firstFile = selectedFiles[0]
+      const relativePath = firstFile.webkitRelativePath || firstFile.name
+      const selectedDirectory = relativePath.split('/')[0] || ''
+
+      const form = directoryInput.closest('form')
+      const subdirectoryInput = form?.querySelector('input[name="subdirectory"]')
+      if (subdirectoryInput) {
+        subdirectoryInput.value = selectedDirectory
+      }
     },
 
     updateLibrary() {


### PR DESCRIPTION
### Motivation
- Improve the admin library row UX by letting users browse and select a local/share directory instead of typing the subdirectory manually.
- Auto-populate the `subdirectory` input from the selected folder to reduce typing errors and speed library additions.

### Description
- Updated `docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html` to add a hidden `type="file"` input per row with `webkitdirectory` and `data-directory-picker` attributes.
- Added a visible `Browse` button next to the existing `Add` button that triggers the hidden directory input via the Alpine handler `openDirectoryPicker(event)`.
- Implemented `setSelectedDirectory(event)` in the page's `libraryPage()` Alpine component to read `webkitRelativePath` from the selected files and set the `input[name="subdirectory"]` value to the selected top-level folder.
- All changes are row-scoped so the picker only affects the form it was opened from and does not change backend routes or public interfaces.

### Testing
- Ran `cargo check` in `docker/core/mkwebaxum`, which failed due to the environment's configured private registry returning HTTP `403 Forbidden`, so the Rust workspace build could not complete in this environment.  
- No frontend automated tests were present or executed; the change is confined to template/JS additions and can be manually verified by loading the admin library page and using the new `Browse` button to populate the `subdirectory` field.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d82f4118808321a65f83f49ad2e117)