### PR TITLE
Replace stdout prints with structured tracing logs and add tracing dependency

### DIFF
--- a/docker/core/mkwebaxum/Cargo.toml
+++ b/docker/core/mkwebaxum/Cargo.toml
@@ -75,6 +75,7 @@ sqlx = { version = "0.8.6", features = [
 stdext = "0.3.3"
 sys-info = "0.9.1"
 tokio = { version = "1.49.0", features = ["full"] }
+tracing = "0.1.41"
 tower = { version = "0.5.3", features = ["retry", "timeout", "util"] }
 tower-http = { version = "0.6.8", features = ["fs", "set-header"] }
 tower-sessions = "0.14.0"

--- a/docker/core/mkwebaxum/Cargo.toml
+++ b/docker/core/mkwebaxum/Cargo.toml
@@ -76,6 +76,7 @@ stdext = "0.3.3"
 sys-info = "0.9.1"
 tokio = { version = "1.49.0", features = ["full"] }
 tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 tower = { version = "0.5.3", features = ["retry", "timeout", "util"] }
 tower-http = { version = "0.6.8", features = ["fs", "set-header"] }
 tower-sessions = "0.14.0"

--- a/docker/core/mkwebaxum/src/admin/bp_library.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_library.rs
@@ -1,12 +1,12 @@
-use crate::mk_lib_database;
 use crate::AppState;
+use crate::mk_lib_database;
 use askama::Template;
 use axum::extract::{Form, State};
 use axum::{
+    Extension, Json,
     extract::{Path, Query},
     http::{Method, StatusCode},
     response::{Html, IntoResponse, Redirect},
-    Extension, Json,
 };
 use axum_flash::Flash;
 use axum_session::{SessionConfig, SessionLayer};
@@ -14,10 +14,10 @@ use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use mk_lib_rabbitmq;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use sqlx::postgres::PgPool;
 use tokio::process::Command;
-use std::io::{self, Write};
+use tracing::{error, info};
 
 #[derive(Template)]
 #[template(path = "bss_error/bss_error_403.html")]
@@ -304,8 +304,7 @@ pub async fn admin_library_share_directories(
     auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
     Query(query): Query<ShareDirectoryBrowseQuery>,
 ) -> impl IntoResponse {
-    println!("Share ir");
-    io::stdout().flush().unwrap();
+    info!("Browsing share directories request received");
     let current_user = auth.current_user.clone().unwrap_or_default();
     if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
         [Method::GET],
@@ -320,8 +319,7 @@ pub async fn admin_library_share_directories(
             Json(json!({"error": "Not authorized"})),
         );
     }
-    println!("Share ir3");
-    io::stdout().flush().unwrap();
+    info!("Share directory request authorized");
     let share_info =
         match mk_lib_database::mk_lib_database_network_share::mk_lib_database_network_share_detail(
             &state.sqlx_pool_ro,
@@ -337,8 +335,7 @@ pub async fn admin_library_share_directories(
                 );
             }
         };
-    println!("Share info: {:?}", share_info);
-    io::stdout().flush().unwrap();
+    info!(share_guid = %query.share_guid, "Loaded share details for directory browse");
     let requested_path = query.path.unwrap_or_default();
     let cleaned_path = requested_path
         .trim()
@@ -383,7 +380,9 @@ pub async fn admin_library_share_directories(
             smb_command.arg("-W").arg(workgroup);
         }
     }
-    if let Some(user) = share_info.mm_share_auth_user.as_deref() && user != "guest" {
+    if let Some(user) = share_info.mm_share_auth_user.as_deref()
+        && user != "guest"
+    {
         let pass = share_info
             .mm_share_auth_password
             .as_deref()
@@ -392,12 +391,11 @@ pub async fn admin_library_share_directories(
     } else {
         smb_command.arg("-N");
     }
-    println!("Running smbclient command: {:?}", smb_command);
-    io::stdout().flush().unwrap();
+    info!(?smb_command, "Running smbclient directory listing command");
     let smb_output = match smb_command.output().await {
         Ok(data) => data,
         Err(error) => {
-            eprintln!("smbclient execution failed: {error:?}");
+            error!(?error, "smbclient execution failed");
             return (
                 StatusCode::BAD_GATEWAY,
                 Json(json!({"error": "Unable to run smbclient"})),
@@ -415,13 +413,12 @@ pub async fn admin_library_share_directories(
         };
         let (status_code, error_message) =
             classify_smbclient_browse_error(&stdout_output, &stderr_output);
-        eprintln!(
-            "smbclient failed with status {:?}, stdout: {}, stderr: {}",
-            smb_output.status.code(),
-            stdout_output,
-            stderr_output
+        error!(
+            status_code = ?smb_output.status.code(),
+            stdout = %stdout_output,
+            stderr = %stderr_output,
+            "smbclient failed"
         );
-        io::stdout().flush().unwrap();
         return (
             status_code,
             Json(json!({"error": error_message, "details": details_output})),

--- a/docker/core/mkwebaxum/src/main.rs
+++ b/docker/core/mkwebaxum/src/main.rs
@@ -44,6 +44,7 @@ use tower::timeout::TimeoutLayer;
 use tower::{ServiceBuilder, timeout::error::Elapsed};
 use tower_http::services::{ServeDir, ServeFile};
 use tower_http::set_header::SetResponseHeaderLayer;
+use tracing_subscriber::{EnvFilter, fmt};
 
 type Client = hyper_util::client::legacy::Client<HttpConnector, Body>;
 mod axum_custom_filters;
@@ -162,6 +163,12 @@ impl FromRef<AppState> for axum_flash::Config {
 
 #[tokio::main]
 async fn main() {
+    fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
     // connect to db and do a version check
     let (sqlx_pool_rw, sqlx_pool_ro) =
         mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120)


### PR DESCRIPTION
### Motivation
- Improve observability and replace ad-hoc `println!`/`eprintln!` debugging with structured logging for production readiness.
- Use the `tracing` ecosystem to produce contextual log messages for SMB client operations and errors.

### Description
- Add `tracing = "0.1.41"` to `docker/core/mkwebaxum/Cargo.toml` to enable structured logging.
- Import `tracing::{error, info}` and replace `println!`, `eprintln!` and `io::stdout().flush()` calls with `info!` and `error!` calls in `docker/core/mkwebaxum/src/admin/bp_library.rs` for better log semantics.
- Log the constructed `smbclient` command and include stdout/stderr and exit status in error logs for failed executions.
- Minor reordering and cleanup of `use` statements and formatting adjustments to an `if let` condition and `serde_json` imports.

### Testing
- Ran `cargo build` for the `mkwebaxum` crate to verify compilation with the new dependency, and the build completed successfully.
- Ran `cargo test` for the crate and existing automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc323b9d0c8321ad3602609906cd90)