### PR TITLE
Fix AD login spawn_blocking lifetime capture

### DIFF
--- a/docker/core/mkwebaxum/src/public/bp_login.rs
+++ b/docker/core/mkwebaxum/src/public/bp_login.rs
@@ -60,6 +60,7 @@ async fn try_ad_login(sqlx_pool: &PgPool, username: &str, password: &str) -> Opt
     if password.trim().is_empty() || !env_flag_enabled("MKWEBAPP_AD_LOGIN_ENABLED") {
         return None;
     }
+    let password_owned = password.to_string();
 
     let ldap_ip = match std::env::var("MKWEBAPP_AD_LDAP_IP") {
         Ok(value) if !value.trim().is_empty() => value,
@@ -82,7 +83,7 @@ async fn try_ad_login(sqlx_pool: &PgPool, username: &str, password: &str) -> Opt
             ldap_ip,
             ldap_port,
             &bind_username,
-            password,
+            &password_owned,
         )
     })
     .await;


### PR DESCRIPTION
### Motivation
- Fix a Rust lifetime error (`E0521`) where the borrowed `password: &str` escaped into a `tokio::task::spawn_blocking` closure that requires `'static`.

### Description
- Clone the incoming `password` into an owned `String` with `let password_owned = password.to_string();` and update the LDAP bind call inside the blocking closure to use `&password_owned` in `docker/core/mkwebaxum/src/public/bp_login.rs`.

### Testing
- Ran `cargo fmt` in `docker/core/mkwebaxum` which succeeded; `cargo check` and `cargo clippy -- -D warnings` were attempted but both failed due to a private registry returning HTTP 403 in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1710540c883219ce0bd371b0f7a05)