### PR TITLE
Add optional Authy 2FA to mkwebapp login

### DIFF
--- a/docker/core/mkwebaxum/src/public/bp_login.rs
+++ b/docker/core/mkwebaxum/src/public/bp_login.rs
@@ -8,6 +8,7 @@ use axum::{
 use axum_flash::{Flash, IncomingFlashes};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
+use reqwest::StatusCode;
 use serde::Deserialize;
 use sqlx::postgres::PgPool;
 
@@ -17,6 +18,11 @@ struct LoginTemplate {
     flash_messages: Vec<String>,
 }
 
+#[derive(Deserialize)]
+struct AuthyVerifyResponse {
+    success: Option<String>,
+}
+
 pub async fn public_login(flashes: IncomingFlashes) -> impl IntoResponse {
     let template = LoginTemplate {
         flash_messages: flashes
@@ -24,14 +30,39 @@ pub async fn public_login(flashes: IncomingFlashes) -> impl IntoResponse {
             .map(|(_, message)| message.to_string())
             .collect(),
     };
-    let reply_html = template.render().unwrap();
-    (flashes, Html(reply_html))
+
+    match template.render() {
+        Ok(reply_html) => (flashes, Html(reply_html)).into_response(),
+        Err(_) => Redirect::to("/public/login").into_response(),
+    }
 }
 
 #[derive(Deserialize)]
 pub struct LoginInput {
     username: String,
     password: String,
+    authy_token: Option<String>,
+}
+
+async fn verify_authy_token(authy_id: &str, authy_token: &str, api_key: &str) -> bool {
+    let verify_url = format!(
+        "https://api.authy.com/protected/json/verify/{}/{}/?api_key={}",
+        authy_token, authy_id, api_key
+    );
+
+    let response = match reqwest::Client::new().get(&verify_url).send().await {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+
+    if response.status() != StatusCode::OK {
+        return false;
+    }
+
+    match response.json::<AuthyVerifyResponse>().await {
+        Ok(payload) => payload.success.as_deref() == Some("true"),
+        Err(_) => false,
+    }
 }
 
 pub async fn public_login_post(
@@ -41,15 +72,53 @@ pub async fn public_login_post(
     Form(input_data): Form<LoginInput>,
 ) -> (Flash, Redirect) {
     let user_id: i64 =
-        mk_lib_database::mk_lib_database_user::mk_lib_database_user_login_verification(
+        match mk_lib_database::mk_lib_database_user::mk_lib_database_user_login_verification(
             &state.sqlx_pool_rw,
             &input_data.username,
             &input_data.password,
         )
         .await
-        .unwrap();
+        {
+            Ok(value) => value,
+            Err(_) => {
+                return (
+                    flash.error("Unable to verify login request. Please try again."),
+                    Redirect::to("/public/login"),
+                );
+            }
+        };
+
     if user_id > 0 {
-        println!("Login User {:?}", user_id);
+        let authy_id = mk_lib_database::mk_lib_database_user::mk_lib_database_user_authy_id(
+            &state.sqlx_pool_rw,
+            user_id,
+        )
+        .await
+        .ok()
+        .flatten();
+
+        if let Some(authy_user_id) = authy_id {
+            let authy_api_key = std::env::var("MKWEBAPP_AUTHY_API_KEY").ok();
+            if let Some(api_key) = authy_api_key {
+                let submitted_token = input_data.authy_token.unwrap_or_default();
+                if submitted_token.trim().is_empty() {
+                    return (
+                        flash.error("2FA code is required for this account."),
+                        Redirect::to("/public/login"),
+                    );
+                }
+
+                let token_valid =
+                    verify_authy_token(&authy_user_id, submitted_token.trim(), &api_key).await;
+                if !token_valid {
+                    return (
+                        flash.error("Invalid 2FA code."),
+                        Redirect::to("/public/login"),
+                    );
+                }
+            }
+        }
+
         let _result = mk_lib_database::mk_lib_database_user::mk_lib_database_user_login(
             &state.sqlx_pool_rw,
             user_id,

--- a/docker/core/mkwebaxum/templates/bss_public/bss_public_login.html
+++ b/docker/core/mkwebaxum/templates/bss_public/bss_public_login.html
@@ -60,6 +60,17 @@
                      focus:outline-none focus:ring-2 focus:ring-indigo-500"
             >
 
+            <input
+              type="text"
+              name="authy_token"
+              inputmode="numeric"
+              pattern="[0-9]*"
+              autocomplete="one-time-code"
+              placeholder="2FA Code (if enabled)"
+              class="w-full rounded-lg border border-gray-300 px-4 py-2
+                     focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            >
+
             <button
               type="submit"
               class="w-full bg-indigo-600 hover:bg-indigo-700

--- a/src/mk_lib_database/src/mk_lib_database_user.rs
+++ b/src/mk_lib_database/src/mk_lib_database_user.rs
@@ -3,8 +3,8 @@ use axum_session_auth::Authentication;
 use axum_session_auth::*;
 use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
-use sqlx::postgres::PgPool;
 use sqlx::FromRow;
+use sqlx::postgres::PgPool;
 use std::collections::HashSet;
 
 /*
@@ -261,6 +261,41 @@ pub async fn mk_lib_database_user_login(
         .await?;
     transaction.commit().await?;
     Ok(())
+}
+
+pub async fn mk_lib_database_user_authy_id(
+    sqlx_pool: &sqlx::PgPool,
+    user_id: i64,
+) -> Result<Option<String>, sqlx::Error> {
+    let has_authy_column: (bool,) = sqlx::query_as(
+        r#"select exists(
+            select 1
+            from information_schema.columns
+            where table_schema = 'public'
+                and table_name = 'mm_axum_users'
+                and column_name = 'authy_id'
+        )"#,
+    )
+    .fetch_one(sqlx_pool)
+    .await?;
+
+    if !has_authy_column.0 {
+        return Ok(None);
+    }
+
+    let authy_id: (Option<String>,) =
+        sqlx::query_as(r#"select authy_id::text from mm_axum_users where id = $1 limit 1"#)
+            .bind(user_id)
+            .fetch_one(sqlx_pool)
+            .await?;
+
+    Ok(authy_id.0.and_then(|value| {
+        if value.trim().is_empty() {
+            None
+        } else {
+            Some(value)
+        }
+    }))
 }
 
 pub async fn mk_lib_database_user_logout(


### PR DESCRIPTION
### Motivation

- Provide optional per-user 2FA using Authy while keeping login behavior unchanged for deployments that do not enable 2FA. 
- Make 2FA opt-in at the user level (via an `authy_id` column) and opt-in at deployment level via an API key to avoid unexpected breakage. 
- Avoid breaking installs that do not have the `mm_axum_users.authy_id` column by detecting its presence before querying it.

### Description

- Added `mk_lib_database_user_authy_id(sqlx_pool, user_id) -> Result<Option<String>, sqlx::Error>` which first checks `information_schema.columns` for `mm_axum_users.authy_id` and safely returns `None` when the column or value is absent. 
- Updated the login handler in `public_login_post` to: first validate username/password, then if the user has an `authy_id` and the environment variable `MKWEBAPP_AUTHY_API_KEY` is present require and verify a submitted Authy 2FA code using Authy REST verify API. 
- Added `authy_token` to the public login form template and included a numeric, `autocomplete="one-time-code"` input so users can submit their OTP when required. 
- Improved error handling in `public_login` and password verification to avoid `unwrap()` and return safe flash/redirect flows on failure. 
- No database migration files were added or modified; the DB helper intentionally tolerates the absence of the `authy_id` column.

### Testing

- Ran `cargo fmt` in `docker/core/mkwebaxum`, which completed successfully. 
- Ran `cargo check` in `docker/core/mkwebaxum`, which failed in this environment due to a private registry returning HTTP 403 (network/private-registry issue unrelated to the change). 
- Ran `cargo clippy -- -D warnings` in `docker/core/mkwebaxum`, which also failed due to the same private registry 403 in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14cfb5d3883219fc204e2a9e2ea25)