### PR TITLE
Fix admin library Browse button and add SMB share directory browser

### DIFF
--- a/docker/core/mkwebaxum/src/admin/bp_library.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_library.rs
@@ -313,12 +313,11 @@ pub async fn admin_library_share_directories(
         share_info.mm_network_share_path.trim_matches('/')
     );
 
-    let mut smb_commands: Vec<String> =
-        vec![String::from("recurse OFF"), String::from("prompt OFF")];
-    if cleaned_path.is_empty() == false {
-        smb_commands.push(format!("cd \"{}\"", cleaned_path));
-    }
-    smb_commands.push(String::from("ls"));
+    let smb_commands: Vec<String> = vec![
+        String::from("recurse OFF"),
+        String::from("prompt OFF"),
+        String::from("ls"),
+    ];
 
     let mut smb_command = Command::new("smbclient");
     smb_command
@@ -326,6 +325,9 @@ pub async fn admin_library_share_directories(
         .arg("-g")
         .arg("-c")
         .arg(smb_commands.join(";"));
+    if cleaned_path.is_empty() == false {
+        smb_command.arg("-D").arg(&cleaned_path);
+    }
     if let Some(workgroup) = share_info.mm_network_share_workgroup.as_deref() {
         if workgroup.is_empty() == false {
             smb_command.arg("-W").arg(workgroup);

--- a/docker/core/mkwebaxum/src/admin/bp_library.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_library.rs
@@ -3,8 +3,8 @@ use crate::mk_lib_database;
 use askama::Template;
 use axum::extract::{Form, State};
 use axum::{
-    Extension,
-    extract::Path,
+    Extension, Json,
+    extract::{Path, Query},
     http::{Method, StatusCode},
     response::{Html, IntoResponse, Redirect},
 };
@@ -13,9 +13,10 @@ use axum_session::{SessionConfig, SessionLayer};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_rabbitmq;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sqlx::postgres::PgPool;
+use tokio::process::Command;
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_403.html")]
@@ -50,6 +51,19 @@ pub struct AddShareLibraryInput {
     share_guid: uuid::Uuid,
     subdirectory: String,
     media_class: i16,
+}
+
+#[derive(Deserialize)]
+pub struct ShareDirectoryBrowseQuery {
+    share_guid: uuid::Uuid,
+    path: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ShareDirectoryBrowseResponse {
+    current_path: String,
+    parent_path: Option<String>,
+    directories: Vec<String>,
 }
 
 pub async fn admin_library(
@@ -241,6 +255,143 @@ pub async fn admin_library_share_scan(
             .unwrap();
         Redirect::to("/admin/library")
     }
+}
+
+pub async fn admin_library_share_directories(
+    State(state): State<AppState>,
+    method: Method,
+    auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
+    Query(query): Query<ShareDirectoryBrowseQuery>,
+) -> impl IntoResponse {
+    let current_user = auth.current_user.clone().unwrap_or_default();
+    if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
+        [Method::GET],
+        false,
+    )
+    .requires(Rights::any([Rights::permission("Admin::View")]))
+    .validate(&current_user, &method, None)
+    .await
+    {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "Not authorized"})),
+        );
+    }
+
+    let share_info =
+        match mk_lib_database::mk_lib_database_network_share::mk_lib_database_network_share_detail(
+            &state.sqlx_pool_ro,
+            query.share_guid,
+        )
+        .await
+        {
+            Ok(data) => data,
+            Err(_) => {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(json!({"error": "Share information not found"})),
+                );
+            }
+        };
+
+    let requested_path = query.path.unwrap_or_default();
+    let cleaned_path = requested_path
+        .trim()
+        .replace('\\', "/")
+        .trim_matches('/')
+        .to_string();
+    if cleaned_path.split('/').any(|segment| segment == "..") {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "Invalid path"})),
+        );
+    }
+
+    let share_uri = format!(
+        "//{}/{}",
+        share_info.mm_network_share_ip,
+        share_info.mm_network_share_path.trim_matches('/')
+    );
+
+    let mut smb_commands: Vec<String> =
+        vec![String::from("recurse OFF"), String::from("prompt OFF")];
+    if cleaned_path.is_empty() == false {
+        smb_commands.push(format!("cd \"{}\"", cleaned_path));
+    }
+    smb_commands.push(String::from("ls"));
+
+    let mut smb_command = Command::new("smbclient");
+    smb_command
+        .arg(share_uri)
+        .arg("-g")
+        .arg("-c")
+        .arg(smb_commands.join(";"));
+    if let Some(workgroup) = share_info.mm_network_share_workgroup.as_deref() {
+        if workgroup.is_empty() == false {
+            smb_command.arg("-W").arg(workgroup);
+        }
+    }
+    if let Some(user) = share_info.mm_share_auth_user.as_deref() {
+        let pass = share_info
+            .mm_share_auth_password
+            .as_deref()
+            .unwrap_or_default();
+        smb_command.arg("-U").arg(format!("{}%{}", user, pass));
+    } else {
+        smb_command.arg("-N");
+    }
+
+    let smb_output = match smb_command.output().await {
+        Ok(data) => data,
+        Err(_) => {
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({"error": "Unable to run smbclient"})),
+            );
+        }
+    };
+
+    if smb_output.status.success() == false {
+        let stderr_output = String::from_utf8_lossy(&smb_output.stderr).to_string();
+        return (
+            StatusCode::BAD_GATEWAY,
+            Json(json!({"error": "Failed to list share directories", "details": stderr_output})),
+        );
+    }
+
+    let stdout_data = String::from_utf8_lossy(&smb_output.stdout);
+    let mut directories = Vec::new();
+    for line in stdout_data.lines() {
+        let parts: Vec<&str> = line.split('|').collect();
+        if parts.len() < 2 || parts[0] != "D" {
+            continue;
+        }
+        if parts[1] == "." || parts[1] == ".." {
+            continue;
+        }
+        directories.push(parts[1].to_string());
+    }
+    directories.sort_unstable();
+
+    let parent_path = cleaned_path
+        .rsplit_once('/')
+        .map(|(parent, _)| parent.to_string())
+        .or_else(|| {
+            if cleaned_path.is_empty() {
+                None
+            } else {
+                Some(String::new())
+            }
+        });
+
+    (
+        StatusCode::OK,
+        Json(json!(ShareDirectoryBrowseResponse {
+            current_path: cleaned_path,
+            parent_path,
+            directories,
+        })),
+    )
 }
 
 /*

--- a/docker/core/mkwebaxum/src/main.rs
+++ b/docker/core/mkwebaxum/src/main.rs
@@ -238,6 +238,10 @@ async fn main() {
             "/admin/library_share_scan",
             get(admin::bp_library::admin_library_share_scan),
         )
+        .route_with_tsr(
+            "/admin/library/share_directories",
+            get(admin::bp_library::admin_library_share_directories),
+        )
         //.post(admin::bp_library::admin_library_post))
         .route_with_tsr(
             "/admin/server_links",

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
@@ -72,13 +72,6 @@
                     name="subdirectory"
                     placeholder="Directory from share"
                     class="border rounded px-2 py-1 w-full md:w-56">
-                  <input
-                    type="file"
-                    data-directory-picker
-                    class="hidden"
-                    webkitdirectory
-                    directory
-                    @change="setSelectedDirectory($event)">
                   <select name="media_class" class="border rounded px-2 py-1 w-full md:w-44">
                     <option value="1">Movie</option>
                     <option value="2">TV</option>
@@ -92,9 +85,9 @@
                   </select>
                   <button
                     type="button"
-                    @click="openDirectoryPicker($event)"
+                    @click="openDirectoryPicker($event, '{{ row_data.mm_network_share_guid }}')"
                     aria-label="Browse share directory"
-                    class="bg-gray-600 text-white px-3 py-1 rounded hover:bg-gray-700">
+                    class="bg-gray-700 text-white px-3 py-1 rounded hover:bg-gray-800 whitespace-nowrap shrink-0 font-medium">
                     Browse
                   </button>
                   <button
@@ -205,6 +198,51 @@
       </div>
     </div>
 
+    <!-- Share Browser Modal -->
+    <div x-show="showShareBrowser" x-cloak class="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+      <div class="bg-white rounded shadow-lg w-full max-w-2xl p-6">
+        <div class="flex items-center justify-between mb-3">
+          <h3 class="text-lg font-semibold">Browse Share Directories</h3>
+          <button @click="showShareBrowser=false" class="bg-gray-200 hover:bg-gray-300 rounded px-3 py-1">Close</button>
+        </div>
+        <p class="text-sm text-gray-600 mb-3">Current path: <span class="font-mono" x-text="browserCurrentPath || '/'"></span></p>
+        <div class="mb-3">
+          <button
+            type="button"
+            @click="navigateToParent"
+            :disabled="browserParentPath === null || browserLoading"
+            class="bg-gray-100 border border-gray-300 rounded px-3 py-1 text-sm disabled:opacity-50 disabled:cursor-not-allowed">
+            Up One Level
+          </button>
+        </div>
+        <p x-show="browserLoading" class="text-sm text-gray-600">Loading directories...</p>
+        <p x-show="browserError" class="text-sm text-red-600" x-text="browserError"></p>
+        <div class="max-h-80 overflow-auto border border-gray-200 rounded">
+          <template x-if="!browserLoading && browserDirectories.length === 0">
+            <p class="p-3 text-sm text-gray-500">No directories found in this location.</p>
+          </template>
+          <template x-for="dirName in browserDirectories" :key="dirName">
+            <div class="flex items-center justify-between gap-2 border-b border-gray-100 px-3 py-2 last:border-b-0">
+              <button
+                type="button"
+                @click="browseInto(dirName)"
+                class="text-left flex-1 text-indigo-700 hover:text-indigo-900 hover:underline"
+                :aria-label="`Open directory ${dirName}`"
+                x-text="dirName">
+              </button>
+              <button
+                type="button"
+                @click="selectCurrentDirectory(dirName)"
+                class="bg-indigo-600 text-white px-3 py-1 rounded hover:bg-indigo-700 text-sm"
+                :aria-label="`Select directory ${dirName}`">
+                Select
+              </button>
+            </div>
+          </template>
+        </div>
+      </div>
+    </div>
+
   </main>
   </div>
 </div>
@@ -215,7 +253,15 @@ function libraryPage() {
   return {
     showEdit: false,
     showDelete: false,
+    showShareBrowser: false,
     selectedGuid: null,
+    activeSubdirectoryInput: null,
+    browserShareGuid: '',
+    browserCurrentPath: '',
+    browserParentPath: null,
+    browserDirectories: [],
+    browserLoading: false,
+    browserError: '',
     editPath: '',
     editClass: '',
 
@@ -231,30 +277,58 @@ function libraryPage() {
       this.showDelete = true
     },
 
-    openDirectoryPicker(event) {
+    openDirectoryPicker(event, shareGuid) {
       const form = event.currentTarget.closest('form')
-      const directoryInput = form?.querySelector('input[data-directory-picker]')
-      if (directoryInput) {
-        directoryInput.click()
+      this.activeSubdirectoryInput = form?.querySelector('input[name=\"subdirectory\"]') ?? null
+      this.browserShareGuid = shareGuid
+      this.showShareBrowser = true
+      this.loadDirectories('')
+    },
+
+    async loadDirectories(path) {
+      this.browserLoading = true
+      this.browserError = ''
+      this.browserDirectories = []
+      try {
+        const params = new URLSearchParams({ share_guid: this.browserShareGuid, path })
+        const response = await fetch(`/admin/library/share_directories?${params.toString()}`)
+        const payload = await response.json()
+        if (!response.ok) {
+          this.browserError = payload.error || 'Unable to browse this share.'
+          return
+        }
+        this.browserCurrentPath = payload.current_path || ''
+        this.browserParentPath = payload.parent_path
+        this.browserDirectories = payload.directories || []
+      } catch (_error) {
+        this.browserError = 'Unable to browse this share.'
+      } finally {
+        this.browserLoading = false
       }
     },
 
-    setSelectedDirectory(event) {
-      const directoryInput = event.currentTarget
-      const selectedFiles = directoryInput.files
-      if (!selectedFiles || selectedFiles.length === 0) {
+    browseInto(dirName) {
+      const nextPath = this.browserCurrentPath
+        ? `${this.browserCurrentPath}/${dirName}`
+        : dirName
+      this.loadDirectories(nextPath)
+    },
+
+    navigateToParent() {
+      if (this.browserParentPath === null) {
         return
       }
+      this.loadDirectories(this.browserParentPath)
+    },
 
-      const firstFile = selectedFiles[0]
-      const relativePath = firstFile.webkitRelativePath || firstFile.name
-      const selectedDirectory = relativePath.split('/')[0] || ''
-
-      const form = directoryInput.closest('form')
-      const subdirectoryInput = form?.querySelector('input[name="subdirectory"]')
-      if (subdirectoryInput) {
-        subdirectoryInput.value = selectedDirectory
+    selectCurrentDirectory(dirName) {
+      const selectedPath = this.browserCurrentPath
+        ? `${this.browserCurrentPath}/${dirName}`
+        : dirName
+      if (this.activeSubdirectoryInput) {
+        this.activeSubdirectoryInput.value = selectedPath
       }
+      this.showShareBrowser = false
     },
 
     updateLibrary() {


### PR DESCRIPTION
### Motivation
- Make the library "Browse" action visible and usable in the admin UI and ensure the browse action lists directories from the configured network share rather than the local disk.
- Provide an authenticated, server-side directory enumeration so share credentials and path validation happen on the backend (avoiding client-side local-only file picking). 

### Description
- Updated the admin template `bss_admin/bss_admin_library.html` to remove the local `webkitdirectory` file input, make the `Browse` button visible/stable, and add a share-browser modal with controls to navigate into child directories, go up, and select a directory into the `subdirectory` input. 
- Added a new backend handler `admin_library_share_directories` in `docker/core/mkwebaxum/src/admin/bp_library.rs` that accepts a `share_guid` and optional `path`, validates `Admin::View` rights, sanitizes the path (rejects `..`), uses `smbclient -g` (via `tokio::process::Command`) to list directories, and returns a JSON `ShareDirectoryBrowseResponse` with `current_path`, `parent_path`, and `directories`.
- Registered the new route at `/admin/library/share_directories` in `docker/core/mkwebaxum/src/main.rs` and wired the frontend modal to call it, parse the JSON, and populate the form input when a directory is selected.
- Kept behavior minimal and non-destructive by only changing the admin library page and adding a single read-only backend endpoint; share enumeration is read-only and path traversal is prevented.

### Testing
- Ran `cargo fmt` in `docker/core/mkwebaxum` and it completed successfully. 
- Attempted `cargo check` and `cargo clippy -- -D warnings` in the same package but both failed due to the environment using a private crate registry that returned HTTP 403 (network/registry access issue), not due to local code errors. 
- Manual inspection: verified template JS calls the new endpoint and that the server handler parses `smbclient -g` output into directory names and returns JSON (no automated unit tests added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d83c9b03c48321ac9817144cb6f9d8)