### PR TITLE
Use EnvFilter for tracing subscriber configuration

### DIFF
--- a/docker/core/mkwebaxum/src/main.rs
+++ b/docker/core/mkwebaxum/src/main.rs
@@ -44,8 +44,7 @@ use tower::timeout::TimeoutLayer;
 use tower::{ServiceBuilder, timeout::error::Elapsed};
 use tower_http::services::{ServeDir, ServeFile};
 use tower_http::set_header::SetResponseHeaderLayer;
-use tracing::Level;
-use tracing_subscriber::{filter::Targets, fmt, prelude::*, registry::Registry};
+use tracing_subscriber::{EnvFilter, fmt, prelude::*, registry::Registry};
 
 type Client = hyper_util::client::legacy::Client<HttpConnector, Body>;
 mod axum_custom_filters;
@@ -169,10 +168,7 @@ async fn main() {
             fmt::layer()
                 .with_target(true)
                 .with_ansi(false)
-                .with_filter(
-                    Targets::new()
-                        .with_target("mkwebapp", Level::TRACE),
-                ),
+                .with_filter(EnvFilter::builder().parse_lossy("mkwebapp=trace")),
         )
         .init();
     tracing::info!("App start");


### PR DESCRIPTION
### Motivation
- Simplify and modernize tracing filter configuration by replacing the older `Targets`/`Level` usage with `EnvFilter` for setting `mkwebapp` log level.

### Description
- Replace imports `tracing::Level` and `tracing_subscriber::filter::Targets` with `tracing_subscriber::EnvFilter` and update the `fmt` layer to use `.with_filter(EnvFilter::builder().parse_lossy("mkwebapp=trace"))` in `docker/core/mkwebaxum/src/main.rs`.

### Testing
- Ran `cargo build` for the project and the build completed successfully.
- Ran `cargo test` and the test suite completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd8ae25e4c832184e921219428b7f9)