### PR TITLE
Fix Loki read query to include all mediakraken jobs

### DIFF
--- a/src/mk_lib_logging/src/mk_lib_logging_loki.rs
+++ b/src/mk_lib_logging/src/mk_lib_logging_loki.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use reqwest::Client;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
-use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
+use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
 use serde::Deserialize;
 use serde_json::json;
 use std::collections::HashMap;
@@ -9,8 +9,7 @@ use std::env;
 use std::sync::OnceLock;
 use tokio::time::Duration;
 
-const LOKI_PUSH_URL: &str =
-    "http://loki.monitoring.svc.mkcluster.local:3100/loki/api/v1/push";
+const LOKI_PUSH_URL: &str = "http://loki.monitoring.svc.mkcluster.local:3100/loki/api/v1/push";
 const LOKI_QUERY_URL: &str =
     "http://loki.monitoring.svc.mkcluster.local:3100/loki/api/v1/query_range";
 
@@ -145,13 +144,23 @@ fn stream_to_logql(labels: &HashMap<String, String>) -> String {
     format!("{{{}}}", stream_labels_to_string(labels))
 }
 
+fn escape_logql_string(value: &str) -> String {
+    value.replace('\\', r#"\\"#).replace('"', r#"\""#)
+}
+
 pub async fn mk_logging_loki_read(
     message_type: &str,
 ) -> Result<Vec<LokiLog>, Box<dyn std::error::Error>> {
+    let now_ns = Utc::now()
+        .timestamp_nanos_opt()
+        .ok_or("failed to generate nanosecond timestamp")?;
+    let start_ns = now_ns - (24 * 60 * 60 * 1_000_000_000_i64);
+
     let query = if message_type.is_empty() {
-        r#"{job="mediakraken"}"#.to_string()
+        r#"{job=~"mediakraken.*"}"#.to_string()
     } else {
-        format!(r#"{{job="mediakraken"}} |= "{}""#, message_type)
+        let escaped_message_type = escape_logql_string(message_type);
+        format!(r#"{{job=~"mediakraken.*"}} |= "{}""#, escaped_message_type)
     };
 
     let resp: LokiResponse = query_client()
@@ -160,6 +169,8 @@ pub async fn mk_logging_loki_read(
             ("query", query.as_str()),
             ("limit", "100"),
             ("direction", "backward"),
+            ("start", &start_ns.to_string()),
+            ("end", &now_ns.to_string()),
         ])
         .send()
         .await?


### PR DESCRIPTION
### Motivation
- Loki can host multiple MediaKraken jobs with different `job` label values, and the previous exact-match query (`job="mediakraken"`) missed logs from other mediakraken-* jobs. 
- The `query_range` call previously relied on backend defaults for time bounds which can miss recent logs or return unexpected ranges. 
- Unescaped user-provided `message_type` could produce malformed LogQL when it contains quotes or backslashes.

### Description
- Change the LogQL selector to a regex matcher `job=~"mediakraken.*"` so all mediakraken-prefixed jobs are included. 
- Add `start` and `end` nanosecond timestamp parameters (now and now - 24h) to the `query_range` request to constrain reads to the last 24 hours. 
- Add `escape_logql_string` to escape `"` and `\` in `message_type` before embedding it in the LogQL filter. 
- Minor stylistic import and constant formatting adjustments in `src/mk_lib_logging/src/mk_lib_logging_loki.rs`.

### Testing
- Ran `cargo fmt` in `src/mk_lib_logging` and it completed successfully. 
- Ran `cargo check` in `src/mk_lib_logging` but it was blocked by the configured crate registry returning HTTP 403 for `config.json` (external registry access issue), so full compilation verification could not complete. 
- Ran `cargo clippy -- -D warnings` in `src/mk_lib_logging` but it was likewise blocked by the external registry `403 Forbidden` error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dee73061008321955130d34d38b68f)