### PR TITLE
mkwebapp: add optional Microsoft AD login support

### DIFF
--- a/docker/core/mkwebaxum/Cargo.toml
+++ b/docker/core/mkwebaxum/Cargo.toml
@@ -52,6 +52,7 @@ hyper = { version = "1.8.1", features = ["full"] }
 hyper-util = { version = "0.1.19", features = ["client-legacy"] }
 ipnetwork = "0.21.1"
 lazy_static = "1.5.0"
+ldap3 = { version = "0.12.1", default-features = false, features = ["tls-native"] }
 libc = "0.2.180"
 num-format = { version = "0.4.4", features = ["with-system-locale"] }
 paginator = "0.2.6"

--- a/docker/core/mkwebaxum/src/public/bp_login.rs
+++ b/docker/core/mkwebaxum/src/public/bp_login.rs
@@ -99,28 +99,41 @@ async fn ms_ad_login_verification(username: &str, password: &str) -> bool {
     login_valid
 }
 
-async fn ensure_local_ms_ad_user(
+fn ms_ad_auto_provision_enabled() -> bool {
+    matches!(
+        std::env::var("MKWEBAPP_MS_AD_AUTO_PROVISION")
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+async fn fetch_local_user_id(
     sqlx_pool: &sqlx::PgPool,
     username: &str,
-) -> Result<i64, sqlx::Error> {
+) -> Result<Option<i64>, sqlx::Error> {
     let row: Option<(i64,)> =
         sqlx::query_as("select id from mm_axum_users where username = $1 limit 1")
             .bind(username)
             .fetch_optional(sqlx_pool)
             .await?;
 
-    let user_id = if let Some((id,)) = row {
-        id
-    } else {
-        let username_owned = username.to_string();
-        let generated_password = uuid::Uuid::new_v4().to_string();
-        mk_lib_database::mk_lib_database_user::mk_lib_database_user_insert(
-            sqlx_pool,
-            &username_owned,
-            &generated_password,
-        )
-        .await?
-    };
+    Ok(row.map(|(id,)| id))
+}
+
+async fn provision_local_ms_ad_user(
+    sqlx_pool: &sqlx::PgPool,
+    username: &str,
+) -> Result<i64, sqlx::Error> {
+    let username_owned = username.to_string();
+    let generated_password = uuid::Uuid::new_v4().to_string();
+    let user_id = mk_lib_database::mk_lib_database_user::mk_lib_database_user_insert(
+        sqlx_pool,
+        &username_owned,
+        &generated_password,
+    )
+    .await?;
 
     sqlx::query(
         r#"insert into mm_axum_user_permissions (user_id, token)
@@ -135,6 +148,22 @@ async fn ensure_local_ms_ad_user(
     .await?;
 
     Ok(user_id)
+}
+
+async fn resolve_local_ms_ad_user(
+    sqlx_pool: &sqlx::PgPool,
+    username: &str,
+) -> Result<Option<i64>, sqlx::Error> {
+    if let Some(user_id) = fetch_local_user_id(sqlx_pool, username).await? {
+        return Ok(Some(user_id));
+    }
+
+    if ms_ad_auto_provision_enabled() {
+        let user_id = provision_local_ms_ad_user(sqlx_pool, username).await?;
+        Ok(Some(user_id))
+    } else {
+        Ok(None)
+    }
 }
 
 pub async fn public_login_post(
@@ -159,8 +188,10 @@ pub async fn public_login_post(
             ms_ad_login_verification(&input_data.username, &input_data.password).await;
         if ad_login_valid {
             let local_username = local_username_for_ad(&input_data.username);
-            user_id = ensure_local_ms_ad_user(&state.sqlx_pool_rw, &local_username)
+            user_id = resolve_local_ms_ad_user(&state.sqlx_pool_rw, &local_username)
                 .await
+                .ok()
+                .flatten()
                 .unwrap_or(0);
         }
     }

--- a/docker/core/mkwebaxum/src/public/bp_login.rs
+++ b/docker/core/mkwebaxum/src/public/bp_login.rs
@@ -33,8 +33,6 @@ pub async fn public_login(flashes: IncomingFlashes) -> impl IntoResponse {
 pub struct LoginInput {
     username: String,
     password: String,
-    #[serde(default)]
-    use_ms_ad: bool,
 }
 
 fn ms_ad_enabled() -> bool {
@@ -99,16 +97,6 @@ async fn ms_ad_login_verification(username: &str, password: &str) -> bool {
     login_valid
 }
 
-fn ms_ad_auto_provision_enabled() -> bool {
-    matches!(
-        std::env::var("MKWEBAPP_MS_AD_AUTO_PROVISION")
-            .unwrap_or_default()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
-}
-
 async fn fetch_local_user_id(
     sqlx_pool: &sqlx::PgPool,
     username: &str,
@@ -120,50 +108,6 @@ async fn fetch_local_user_id(
             .await?;
 
     Ok(row.map(|(id,)| id))
-}
-
-async fn provision_local_ms_ad_user(
-    sqlx_pool: &sqlx::PgPool,
-    username: &str,
-) -> Result<i64, sqlx::Error> {
-    let username_owned = username.to_string();
-    let generated_password = uuid::Uuid::new_v4().to_string();
-    let user_id = mk_lib_database::mk_lib_database_user::mk_lib_database_user_insert(
-        sqlx_pool,
-        &username_owned,
-        &generated_password,
-    )
-    .await?;
-
-    sqlx::query(
-        r#"insert into mm_axum_user_permissions (user_id, token)
-            select $1, $2
-            where not exists (
-                select 1 from mm_axum_user_permissions where user_id = $1 and token = $2
-            )"#,
-    )
-    .bind(user_id)
-    .bind("User::View")
-    .execute(sqlx_pool)
-    .await?;
-
-    Ok(user_id)
-}
-
-async fn resolve_local_ms_ad_user(
-    sqlx_pool: &sqlx::PgPool,
-    username: &str,
-) -> Result<Option<i64>, sqlx::Error> {
-    if let Some(user_id) = fetch_local_user_id(sqlx_pool, username).await? {
-        return Ok(Some(user_id));
-    }
-
-    if ms_ad_auto_provision_enabled() {
-        let user_id = provision_local_ms_ad_user(sqlx_pool, username).await?;
-        Ok(Some(user_id))
-    } else {
-        Ok(None)
-    }
 }
 
 pub async fn public_login_post(
@@ -183,12 +127,12 @@ pub async fn public_login_post(
 
     let mut user_id = local_login_result;
 
-    if user_id <= 0 && input_data.use_ms_ad {
+    if user_id <= 0 {
         let ad_login_valid =
             ms_ad_login_verification(&input_data.username, &input_data.password).await;
         if ad_login_valid {
             let local_username = local_username_for_ad(&input_data.username);
-            user_id = resolve_local_ms_ad_user(&state.sqlx_pool_rw, &local_username)
+            user_id = fetch_local_user_id(&state.sqlx_pool_rw, &local_username)
                 .await
                 .ok()
                 .flatten()

--- a/docker/core/mkwebaxum/src/public/bp_login.rs
+++ b/docker/core/mkwebaxum/src/public/bp_login.rs
@@ -8,6 +8,7 @@ use axum::{
 use axum_flash::{Flash, IncomingFlashes};
 use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
+use ldap3::LdapConnAsync;
 use serde::Deserialize;
 use sqlx::postgres::PgPool;
 
@@ -32,6 +33,108 @@ pub async fn public_login(flashes: IncomingFlashes) -> impl IntoResponse {
 pub struct LoginInput {
     username: String,
     password: String,
+    #[serde(default)]
+    use_ms_ad: bool,
+}
+
+fn ms_ad_enabled() -> bool {
+    matches!(
+        std::env::var("MKWEBAPP_MS_AD_ENABLED")
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+fn ms_ad_bind_username(username: &str) -> String {
+    if username.contains('\\') || username.contains('@') {
+        return username.to_string();
+    }
+
+    let domain = std::env::var("MKWEBAPP_MS_AD_DOMAIN").unwrap_or_default();
+    if domain.is_empty() {
+        username.to_string()
+    } else {
+        format!("{username}@{domain}")
+    }
+}
+
+fn local_username_for_ad(username: &str) -> String {
+    if let Some((_, suffix)) = username.split_once('\\') {
+        return suffix.to_string();
+    }
+
+    if let Some((prefix, _)) = username.split_once('@') {
+        return prefix.to_string();
+    }
+
+    username.to_string()
+}
+
+async fn ms_ad_login_verification(username: &str, password: &str) -> bool {
+    if !ms_ad_enabled() || username.is_empty() || password.is_empty() {
+        return false;
+    }
+
+    let ad_url = std::env::var("MKWEBAPP_MS_AD_URL").unwrap_or_default();
+    if ad_url.is_empty() {
+        return false;
+    }
+
+    let bind_username = ms_ad_bind_username(username);
+
+    let Ok((conn, mut ldap)) = LdapConnAsync::new(&ad_url).await else {
+        return false;
+    };
+    ldap3::drive!(conn);
+
+    let login_valid = match ldap.simple_bind(&bind_username, password).await {
+        Ok(result) => result.success().is_ok(),
+        Err(_) => false,
+    };
+
+    let _ = ldap.unbind().await;
+
+    login_valid
+}
+
+async fn ensure_local_ms_ad_user(
+    sqlx_pool: &sqlx::PgPool,
+    username: &str,
+) -> Result<i64, sqlx::Error> {
+    let row: Option<(i64,)> =
+        sqlx::query_as("select id from mm_axum_users where username = $1 limit 1")
+            .bind(username)
+            .fetch_optional(sqlx_pool)
+            .await?;
+
+    let user_id = if let Some((id,)) = row {
+        id
+    } else {
+        let username_owned = username.to_string();
+        let generated_password = uuid::Uuid::new_v4().to_string();
+        mk_lib_database::mk_lib_database_user::mk_lib_database_user_insert(
+            sqlx_pool,
+            &username_owned,
+            &generated_password,
+        )
+        .await?
+    };
+
+    sqlx::query(
+        r#"insert into mm_axum_user_permissions (user_id, token)
+            select $1, $2
+            where not exists (
+                select 1 from mm_axum_user_permissions where user_id = $1 and token = $2
+            )"#,
+    )
+    .bind(user_id)
+    .bind("User::View")
+    .execute(sqlx_pool)
+    .await?;
+
+    Ok(user_id)
 }
 
 pub async fn public_login_post(
@@ -40,14 +143,28 @@ pub async fn public_login_post(
     flash: Flash,
     Form(input_data): Form<LoginInput>,
 ) -> (Flash, Redirect) {
-    let user_id: i64 =
+    let local_login_result =
         mk_lib_database::mk_lib_database_user::mk_lib_database_user_login_verification(
             &state.sqlx_pool_rw,
             &input_data.username,
             &input_data.password,
         )
         .await
-        .unwrap();
+        .unwrap_or(0);
+
+    let mut user_id = local_login_result;
+
+    if user_id <= 0 && input_data.use_ms_ad {
+        let ad_login_valid =
+            ms_ad_login_verification(&input_data.username, &input_data.password).await;
+        if ad_login_valid {
+            let local_username = local_username_for_ad(&input_data.username);
+            user_id = ensure_local_ms_ad_user(&state.sqlx_pool_rw, &local_username)
+                .await
+                .unwrap_or(0);
+        }
+    }
+
     if user_id > 0 {
         println!("Login User {:?}", user_id);
         let _result = mk_lib_database::mk_lib_database_user::mk_lib_database_user_login(

--- a/docker/core/mkwebaxum/templates/bss_public/bss_public_login.html
+++ b/docker/core/mkwebaxum/templates/bss_public/bss_public_login.html
@@ -60,6 +60,16 @@
                      focus:outline-none focus:ring-2 focus:ring-indigo-500"
             >
 
+
+            <label class="flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                name="use_ms_ad"
+                value="true"
+                class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              >
+              Authenticate with Microsoft Active Directory
+            </label>
             <button
               type="submit"
               class="w-full bg-indigo-600 hover:bg-indigo-700

--- a/docker/core/mkwebaxum/templates/bss_public/bss_public_login.html
+++ b/docker/core/mkwebaxum/templates/bss_public/bss_public_login.html
@@ -60,16 +60,6 @@
                      focus:outline-none focus:ring-2 focus:ring-indigo-500"
             >
 
-
-            <label class="flex items-center gap-2 text-sm text-gray-700">
-              <input
-                type="checkbox"
-                name="use_ms_ad"
-                value="true"
-                class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-              >
-              Authenticate with Microsoft Active Directory
-            </label>
             <button
               type="submit"
               class="w-full bg-indigo-600 hover:bg-indigo-700


### PR DESCRIPTION
### Motivation
- Provide an optional Microsoft Active Directory (AD) authentication path for mkwebapp so users can authenticate with corporate AD while preserving the existing local username/password flow.
- Keep the change minimal and opt-in so AD auth is only used when enabled and when the user selects it on the login form.

### Description
- Added AD-related helper functions in `public/login` including `ms_ad_enabled`, `ms_ad_bind_username`, `local_username_for_ad`, `ms_ad_login_verification` (LDAP simple-bind via `ldap3`), and `ensure_local_ms_ad_user` (provisions a local user and ensures `User::View` permission).
- Updated `public_login_post` flow to attempt local verification first, and if that fails and `use_ms_ad` is selected, validate via AD and provision/lookup a local user before logging in the session.
- Added a form checkbox in the login template to allow users to explicitly choose MS AD authentication and updated `LoginInput` to accept `use_ms_ad`.
- Added `ldap3` crate to `docker/core/mkwebaxum/Cargo.toml` and used `uuid` to generate a random password for locally created AD-provisioned users.

### Testing
- Ran `cargo fmt` in `docker/core/mkwebaxum` successfully.
- Attempted `cargo check` and `cargo clippy -- -D warnings` in the environment but both were blocked by registry access (HTTP 403 from the internal Kellnr crates index), so full compile/lint verification could not complete here.
- Manual inspection and local formatting/rustfmt checks were performed on the modified files (`public/bp_login.rs` and the login template).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14d1782c88321b2d11aeb6276d33c)