### PR TITLE
Refactor mkfanotify: improve event handling and add graceful shutdown

### DIFF
--- a/docker/core/mkfanotify/Cargo.toml
+++ b/docker/core/mkfanotify/Cargo.toml
@@ -20,13 +20,7 @@ mk_lib_database = { version = "0.0.235", registry = "kellnr" }
 mk_lib_logging = { version = "0.0.204", registry = "kellnr" }
 mk_lib_rabbitmq = { version = "0.0.207", registry = "kellnr" }
 
-chrono = { version = "0.4.43", features = ["serde"] }
 fanotify-rs = "0.3.1"
-reqwest = { version = "0.13.2", default-features = false, features = [
-    "json",
-    "native-tls",
-] }
-serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.50.0", features = ["full"] }
 

--- a/docker/core/mkfanotify/src/main.rs
+++ b/docker/core/mkfanotify/src/main.rs
@@ -1,46 +1,122 @@
 use fanotify::high_level::{
-    FanEvent, Fanotify, FanotifyMode, FAN_CLOSE_WRITE, FAN_CREATE, FAN_DELETE,
-    FAN_EVENT_ON_CHILD, FAN_MODIFY, FAN_MOVED_FROM, FAN_MOVED_TO, FAN_ONDIR,
+    FAN_CLOSE_WRITE, FAN_CREATE, FAN_DELETE, FAN_EVENT_ON_CHILD, FAN_MODIFY, FAN_MOVED_FROM,
+    FAN_MOVED_TO, FAN_ONDIR, FanEvent, Fanotify, FanotifyMode,
 };
-use mk_lib_database;
-use mk_lib_rabbitmq;
 use serde_json::json;
 use std::collections::HashMap;
 use std::error::Error;
-use std::time::{Duration, Instant};
+use std::time::{Duration as StdDuration, Instant};
+use tokio::signal;
 use tokio::sync::mpsc;
+use tokio::time::{Duration, MissedTickBehavior, interval};
 
 const DEDUPE_WINDOW_MS: u64 = 1500;
 const CHANNEL_BUFFER: usize = 4096;
-const CLEANUP_EVERY_EVENTS: u64 = 1000;
+const DEDUPE_CLEANUP_SECS: u64 = 30;
+const PUBLISH_QUEUE: &str = "mk_inotify";
 
-const EVENT_TYPE_FILE: u8 = 1;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Action {
+    CreateWrite,
+    Create,
+    Delete,
+    Move,
+    Modify,
+}
 
-const ACTION_CREATE_WRITE: u8 = 1;
-const ACTION_CREATE: u8 = 2;
-const ACTION_DELETE: u8 = 3;
-const ACTION_MOVE: u8 = 4;
-const ACTION_MODIFY: u8 = 5;
+impl Action {
+    fn as_str(self) -> &'static str {
+        match self {
+            Action::CreateWrite => "Create/Write",
+            Action::Create => "Create",
+            Action::Delete => "Delete",
+            Action::Move => "Move",
+            Action::Modify => "Modify",
+        }
+    }
+}
+
+fn classify_event(events: &[FanEvent]) -> Option<Action> {
+    if events.iter().any(|e| matches!(e, FanEvent::CloseWrite)) {
+        Some(Action::CreateWrite)
+    } else if events.iter().any(|e| matches!(e, FanEvent::Create)) {
+        Some(Action::Create)
+    } else if events.iter().any(|e| matches!(e, FanEvent::Delete)) {
+        Some(Action::Delete)
+    } else if events
+        .iter()
+        .any(|e| matches!(e, FanEvent::MovedFrom | FanEvent::MovedTo))
+    {
+        Some(Action::Move)
+    } else if events.iter().any(|e| matches!(e, FanEvent::Modify)) {
+        Some(Action::Modify)
+    } else {
+        None
+    }
+}
+
+fn build_payload(action: Action, path: &str, pid: i32) -> String {
+    json!({
+        "Type": action.as_str(),
+        "Path": path,
+        "Pid": pid,
+    })
+    .to_string()
+}
+
+struct RawEvent {
+    action: Action,
+    path: String,
+    pid: i32,
+}
+
+async fn log_event(payload: serde_json::Value) {
+    if let Err(err) = mk_lib_logging::mk_lib_logging_loki::mk_logging_loki_push(payload).await {
+        eprintln!("mkfanotify: loki push failed: {err}");
+    }
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let (_sqlx_pool_rw, sqlx_pool_ro) =
+    let (_, sqlx_pool_ro) =
         mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120).await?;
 
     mk_lib_database::mk_lib_database_version::mk_lib_database_version_check(&sqlx_pool_ro, false)
         .await?;
 
-    let (_rabbit_connection, rabbit_channel) =
+    let (rabbit_connection, rabbit_channel) =
         mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_connect("mkfanotify").await?;
 
     let fanotify = Fanotify::new_blocking(FanotifyMode::CONTENT)?;
 
-    for row_data in
-        mk_lib_database::mk_lib_database_library::mk_lib_database_library_read(&sqlx_pool_ro)
-            .await?
-    {
-        let lib_path = row_data.mm_media_dir_path;
+    let mut watches_installed: usize = 0;
+    let rows = mk_lib_database::mk_lib_database_library::mk_lib_database_library_read(
+        &sqlx_pool_ro,
+    )
+    .await?;
 
+    for row_data in rows {
+        let lib_path = row_data.mm_media_dir_path;
         let mask = FAN_MODIFY
             | FAN_CLOSE_WRITE
             | FAN_CREATE
@@ -51,98 +127,181 @@ async fn main() -> Result<(), Box<dyn Error>> {
             | FAN_ONDIR;
 
         match fanotify.add_path(mask, &lib_path) {
-            Ok(_) => println!("Loaded fanotify watch for: {}", lib_path),
-            Err(e) => eprintln!("Failed to add fanotify watch for {}: {}", lib_path, e),
+            Ok(_) => {
+                watches_installed += 1;
+                log_event(json!({
+                    "Module": std::module_path!(),
+                    "Event": "watch_installed",
+                    "Path": lib_path,
+                }))
+                .await;
+            }
+            Err(err) => {
+                log_event(json!({
+                    "Module": std::module_path!(),
+                    "Event": "watch_failed",
+                    "Path": lib_path,
+                    "Error": err.to_string(),
+                }))
+                .await;
+            }
         }
     }
 
-    let (tx, mut rx) = mpsc::channel::<String>(CHANNEL_BUFFER);
+    if watches_installed == 0 {
+        log_event(json!({
+            "Module": std::module_path!(),
+            "Event": "no_watches_installed",
+        }))
+        .await;
+        return Err("mkfanotify: no library paths watched".into());
+    }
+
+    let (tx, mut rx) = mpsc::channel::<RawEvent>(CHANNEL_BUFFER);
 
     let watcher_handle = tokio::task::spawn_blocking(move || {
-        let dedupe_window = Duration::from_millis(DEDUPE_WINDOW_MS);
-        let mut recently_sent: HashMap<(u8, u8, String), Instant> = HashMap::new();
-        let mut processed_events: u64 = 0;
-
         loop {
             let events = fanotify.read_event();
-
             for event in events {
-                let action = if event.events.iter().any(|e| matches!(e, FanEvent::CloseWrite)) {
-                    Some(ACTION_CREATE_WRITE)
-                } else if event.events.iter().any(|e| matches!(e, FanEvent::Create)) {
-                    Some(ACTION_CREATE)
-                } else if event.events.iter().any(|e| matches!(e, FanEvent::Delete)) {
-                    Some(ACTION_DELETE)
-                } else if event
-                    .events
-                    .iter()
-                    .any(|e| matches!(e, FanEvent::MovedFrom | FanEvent::MovedTo))
-                {
-                    Some(ACTION_MOVE)
-                } else if event.events.iter().any(|e| matches!(e, FanEvent::Modify)) {
-                    Some(ACTION_MODIFY)
-                } else {
-                    None
-                };
-
-                let Some(action) = action else {
+                let Some(action) = classify_event(&event.events) else {
                     continue;
                 };
-
-                let now = Instant::now();
-                let dedupe_key = (EVENT_TYPE_FILE, action, event.path.clone());
-
-                let should_publish = match recently_sent.get(&dedupe_key) {
-                    Some(last_seen) => now.duration_since(*last_seen) >= dedupe_window,
-                    None => true,
+                let raw = RawEvent {
+                    action,
+                    path: event.path,
+                    pid: event.pid,
                 };
-
-                if !should_publish {
-                    continue;
-                }
-
-                recently_sent.insert(dedupe_key, now);
-
-                let action_text = match action {
-                    ACTION_CREATE_WRITE => "Create/Write",
-                    ACTION_CREATE => "Create",
-                    ACTION_DELETE => "Delete",
-                    ACTION_MOVE => "Move",
-                    ACTION_MODIFY => "Modify",
-                    _ => "Unknown",
-                };
-
-                let payload = json!({
-                    "Type": action_text,
-                    "Path": event.path,
-                    "Pid": event.pid,
-                })
-                .to_string();
-
-                if tx.blocking_send(payload).is_err() {
+                if tx.blocking_send(raw).is_err() {
                     return;
-                }
-
-                processed_events += 1;
-                if processed_events % CLEANUP_EVERY_EVENTS == 0 {
-                    let now = Instant::now();
-                    recently_sent.retain(|_, last_seen| {
-                        now.duration_since(*last_seen) < dedupe_window
-                    });
                 }
             }
         }
     });
 
-    while let Some(payload) = rx.recv().await {
-        mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_publish(
-            rabbit_channel.clone(),
-            "mk_inotify",
-            payload,
-        )
-        .await?;
+    let dedupe_window = StdDuration::from_millis(DEDUPE_WINDOW_MS);
+    let mut recently_sent: HashMap<(Action, String), Instant> = HashMap::new();
+    let mut cleanup_ticker = interval(Duration::from_secs(DEDUPE_CLEANUP_SECS));
+    cleanup_ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    cleanup_ticker.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = shutdown_signal() => {
+                log_event(json!({
+                    "Module": std::module_path!(),
+                    "Event": "shutdown",
+                }))
+                .await;
+                break;
+            }
+            _ = cleanup_ticker.tick() => {
+                let now = Instant::now();
+                recently_sent.retain(|_, last_seen| {
+                    now.duration_since(*last_seen) < dedupe_window
+                });
+            }
+            maybe_event = rx.recv() => {
+                let Some(raw) = maybe_event else { break; };
+                let now = Instant::now();
+                let key = (raw.action, raw.path.clone());
+                if let Some(last) = recently_sent.get(&key)
+                    && now.duration_since(*last) < dedupe_window
+                {
+                    continue;
+                }
+                recently_sent.insert(key, now);
+
+                let payload = build_payload(raw.action, &raw.path, raw.pid);
+                if let Err(err) = mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_publish(
+                    rabbit_channel.clone(),
+                    PUBLISH_QUEUE,
+                    payload,
+                )
+                .await
+                {
+                    log_event(json!({
+                        "Module": std::module_path!(),
+                        "Event": "publish_failed",
+                        "Path": raw.path,
+                        "Action": raw.action.as_str(),
+                        "Error": err.to_string(),
+                    }))
+                    .await;
+                }
+            }
+        }
     }
 
-    watcher_handle.await?;
+    drop(rx);
+    if let Err(err) = mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_close(
+        rabbit_channel,
+        rabbit_connection,
+    )
+    .await
+    {
+        log_event(json!({
+            "Module": std::module_path!(),
+            "Event": "rabbitmq_close_failed",
+            "Error": err.to_string(),
+        }))
+        .await;
+    }
+    watcher_handle.abort();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_prefers_close_write_over_create_and_modify() {
+        let evs = [FanEvent::Modify, FanEvent::CloseWrite, FanEvent::Create];
+        assert_eq!(classify_event(&evs), Some(Action::CreateWrite));
+    }
+
+    #[test]
+    fn classify_prefers_create_over_modify() {
+        let evs = [FanEvent::Modify, FanEvent::Create];
+        assert_eq!(classify_event(&evs), Some(Action::Create));
+    }
+
+    #[test]
+    fn classify_delete() {
+        assert_eq!(classify_event(&[FanEvent::Delete]), Some(Action::Delete));
+    }
+
+    #[test]
+    fn classify_move_from_or_to() {
+        assert_eq!(classify_event(&[FanEvent::MovedFrom]), Some(Action::Move));
+        assert_eq!(classify_event(&[FanEvent::MovedTo]), Some(Action::Move));
+    }
+
+    #[test]
+    fn classify_modify() {
+        assert_eq!(classify_event(&[FanEvent::Modify]), Some(Action::Modify));
+    }
+
+    #[test]
+    fn classify_empty_is_none() {
+        assert_eq!(classify_event(&[]), None);
+    }
+
+    #[test]
+    fn action_strings_stable() {
+        assert_eq!(Action::CreateWrite.as_str(), "Create/Write");
+        assert_eq!(Action::Create.as_str(), "Create");
+        assert_eq!(Action::Delete.as_str(), "Delete");
+        assert_eq!(Action::Move.as_str(), "Move");
+        assert_eq!(Action::Modify.as_str(), "Modify");
+    }
+
+    #[test]
+    fn payload_shape() {
+        let p = build_payload(Action::Create, "/a/b", 42);
+        let v: serde_json::Value = serde_json::from_str(&p).unwrap();
+        assert_eq!(v["Type"], "Create");
+        assert_eq!(v["Path"], "/a/b");
+        assert_eq!(v["Pid"], 42);
+    }
 }

--- a/docker/core/mkfanotify/src/main.rs
+++ b/docker/core/mkfanotify/src/main.rs
@@ -96,8 +96,20 @@ async fn shutdown_signal() {
     }
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    let result = runtime.block_on(async_main());
+    // The watcher is a spawn_blocking task stuck in `fanotify.read_event()`;
+    // `abort()` is a no-op for blocking tasks. Cap the runtime shutdown so
+    // the process always exits promptly even if no filesystem event wakes
+    // the watcher. The OS reclaims the detached thread on process exit.
+    runtime.shutdown_timeout(std::time::Duration::from_secs(2));
+    result
+}
+
+async fn async_main() -> Result<(), Box<dyn Error>> {
     let (_, sqlx_pool_ro) =
         mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120).await?;
 
@@ -246,7 +258,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }))
         .await;
     }
-    watcher_handle.abort();
+    drop(watcher_handle);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
Refactored the mkfanotify module to improve code organization, add proper graceful shutdown handling, and enhance event deduplication logic. The changes move from a simple blocking channel pattern to a more robust async event loop with signal handling.

## Key Changes

- **Event Classification**: Introduced an `Action` enum to replace magic number constants, with a `classify_event()` function that encapsulates event type detection logic
- **Payload Building**: Extracted payload construction into a dedicated `build_payload()` function for better maintainability
- **Event Structure**: Created a `RawEvent` struct to pass structured data through the channel instead of serialized strings
- **Graceful Shutdown**: Added `shutdown_signal()` function to handle SIGTERM and Ctrl+C signals, with proper cleanup and logging
- **Improved Deduplication**: Moved deduplication logic from the blocking watcher thread to the async main loop, with a periodic cleanup ticker instead of event-count-based cleanup
- **Better Logging**: Replaced simple println/eprintln with structured JSON logging via `log_event()` for watch installation, failures, and shutdown events
- **Error Handling**: Enhanced error handling with proper logging for RabbitMQ publish failures and connection closure
- **Test Coverage**: Added comprehensive unit tests for event classification, action string representation, and payload structure

## Implementation Details

- The watcher thread now only handles event reading and classification, sending `RawEvent` objects through the channel
- The main async loop handles deduplication, payload building, and RabbitMQ publishing
- Deduplication uses a `HashMap<(Action, String), Instant>` keyed by action and path instead of including a file type constant
- Cleanup of stale deduplication entries now happens on a 30-second interval rather than every 1000 events
- Removed unused dependencies (chrono, reqwest, serde) from Cargo.toml
- Properly closes RabbitMQ connection on shutdown instead of dropping it

https://claude.ai/code/session_01BfzEueSH9cdw4Vrf39bMCw