### PR TITLE
Harden mk_lib_database: SQL bug, hardcoded key, panics

### DIFF
--- a/src/mk_lib_database/src/mk_lib_database_game_servers.rs
+++ b/src/mk_lib_database/src/mk_lib_database_game_servers.rs
@@ -88,7 +88,7 @@ pub async fn mk_lib_database_game_server_upsert(
     // TODO um, would return "invalid" uuid on update
     let new_guid = uuid::Uuid::now_v7();
     sqlx::query(
-        r#"INSERT INTO mm_game_dedicated_servers(mm_game_server_guid, mm_game_server_name, mm_game_server_json) VALUES($ 1, $2, $3) ON CONFLICT(mm_game_server_name) DO UPDATE SET mm_game_server_json = $4"#,
+        r#"INSERT INTO mm_game_dedicated_servers(mm_game_server_guid, mm_game_server_name, mm_game_server_json) VALUES($1, $2, $3) ON CONFLICT(mm_game_server_name) DO UPDATE SET mm_game_server_json = $4"#,
     )
     .bind(new_guid)
     .bind(server_name)

--- a/src/mk_lib_database/src/mk_lib_database_library.rs
+++ b/src/mk_lib_database/src/mk_lib_database_library.rs
@@ -49,8 +49,8 @@ pub async fn mk_lib_database_library_path_audit_read(
 
 #[derive(Debug, FromRow, Deserialize, Serialize)]
 pub struct DBLibraryPathStatus {
-    mm_media_dir_path: String,
-    mm_media_dir_status: String,
+    pub mm_media_dir_path: String,
+    pub mm_media_dir_status: String,
 }
 
 pub async fn mk_lib_database_library_path_status(

--- a/src/mk_lib_database/src/mk_lib_database_network_share.rs
+++ b/src/mk_lib_database/src/mk_lib_database_network_share.rs
@@ -11,13 +11,22 @@ fn share_auth_key() -> String {
     std::env::var("MK_SHARE_AUTH_KEY").unwrap_or_else(|_| "fake-strong-key".to_string())
 }
 
-fn parse_share_subpath(network_share_path: &str) -> Option<String> {
-    let path_name = network_share_path.replace("\\\\", "/");
-    path_name
-        .splitn(3, '/')
-        .nth(1)
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned)
+/// Extract the share name from a network share path.
+///
+/// Accepts either backslash UNC (`\\host\share\...`, the format nmap's
+/// `smb-enum-shares` emits) or forward-slash UNC (`//host/share/...`). The
+/// host segment is stripped — it is stored separately in
+/// `mm_network_share_ip` — and any deeper subpath is dropped, so only the
+/// share name itself is returned. A bare `share` with no UNC prefix is also
+/// accepted and returned unchanged.
+fn parse_share_name(network_share_path: &str) -> Option<String> {
+    let normalized = network_share_path.replace('\\', "/");
+    let had_unc_prefix = normalized.starts_with("//");
+    let mut segments = normalized.split('/').filter(|s| !s.is_empty());
+    if had_unc_prefix {
+        segments.next()?;
+    }
+    segments.next().map(str::to_owned)
 }
 
 pub async fn mk_lib_database_network_share_exists(
@@ -25,9 +34,9 @@ pub async fn mk_lib_database_network_share_exists(
     network_share_ip: std::net::IpAddr,
     network_share_path: &str,
 ) -> Result<bool, sqlx::Error> {
-    let share_path = parse_share_subpath(network_share_path).ok_or_else(|| {
+    let share_path = parse_share_name(network_share_path).ok_or_else(|| {
         sqlx::Error::Protocol(format!(
-            "invalid share path (expected '//host/share/...', got {network_share_path:?})"
+            "invalid share path (expected '//host/share' or '\\\\host\\share', got {network_share_path:?})"
         ))
     })?;
     let row: (bool,) = sqlx::query_as(
@@ -139,9 +148,9 @@ pub async fn mk_lib_database_network_share_insert(
     network_share_comment: &str,
     network_share_version: i16
 ) -> Result<uuid::Uuid, sqlx::Error> {
-    let share_path = parse_share_subpath(network_share_path).ok_or_else(|| {
+    let share_path = parse_share_name(network_share_path).ok_or_else(|| {
         sqlx::Error::Protocol(format!(
-            "invalid share path (expected '//host/share/...', got {network_share_path:?})"
+            "invalid share path (expected '//host/share' or '\\\\host\\share', got {network_share_path:?})"
         ))
     })?;
     let new_guid = uuid::Uuid::now_v7();
@@ -183,4 +192,57 @@ pub async fn mk_lib_database_network_share_update_user_info(
     .await?;
     transaction.commit().await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_share_name;
+
+    #[test]
+    fn backslash_unc_returns_share_name_without_host() {
+        assert_eq!(
+            parse_share_name(r"\\192.168.1.5\media").as_deref(),
+            Some("media"),
+        );
+    }
+
+    #[test]
+    fn backslash_unc_with_subpath_drops_subpath() {
+        assert_eq!(
+            parse_share_name(r"\\host\media\movies\2020").as_deref(),
+            Some("media"),
+        );
+    }
+
+    #[test]
+    fn forward_slash_unc_returns_share_name() {
+        assert_eq!(
+            parse_share_name("//192.168.1.5/media").as_deref(),
+            Some("media"),
+        );
+    }
+
+    #[test]
+    fn forward_slash_unc_with_subpath_drops_subpath() {
+        assert_eq!(
+            parse_share_name("//host/media/movies").as_deref(),
+            Some("media"),
+        );
+    }
+
+    #[test]
+    fn bare_share_name_is_returned_as_is() {
+        assert_eq!(parse_share_name("media").as_deref(), Some("media"));
+    }
+
+    #[test]
+    fn empty_string_returns_none() {
+        assert!(parse_share_name("").is_none());
+    }
+
+    #[test]
+    fn unc_without_share_segment_returns_none() {
+        assert!(parse_share_name(r"\\host").is_none());
+        assert!(parse_share_name("//host").is_none());
+    }
 }

--- a/src/mk_lib_database/src/mk_lib_database_network_share.rs
+++ b/src/mk_lib_database/src/mk_lib_database_network_share.rs
@@ -2,19 +2,40 @@ use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use sqlx::types::Uuid;
 
+/// Returns the symmetric key pgcrypto should use for share-auth passwords.
+///
+/// Reads `MK_SHARE_AUTH_KEY` from the environment; falls back to the legacy
+/// key for backward compatibility with databases migrated before this was
+/// configurable. Set the env var in production and rotate existing rows.
+fn share_auth_key() -> String {
+    std::env::var("MK_SHARE_AUTH_KEY").unwrap_or_else(|_| "fake-strong-key".to_string())
+}
+
+fn parse_share_subpath(network_share_path: &str) -> Option<String> {
+    let path_name = network_share_path.replace("\\\\", "/");
+    path_name
+        .splitn(3, '/')
+        .nth(1)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+}
+
 pub async fn mk_lib_database_network_share_exists(
     sqlx_pool: &sqlx::PgPool,
     network_share_ip: std::net::IpAddr,
     network_share_path: &str,
 ) -> Result<bool, sqlx::Error> {
-    let path_name = network_share_path.replace("\\\\", "/");
-    let path_vec: Vec<&str> = path_name.splitn(3, '/').collect();
+    let share_path = parse_share_subpath(network_share_path).ok_or_else(|| {
+        sqlx::Error::Protocol(format!(
+            "invalid share path (expected '//host/share/...', got {network_share_path:?})"
+        ))
+    })?;
     let row: (bool,) = sqlx::query_as(
-        r#"select exists(select 1 from mm_network_shares where mm_network_share_ip = $1 
+        r#"select exists(select 1 from mm_network_shares where mm_network_share_ip = $1
         and mm_network_share_path = $2 limit 1) as found_record limit 1"#,
     )
     .bind(network_share_ip)
-    .bind(path_vec[1])
+    .bind(share_path)
     .fetch_one(sqlx_pool)
     .await?;
     Ok(row.0)
@@ -52,15 +73,16 @@ pub async fn mk_lib_database_network_share_detail(
     share_guid: uuid::Uuid,
 ) -> Result<DBShareList, sqlx::Error> {
     let table_row: DBShareList = sqlx::query_as(
-        r#"select mm_network_share_guid, mm_network_share_ip, mm_network_share_path, 
-        mm_network_share_comment, mm_share_auth_user, 
-        pgp_sym_decrypt(mm_share_auth_password::bytea, 'fake-strong-key') AS mm_share_auth_password, 
-        mm_network_share_version, mm_network_share_workgroup 
+        r#"select mm_network_share_guid, mm_network_share_ip, mm_network_share_path,
+        mm_network_share_comment, mm_share_auth_user,
+        pgp_sym_decrypt(mm_share_auth_password::bytea, $2) AS mm_share_auth_password,
+        mm_network_share_version, mm_network_share_workgroup
         from mm_network_shares
         LEFT JOIN mm_share_auth ON mm_network_shares.mm_network_share_user_guid = mm_share_auth.mm_share_auth_guid
         where mm_network_share_guid = $1"#,
     )
     .bind(share_guid)
+    .bind(share_auth_key())
     .fetch_one(sqlx_pool)
     .await?;
     Ok(table_row)
@@ -82,15 +104,16 @@ pub async fn mk_lib_database_network_share_read(
     sqlx_pool: &sqlx::PgPool,
 ) -> Result<Vec<DBShareList>, sqlx::Error> {
     let table_rows: Vec<DBShareList> = sqlx::query_as(
-        r#"select mm_network_share_guid, mm_network_share_ip, mm_network_share_path, 
-        mm_network_share_comment, mm_network_share_version, 
+        r#"select mm_network_share_guid, mm_network_share_ip, mm_network_share_path,
+        mm_network_share_comment, mm_network_share_version,
         mm_share_auth_user,
-        pgp_sym_decrypt(mm_share_auth_password::bytea, 'fake-strong-key') AS mm_share_auth_password, 
-        mm_network_share_workgroup 
-        from mm_network_shares LEFT JOIN mm_share_auth 
+        pgp_sym_decrypt(mm_share_auth_password::bytea, $1) AS mm_share_auth_password,
+        mm_network_share_workgroup
+        from mm_network_shares LEFT JOIN mm_share_auth
         ON mm_network_shares.mm_network_share_user_guid = mm_share_auth.mm_share_auth_guid
         order by mm_network_share_path"#,
     )
+    .bind(share_auth_key())
     .fetch_all(sqlx_pool)
     .await?;
     Ok(table_rows)
@@ -116,18 +139,21 @@ pub async fn mk_lib_database_network_share_insert(
     network_share_comment: &str,
     network_share_version: i16
 ) -> Result<uuid::Uuid, sqlx::Error> {
+    let share_path = parse_share_subpath(network_share_path).ok_or_else(|| {
+        sqlx::Error::Protocol(format!(
+            "invalid share path (expected '//host/share/...', got {network_share_path:?})"
+        ))
+    })?;
     let new_guid = uuid::Uuid::now_v7();
     let mut transaction = sqlx_pool.begin().await?;
-    let path_name = network_share_path.replace("\\\\", "/");
-    let path_vec: Vec<&str> = path_name.splitn(3, '/').collect();
     sqlx::query(
-        r#"insert into mm_network_shares (mm_network_share_guid, mm_network_share_ip, 
-        mm_network_share_path, mm_network_share_comment, mm_network_share_version) 
+        r#"insert into mm_network_shares (mm_network_share_guid, mm_network_share_ip,
+        mm_network_share_path, mm_network_share_comment, mm_network_share_version)
         values ($1, $2, $3, $4, $5)"#,
     )
     .bind(new_guid)
     .bind(network_share_ip)
-    .bind(path_vec[1])
+    .bind(share_path)
     .bind(network_share_comment)
     .bind(network_share_version)
     .execute(&mut *transaction)
@@ -136,18 +162,22 @@ pub async fn mk_lib_database_network_share_insert(
     Ok(new_guid)
 }
 
+/// Point a share row at an existing `mm_share_auth` entry.
+///
+/// `network_share_auth_guid` must reference a row in `mm_share_auth`. To
+/// rotate the stored credentials themselves, update `mm_share_auth` directly
+/// (the password is encrypted with `pgp_sym_encrypt` there).
 pub async fn mk_lib_database_network_share_update_user_info(
     sqlx_pool: &sqlx::PgPool,
     network_share_uuid: Uuid,
-    network_share_user: String,
-    network_share_password: String,
+    network_share_auth_guid: Uuid,
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(
-        r#"update mm_network_shares set mm_network_share_user_guid = $1 
+        r#"update mm_network_shares set mm_network_share_user_guid = $1
         where mm_network_share_guid = $2"#,
     )
-    .bind(network_share_user)
+    .bind(network_share_auth_guid)
     .bind(network_share_uuid)
     .execute(&mut *transaction)
     .await?;

--- a/src/mk_lib_database/src/mk_lib_database_user.rs
+++ b/src/mk_lib_database/src/mk_lib_database_user.rs
@@ -51,7 +51,7 @@ impl Default for User {
 #[async_trait]
 impl Authentication<User, i64, PgPool> for User {
     async fn load_user(userid: i64, pool: Option<&PgPool>) -> Result<User, anyhow::Error> {
-        let pool = pool.unwrap();
+        let pool = pool.ok_or_else(|| anyhow::anyhow!("no PgPool provided to load_user"))?;
         User::get_user(userid, pool)
             .await
             .ok_or_else(|| anyhow::anyhow!("Could not load user"))

--- a/src/mk_lib_database/src/mk_lib_database_version_schema.rs
+++ b/src/mk_lib_database/src/mk_lib_database_version_schema.rs
@@ -232,9 +232,12 @@ pub async fn mk_lib_database_update_schema(
         .execute(&mut *transaction)
         .await?;
         let new_guid = uuid::Uuid::now_v7();
-        sqlx::query(r#"INSERT INTO mm_share_auth (mm_share_auth_guid, mm_share_auth_user, mm_share_auth_password) 
-        values ($1, 'guest', pgp_sym_encrypt('guest', 'fake-strong-key'));"#)
+        let share_auth_key = std::env::var("MK_SHARE_AUTH_KEY")
+            .unwrap_or_else(|_| "fake-strong-key".to_string());
+        sqlx::query(r#"INSERT INTO mm_share_auth (mm_share_auth_guid, mm_share_auth_user, mm_share_auth_password)
+        values ($1, 'guest', pgp_sym_encrypt('guest', $2));"#)
             .bind(new_guid)
+            .bind(share_auth_key)
             .execute(&mut *transaction)
             .await?;
         sqlx::query(r#"ALTER TABLE mm_network_shares ADD COLUMN mm_network_share_workgroup text;"#)


### PR DESCRIPTION
## Summary
Focused hardening pass on `mk_lib_database`:

- **game_servers**: fix `VALUES($ 1, $2, $3)` — the stray space made the statement fail to parse at runtime.
- **library**: make `DBLibraryPathStatus` fields `pub` so the `FromRow` derive and external callers can actually read them.
- **user**: replace `pool.unwrap()` in `load_user` with a proper `Err` so a missing `PgPool` doesn't abort the process.
- **network_share**:
  - Stop embedding the literal `'fake-strong-key'` in every `pgp_sym_decrypt` call. A `share_auth_key()` helper reads `MK_SHARE_AUTH_KEY` from the environment and the value is passed as a bind parameter; the legacy key remains the fallback so unmigrated deployments keep working.
  - Replace the unchecked `path_vec[1]` index with a `parse_share_subpath` helper that returns a descriptive error instead of panicking on inputs that don't contain a share segment.
  - Fix `update_user_info`: it was binding a `String` into a uuid column and ignoring the `password` argument entirely. Signature now takes a `Uuid` and drops the unused password param (password writes belong on `mm_share_auth`).
- **version_schema**: bind the share-auth key in the schema migration too.

Out of scope for this PR: `.unwrap()` calls in the `metadata/*` parsers — those warrant a separate, dedicated pass.

## Test plan
- [ ] `cargo check -p mk_lib_database` in an environment with access to the Kellnr registry.
- [ ] Confirm `MK_SHARE_AUTH_KEY` env var is set in production deployments before rotating; rows written with the legacy key remain decryptable as long as the env var is unset.
- [ ] Exercise share insert/exists paths with a malformed share path to confirm the new `Protocol` error surfaces rather than panicking.
- [ ] Audit callers of `mk_lib_database_network_share_update_user_info` in downstream binaries (none in-workspace) for the signature change.

https://claude.ai/code/session_0156KVpZNzCVtt2TwxxEmr3i