### PR TITLE
Fix mkwebaxum Docker multi-stage artifact paths

### DIFF
--- a/docker/core/mkwebaxum/Dockerfile
+++ b/docker/core/mkwebaxum/Dockerfile
@@ -31,6 +31,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=/usr/local/cargo/git \
   --mount=type=cache,target=/mediakraken/target \
   cargo build --release --target x86_64-unknown-linux-musl \
+  && mkdir -p /mediakraken/deps \
   && cp /mediakraken/target/x86_64-unknown-linux-musl/release/mkwebapp /mediakraken/mkwebapp \
   && ldd /mediakraken/mkwebapp | tr -s '[:blank:]' '\n' | grep '^/' | \
   xargs -I % sh -c 'mkdir -p $(dirname /mediakraken/deps%); cp % /mediakraken/deps%;'
@@ -42,7 +43,7 @@ FROM scratch
 # otherwise throws file not found error
 ADD alpine-minirootfs-x86_64.tar.gz /
 # deps has full /usr/lib/x86_64-linux-gnu path.....hence copy to /
-COPY --from=cargo-build-mkwebapp /mediakraken/deps/* /
+COPY --from=cargo-build-mkwebapp /mediakraken/deps/ /
 
 WORKDIR /mediakraken
 

--- a/docker/core/mkwebaxum/Dockerfile
+++ b/docker/core/mkwebaxum/Dockerfile
@@ -31,8 +31,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
   --mount=type=cache,target=/usr/local/cargo/git \
   --mount=type=cache,target=/mediakraken/target \
   cargo build --release --target x86_64-unknown-linux-musl \
-  && cp /mediakraken/target/x86_64-unknown-linux-musl/release/mk* /mediakraken/target/.;
-RUN ldd /mediakraken/target/mkwebapp | tr -s '[:blank:]' '\n' | grep '^/' | \
+  && cp /mediakraken/target/x86_64-unknown-linux-musl/release/mkwebapp /mediakraken/mkwebapp \
+  && ldd /mediakraken/mkwebapp | tr -s '[:blank:]' '\n' | grep '^/' | \
   xargs -I % sh -c 'mkdir -p $(dirname /mediakraken/deps%); cp % /mediakraken/deps%;'
 
 ####################################################################################################
@@ -58,7 +58,7 @@ COPY --from=cargo-build-mkwebapp /mediakraken/templates /mediakraken/templates
 COPY --from=cargo-build-mkwebapp /mediakraken/static /mediakraken/static
 
 # Copy our build
-COPY --from=cargo-build-mkwebapp /mediakraken/target/mkwebapp /mediakraken/mkwebapp
+COPY --from=cargo-build-mkwebapp /mediakraken/mkwebapp /mediakraken/mkwebapp
 
 # Use an unprivileged user.
 USER mediakraken:mediakraken


### PR DESCRIPTION
### Motivation

- The BuildKit cache-mounted `/mediakraken/target` was not persisted between stages, causing `COPY --from` failures for the `mkwebapp` binary and for `/mediakraken/deps` in the final image. 
- Persist the built binary and collect its shared-library dependencies from a non-cache path so the final stage can reliably copy artifacts.

### Description

- Updated the cargo build `RUN` step in `docker/core/mkwebaxum/Dockerfile` to copy the built `mkwebapp` binary to `/mediakraken/mkwebapp` and run `ldd` against that persisted path to populate `/mediakraken/deps` in the same step. 
- Replaced the final-stage `COPY` that used `/mediakraken/target/mkwebapp` with a `COPY` from `/mediakraken/mkwebapp` so the final image reads from the persisted artifact. 
- File modified: `docker/core/mkwebaxum/Dockerfile`.

### Testing

- Located and inspected Dockerfile occurrences with `rg` and reviewed the file with `nl -ba` to confirm the build and copy lines were updated, which succeeded. 
- Applied the patch to `docker/core/mkwebaxum/Dockerfile` and validated the patch tool reported success and the file now contains the new `cp`/`ldd` sequence and updated `COPY` paths. 
- No container/image build was executed as part of these automated edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbfa8553a48321a9cdc6839366f32e)