### PR TITLE
mkwebapp: add optional AD-backed login fallback

### DIFF
--- a/docker/core/mkwebaxum/src/public/bp_login.rs
+++ b/docker/core/mkwebaxum/src/public/bp_login.rs
@@ -10,6 +10,7 @@ use axum_session_auth::*;
 use axum_session_sqlx::SessionPgPool;
 use reqwest::StatusCode;
 use serde::Deserialize;
+use sqlx::Row;
 use sqlx::postgres::PgPool;
 
 #[derive(Template)]
@@ -44,6 +45,57 @@ pub struct LoginInput {
     authy_token: Option<String>,
 }
 
+fn env_flag_enabled(var_name: &str) -> bool {
+    match std::env::var(var_name) {
+        Ok(value) => {
+            let normalized = value.trim().to_ascii_lowercase();
+            matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
+        }
+        Err(_) => false,
+    }
+}
+
+async fn try_ad_login(sqlx_pool: &PgPool, username: &str, password: &str) -> Option<i64> {
+    if password.trim().is_empty() || !env_flag_enabled("MKWEBAPP_AD_LOGIN_ENABLED") {
+        return None;
+    }
+
+    let ldap_ip = match std::env::var("MKWEBAPP_AD_LDAP_IP") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => return None,
+    };
+    let ldap_port = std::env::var("MKWEBAPP_AD_LDAP_PORT").unwrap_or_else(|_| "389".to_string());
+    let ldap_domain = match std::env::var("MKWEBAPP_AD_DOMAIN") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => return None,
+    };
+
+    let bind_username = if username.contains('@') {
+        username.to_string()
+    } else {
+        format!("{}@{}", username, ldap_domain)
+    };
+
+    if mk_lib_network::mk_lib_network_ldap::ldap_bind(ldap_ip, ldap_port, &bind_username, password)
+        .await
+        .is_err()
+    {
+        return None;
+    }
+
+    let query_result = sqlx::query(r#"select id from mm_axum_users where username = $1 limit 1"#)
+        .bind(username)
+        .fetch_optional(sqlx_pool)
+        .await
+        .ok()
+        .flatten();
+
+    match query_result {
+        Some(row) => row.try_get::<i64, _>("id").ok(),
+        None => None,
+    }
+}
+
 async fn verify_authy_token(authy_id: &str, authy_token: &str, api_key: &str) -> bool {
     let verify_url = format!(
         "https://api.authy.com/protected/json/verify/{}/{}/?api_key={}",
@@ -71,7 +123,7 @@ pub async fn public_login_post(
     flash: Flash,
     Form(input_data): Form<LoginInput>,
 ) -> (Flash, Redirect) {
-    let user_id: i64 =
+    let mut user_id: i64 =
         match mk_lib_database::mk_lib_database_user::mk_lib_database_user_login_verification(
             &state.sqlx_pool_rw,
             &input_data.username,
@@ -87,6 +139,16 @@ pub async fn public_login_post(
                 );
             }
         };
+
+    if user_id <= 0 {
+        user_id = try_ad_login(
+            &state.sqlx_pool_rw,
+            &input_data.username,
+            &input_data.password,
+        )
+        .await
+        .unwrap_or(0);
+    }
 
     if user_id > 0 {
         let authy_id = mk_lib_database::mk_lib_database_user::mk_lib_database_user_authy_id(

--- a/docker/core/mkwebaxum/src/public/bp_login.rs
+++ b/docker/core/mkwebaxum/src/public/bp_login.rs
@@ -12,6 +12,7 @@ use reqwest::StatusCode;
 use serde::Deserialize;
 use sqlx::Row;
 use sqlx::postgres::PgPool;
+use tokio::task;
 
 #[derive(Template)]
 #[template(path = "bss_public/bss_public_login.html")]
@@ -76,10 +77,17 @@ async fn try_ad_login(sqlx_pool: &PgPool, username: &str, password: &str) -> Opt
         format!("{}@{}", username, ldap_domain)
     };
 
-    if mk_lib_network::mk_lib_network_ldap::ldap_bind(ldap_ip, ldap_port, &bind_username, password)
-        .await
-        .is_err()
-    {
+    let bind_result = task::spawn_blocking(move || {
+        mk_lib_network::mk_lib_network_ldap::ldap_bind_blocking(
+            ldap_ip,
+            ldap_port,
+            &bind_username,
+            password,
+        )
+    })
+    .await;
+
+    if !matches!(bind_result, Ok(Ok(_))) {
         return None;
     }
 

--- a/src/mk_lib_network/src/mk_lib_network_ldap.rs
+++ b/src/mk_lib_network/src/mk_lib_network_ldap.rs
@@ -9,6 +9,15 @@ pub async fn ldap_bind(
     ldap_bind: &str,
     ldap_secret: &str,
 ) -> Result<LdapResult> {
+    ldap_bind_blocking(ldap_ip, ldap_port, ldap_bind, ldap_secret)
+}
+
+pub fn ldap_bind_blocking(
+    ldap_ip: String,
+    ldap_port: String,
+    ldap_bind: &str,
+    ldap_secret: &str,
+) -> Result<LdapResult> {
     let mut ldap = LdapConn::new(&format!("ldap://{}:{}", ldap_ip, ldap_port))?;
     let res = ldap
         .simple_bind(ldap_bind, ldap_secret)? // "cn=Manager,dc=example,dc=org"


### PR DESCRIPTION
### Motivation
- Allow optional Microsoft Active Directory (LDAP) authentication as a non-destructive fallback when local DB username/password verification fails.
- Keep existing local authorization/session model unchanged by requiring the AD-authenticated account to already exist in `mm_axum_users` before creating a session.

### Description
- Added an environment-gated AD login path in `docker/core/mkwebaxum/src/public/bp_login.rs` by introducing `env_flag_enabled` and `try_ad_login` helper functions and importing `sqlx::Row`.
- The handler still attempts local DB verification via `mk_lib_database_user_login_verification` first and only calls AD bind when that returns no user and `MKWEBAPP_AD_LOGIN_ENABLED` is enabled.
- AD connection parameters are read from `MKWEBAPP_AD_LDAP_IP`, optional `MKWEBAPP_AD_LDAP_PORT` (default `389`), and `MKWEBAPP_AD_DOMAIN` (used to form `username@domain` when necessary), and the code uses `mk_lib_network::mk_lib_network_ldap::ldap_bind` to verify credentials.
- On successful AD bind the code looks up `id` in `mm_axum_users` and only logs in the user if that row exists to preserve existing permissions/session behavior.

### Testing
- Ran `cargo fmt` in `docker/core/mkwebaxum` successfully.
- Attempted `cargo check` but it failed due to environment private-registry access returning HTTP 403, preventing a full compile validation.
- Attempted `cargo clippy -- -D warnings` but it also failed for the same private registry HTTP 403 error in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e168f36328832182277bcc1b251f41)