### PR TITLE
mk_lib_network: add AWS SMTP (SES) email helpers

### DIFF
--- a/src/mk_lib_network/src/lib.rs
+++ b/src/mk_lib_network/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod mk_lib_network;
 pub mod mk_lib_network_dlna;
 pub mod mk_lib_network_email;
+pub mod mk_lib_network_email_aws;
 pub mod mk_lib_network_external_ip;
 pub mod mk_lib_network_ftp;
 #[cfg(feature = "infiniband")]

--- a/src/mk_lib_network/src/mk_lib_network_email_aws.rs
+++ b/src/mk_lib_network/src/mk_lib_network_email_aws.rs
@@ -1,0 +1,48 @@
+use lettre::transport::smtp::authentication::Credentials;
+use lettre::{Message, SmtpTransport, Transport};
+
+pub fn mk_lib_network_email_aws_transport(
+    aws_region: &str,
+    aws_access_key_id: &str,
+    aws_secret_access_key: &str,
+) -> Result<SmtpTransport, Box<dyn std::error::Error>> {
+    let smtp_endpoint = format!("email-smtp.{}.amazonaws.com", aws_region);
+    let creds = Credentials::new(
+        aws_access_key_id.to_string(),
+        aws_secret_access_key.to_string(),
+    );
+
+    let mailer = SmtpTransport::relay(&smtp_endpoint)?
+        .credentials(creds)
+        .port(587)
+        .build();
+
+    Ok(mailer)
+}
+
+pub async fn mk_lib_network_email_send_aws(
+    email_from: String,
+    email_reply_to: String,
+    email_to: String,
+    email_subject: String,
+    email_body: String,
+    aws_region: String,
+    aws_access_key_id: String,
+    aws_secret_access_key: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let email = Message::builder()
+        .from(email_from.parse()?)
+        .reply_to(email_reply_to.parse()?)
+        .to(email_to.parse()?)
+        .subject(email_subject)
+        .body(email_body)?;
+
+    let mailer = mk_lib_network_email_aws_transport(
+        &aws_region,
+        &aws_access_key_id,
+        &aws_secret_access_key,
+    )?;
+
+    mailer.send(&email)?;
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable helper to send email via AWS SES SMTP endpoints from `mk_lib_network` without using `unwrap`/`expect`.
- Keep email sending logic separate from the existing `mk_lib_network_email` Gmail helper and expose an AWS-specific transport for code that needs SES SMTP.

### Description
- Added a new module `mk_lib_network_email_aws` at `src/mk_lib_network/src/mk_lib_network_email_aws.rs` that implements `mk_lib_network_email_aws_transport(...)` to build an SMTP transport for `email-smtp.<region>.amazonaws.com` on port `587` and `mk_lib_network_email_send_aws(...)` to build and send a `lettre::Message` using provided AWS SMTP credentials.
- Exported the new module from `src/mk_lib_network/src/lib.rs` by adding `pub mod mk_lib_network_email_aws;` so the helpers are publicly available.
- New functions return `Result` and propagate errors instead of panicking, following the project error-handling guidance.

### Testing
- Ran formatting on modified files with `rustfmt --edition 2024 src/mk_lib_network/src/mk_lib_network_email_aws.rs src/mk_lib_network/src/lib.rs` which succeeded.
- Attempted `cargo fmt`, `cargo check`, and `cargo clippy -- -D warnings` for the crate using `--manifest-path src/mk_lib_network/Cargo.toml`, but these failed in this environment because the custom registry `kellnr` referenced in the crate manifest is not available. No crate-level compilation/lint results could be produced for that reason.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14e943fe883219d2a0e81f257ba6f)