### PR TITLE
Log full smbclient failure details in admin library browse

### DIFF
--- a/docker/core/mkwebaxum/src/admin/bp_library.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_library.rs
@@ -345,7 +345,8 @@ pub async fn admin_library_share_directories(
 
     let smb_output = match smb_command.output().await {
         Ok(data) => data,
-        Err(_) => {
+        Err(error) => {
+            println!("smbclient execution failed: {error:?}");
             return (
                 StatusCode::BAD_GATEWAY,
                 Json(json!({"error": "Unable to run smbclient"})),
@@ -355,6 +356,11 @@ pub async fn admin_library_share_directories(
 
     if smb_output.status.success() == false {
         let stderr_output = String::from_utf8_lossy(&smb_output.stderr).to_string();
+        println!(
+            "smbclient failed with status {:?}, stderr: {}",
+            smb_output.status.code(),
+            stderr_output
+        );
         return (
             StatusCode::BAD_GATEWAY,
             Json(json!({"error": "Failed to list share directories", "details": stderr_output})),


### PR DESCRIPTION
### Motivation
- Improve visibility into SMB command failures when browsing share directories so operators can diagnose why `smbclient` failed to start or returned an error.

### Description
- Updated `docker/core/mkwebaxum/src/admin/bp_library.rs` in `admin_library_share_directories` to print the full execution `Err` (`Debug`) when `smbclient` fails to start. 
- Added a log that prints the `smbclient` exit status code and captured `stderr` when the process runs but exits with a non-success status. 
- Kept existing behavior of returning `StatusCode::BAD_GATEWAY` and the same JSON error payloads to callers.

### Testing
- Ran `cargo fmt --check` (in repo subpackage); this failed due to pre-existing formatting differences in many unrelated files. 
- Ran `cargo check -p mkwebaxum` (in `docker/core`); this failed due to blocked crates registry access (HTTP 403 from the configured registry), preventing a full compilation check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85bbab9648321a0a6ec23664de3d8)