### PR TITLE
Harden mk_lib_file: SMB injection, NFS stub, share mount fixes

### DIFF
--- a/docker/core/mkmediascanner/src/main.rs
+++ b/docker/core/mkmediascanner/src/main.rs
@@ -163,12 +163,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         &share_info,
                                         format!("/{}", row_data.mm_media_dir_path).as_str(),
                                     )
-                                    .unwrap_or_else(|_| {
+                                    .or_else(|_| {
                                         mk_lib_file::mk_lib_smb::mk_file_smb_client_tree(
                                             smb_client,
                                             format!("/{}", row_data.mm_media_dir_path).as_str(),
                                         )
                                     })
+                                    .unwrap_or_default()
                                 } else {
                                     mk_nfs_tree(
                                         &share_info,
@@ -189,12 +190,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                         &share_info,
                                                         format!("/{}", file_metadata.name).as_str(),
                                                     )
-                                                    .unwrap_or_else(|_| {
+                                                    .or_else(|_| {
                                                         mk_lib_file::mk_lib_smb::mk_file_smb_client_tree(
                                                             smb_client,
                                                             format!("/{}", file_metadata.name).as_str(),
                                                         )
                                                     })
+                                                    .unwrap_or_default()
                                         } else {
                                             mk_nfs_tree(
                                                 &share_info,

--- a/src/mk_lib_file/src/mk_lib_file.rs
+++ b/src/mk_lib_file/src/mk_lib_file.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::io;
 use tokio::fs;
+use tokio::task;
 use walkdir::{DirEntry, WalkDir};
 
 pub async fn mk_read_file_data(file_to_read: &str) -> io::Result<String> {
@@ -29,14 +30,22 @@ pub fn mk_file_is_hidden(entry: &DirEntry) -> bool {
 //  .filter_map(Result::ok)
 //  .filter(|d| d.path().extension() == Some(OsStr::from_bytes(b"zip")))
 //  .filter(|e| !e.file_type().is_dir())
-pub async fn mk_directory_walk(dir_path: String) -> Result<Vec<String>, Box<dyn Error>> {
-    let mut file_list: Vec<String> = Vec::new();
-    let walker = WalkDir::new(dir_path).into_iter();
-    for entry in walker.filter_entry(|e| !mk_file_is_hidden(e)) {
-        let entry = entry?;
-        file_list.push(entry.path().display().to_string());
-    }
-    Ok(file_list)
+pub async fn mk_directory_walk(dir_path: String) -> Result<Vec<String>, Box<dyn Error + Send + Sync>> {
+    // WalkDir performs blocking syscalls per entry, so run it off the async
+    // runtime to avoid stalling other tasks on the current worker thread.
+    task::spawn_blocking(move || -> Result<Vec<String>, walkdir::Error> {
+        let mut file_list: Vec<String> = Vec::new();
+        for entry in WalkDir::new(dir_path)
+            .into_iter()
+            .filter_entry(|e| !mk_file_is_hidden(e))
+        {
+            let entry = entry?;
+            file_list.push(entry.path().display().to_string());
+        }
+        Ok(file_list)
+    })
+    .await?
+    .map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/src/mk_lib_file/src/mk_lib_file_share.rs
+++ b/src/mk_lib_file/src/mk_lib_file_share.rs
@@ -1,45 +1,63 @@
+use mk_lib_database;
 use std::error::Error;
 use std::fs;
 use std::process::{Command, Stdio};
-use mk_lib_database;
+
+fn validate_mount_option_value(value: &str, field: &str) -> Result<(), Box<dyn Error>> {
+    // `-o key=value,key=value,...` is comma-separated, so a value containing
+    // `,` or NUL could inject additional mount flags. Refuse those here.
+    if value.contains(',') || value.contains('\0') || value.contains('\n') {
+        return Err(format!(
+            "mount option {field:?} contains disallowed characters: {value:?}"
+        )
+        .into());
+    }
+    Ok(())
+}
 
 pub async fn mk_file_share_mount(
-    host_ip: &String,
-    host_path: &String,
+    host_ip: &str,
+    host_path: &str,
     share_guid: &uuid::Uuid,
     share_username: &Option<String>,
     share_password: &Option<String>,
-    share_version_old: Option<bool>,
+    share_version_old: bool,
 ) -> Result<(), Box<dyn Error>> {
-    /*
-     # due to old ass synology
-     mount -t cifs -o rw,guest,vers=1.0  //192.168.1.122/testshare /mnt
-     ,username=user_name,password=password
-    */
-    let mut share_options = vec![
-        format!("{}/{}", host_ip, host_path.replace("\\", "/")),
-        format!("/mediakraken/mnt/{}", share_guid),
-    ];
-    if share_version_old.is_some() {
-        share_options.push("-o rw,guest,vers=1.0".to_string());
+    // Example target: mount -t cifs -o rw,guest,vers=1.0 //host/share /mnt
+    let source = format!("//{}/{}", host_ip, host_path.replace('\\', "/"));
+    let target = format!("/mediakraken/mnt/{share_guid}");
+    fs::create_dir_all(&target)?;
+
+    let mut options: Vec<String> = Vec::new();
+    if share_version_old {
+        options.push("rw".to_string());
+        options.push("guest".to_string());
+        options.push("vers=1.0".to_string());
     }
-    if share_username.is_some() {
-        share_options.push(format!(
-            "-o username={:?},password={:?}",
-            share_username, share_password
-        ));
+    if let Some(user) = share_username.as_deref() {
+        validate_mount_option_value(user, "username")?;
+        options.push(format!("username={user}"));
+        if let Some(pass) = share_password.as_deref() {
+            validate_mount_option_value(pass, "password")?;
+            options.push(format!("password={pass}"));
+        }
     }
-    fs::create_dir_all(format!("/mediakraken/mnt/{}", share_guid))?;
-    let output = Command::new("mount")
-        .args(&share_options)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .unwrap();
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    println!("Mount out: {:?}", stdout);
-    let stderr = String::from_utf8(output.stderr).unwrap();
-    println!("Mount err: {:?}", stderr);
+
+    let mut cmd = Command::new("mount");
+    if !options.is_empty() {
+        cmd.arg("-o").arg(options.join(","));
+    }
+    cmd.arg(&source).arg(&target);
+
+    let output = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "mount {source} -> {target} failed: status={:?} stderr={}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
     Ok(())
 }
 
@@ -47,15 +65,24 @@ pub async fn mk_file_share_mount_all(
     shares_to_mount: Vec<mk_lib_database::mk_lib_database_network_share::DBShareList>,
 ) -> Result<(), Box<dyn Error>> {
     for share_info in shares_to_mount.iter() {
-        let _result = mk_file_share_mount(
+        // `mm_network_share_version` is an i16 in the DB; treat `1` as the
+        // "old SMBv1" flag since that's what the original behaviour encoded.
+        let share_version_old = share_info.mm_network_share_version == 1;
+        if let Err(e) = mk_file_share_mount(
             &share_info.mm_network_share_ip.to_string(),
             &share_info.mm_network_share_path,
             &share_info.mm_network_share_guid,
-            &share_info.mm_network_share_user,
-            &share_info.mm_network_share_password,
-            share_info.mm_network_share_version,
+            &share_info.mm_share_auth_user,
+            &share_info.mm_share_auth_password,
+            share_version_old,
         )
-        .await;
+        .await
+        {
+            eprintln!(
+                "failed to mount share {}: {e}",
+                share_info.mm_network_share_guid
+            );
+        }
     }
     Ok(())
 }

--- a/src/mk_lib_file/src/mk_lib_nfs.rs
+++ b/src/mk_lib_file/src/mk_lib_nfs.rs
@@ -1,15 +1,17 @@
 use libnfs::*;
-use nix::{fcntl::OFlag, sys::stat::Mode};
 use std::error::Error;
 
+/// Stub for future NFS share mounting.
+///
+/// The previous implementation ignored `share_to_mount` entirely and always
+/// mounted the hard-coded `0.0.0.0:/srv/nfs`, which was actively dangerous:
+/// it could attach to any NFS server reachable from the process. Until a
+/// real implementation lands we return an error so callers surface the gap
+/// instead of silently mounting the wrong target.
 pub fn mk_file_nfs_client_connect(
-    share_to_mount: mk_lib_database::mk_lib_database_network_share::DBShareList,
+    _share_to_mount: mk_lib_database::mk_lib_database_network_share::DBShareList,
 ) -> Result<NFSClient, Box<dyn Error>> {
-    let mut nfs = Nfs::new()?;
-    nfs.set_uid(1000)?;
-    nfs.set_gid(1000)?;
-    nfs.set_debug(9)?;
-    nfs.mount("0.0.0.0", "/srv/nfs")?;
+    Err("mk_file_nfs_client_connect is not implemented".into())
 }
 
 /*

--- a/src/mk_lib_file/src/mk_lib_smb.rs
+++ b/src/mk_lib_file/src/mk_lib_smb.rs
@@ -1,5 +1,5 @@
 use mk_lib_database;
-use pavao::{SmbClient, SmbCredentials, SmbDirent, SmbDirentType, SmbOptions, SmbStat};
+use pavao::{SmbClient, SmbCredentials, SmbDirent, SmbDirentType, SmbOptions};
 use std::error::Error;
 use std::path::PathBuf;
 use std::process::Command;
@@ -7,13 +7,11 @@ use std::process::Command;
 pub fn mk_file_smb_client_connect(
     share_to_mount: mk_lib_database::mk_lib_database_network_share::DBShareList,
 ) -> Result<SmbClient, Box<dyn Error>> {
-    let mut smb_workgroup = "WORKGROUP";
-    if share_to_mount.mm_network_share_workgroup.is_some() {
-        smb_workgroup = share_to_mount
-            .mm_network_share_workgroup
-            .as_deref()
-            .unwrap_or("WORKGROUP");
-    }
+    let smb_workgroup = share_to_mount
+        .mm_network_share_workgroup
+        .as_deref()
+        .filter(|w| !w.is_empty())
+        .unwrap_or("WORKGROUP");
     let client = SmbClient::new(
         SmbCredentials::default()
             .server(format!("smb://{}", share_to_mount.mm_network_share_ip))
@@ -32,13 +30,7 @@ pub fn mk_file_smb_client_connect(
             )
             .workgroup(smb_workgroup),
         SmbOptions::default().one_share_per_server(true),
-    )
-    .unwrap();
-    println!("IP: {:?}", share_to_mount.mm_network_share_ip);
-    println!("Path: {:?}", share_to_mount.mm_network_share_path);
-    //println!("User: {:?}", share_to_mount.mm_share_auth_user);
-    //println!("Pass: {:?}", share_to_mount.mm_share_auth_password.unwrap());
-    println!("Workgroup: {:?}", smb_workgroup);
+    )?;
     Ok(client)
 }
 
@@ -56,27 +48,32 @@ pub struct File_Metadata {
 }
 
 // tree(&client, "/");
-pub fn mk_file_smb_client_tree(client: &SmbClient, uri: &str) -> Vec<File_Metadata> {
+pub fn mk_file_smb_client_tree(
+    client: &SmbClient,
+    uri: &str,
+) -> Result<Vec<File_Metadata>, Box<dyn Error>> {
     let mut file_list: Vec<File_Metadata> = vec![];
-    for entity in client.list_dir(uri).unwrap().into_iter() {
+    for entity in client.list_dir(uri)?.into_iter() {
         let entity_uri = mk_file_smb_client_entity_uri(&entity, uri);
-        let stat = client.stat(entity_uri.as_str()).unwrap();
-        let mut new_file = File_Metadata {
+        let is_dir = entity.get_type() == SmbDirentType::Dir;
+        file_list.push(File_Metadata {
             name: entity_uri,
-            directory: false,
-        };
-        if entity.get_type() == SmbDirentType::Dir {
-            new_file.directory = true;
-        }
-        file_list.push(new_file);
+            directory: is_dir,
+        });
     }
-    file_list
+    Ok(file_list)
 }
 
 pub fn mk_file_smb_client_tree_smbclient(
     share_to_mount: &mk_lib_database::mk_lib_database_network_share::DBShareList,
     uri: &str,
 ) -> Result<Vec<File_Metadata>, Box<dyn Error>> {
+    // smbclient's `-c` argument is a script: commands are separated by `;`
+    // and paths are quoted with `"`. A uri containing either character could
+    // inject additional smbclient commands, so reject it up front.
+    if uri.contains([';', '"', '\n', '\r', '\\']) {
+        return Err(format!("smbclient path contains disallowed characters: {uri:?}").into());
+    }
     let mut smb_command = Command::new("smbclient");
     let share_uri = format!(
         "//{}/{}",
@@ -100,10 +97,17 @@ pub fn mk_file_smb_client_tree_smbclient(
         }
     }
     if let Some(user) = share_to_mount.mm_share_auth_user.as_deref() {
+        // The `-U user%pass` form exposes the password to anything that can
+        // read this process's argv (ps, /proc). Reject `%` in the credentials
+        // so a malicious password can't escape the user field; a follow-up
+        // should move to an auth file via `-A` to keep the secret off argv.
         let pass = share_to_mount
             .mm_share_auth_password
             .as_deref()
             .unwrap_or_default();
+        if user.contains('%') || pass.contains('%') || user.contains('\n') || pass.contains('\n') {
+            return Err("smb credentials contain disallowed characters".into());
+        }
         smb_command.arg("-U").arg(format!("{}%{}", user, pass));
     } else {
         smb_command.arg("-N");
@@ -151,15 +155,4 @@ fn mk_file_smb_client_entity_uri(entity: &SmbDirent, path: &str) -> String {
     let mut p = PathBuf::from(path);
     p.push(PathBuf::from(entity.name()));
     p.as_path().to_string_lossy().to_string()
-}
-
-fn mk_file_smb_client_print_entry(entity: &SmbDirent, stat: &SmbStat) {
-    println!(
-        "{:32}\t{}\t{}\t{}\t{:?}",
-        entity.name(),
-        stat.uid,
-        stat.gid,
-        stat.size,
-        stat.modified,
-    );
 }

--- a/testing_rust/test_share_read_db/src/main.rs
+++ b/testing_rust/test_share_read_db/src/main.rs
@@ -53,7 +53,8 @@ async fn main() {
                             let files_to_process = mk_lib_file::mk_lib_smb::mk_file_smb_client_tree(
                                 &smb_client,
                                 format!("/{}", row_data.mm_media_dir_path).as_str(),
-                            );
+                            )
+                            .unwrap_or_default();
                             println!("FTP: {:?}", files_to_process);
                             mediascan_file_process(
                                 &smb_client,


### PR DESCRIPTION
## Summary

- **nfs**: the previous `mk_file_nfs_client_connect` discarded `share_to_mount` and always mounted the hard-coded `0.0.0.0:/srv/nfs` — i.e. it would attach to any reachable NFS server rather than the one the caller asked for. Replaced with an explicit "not implemented" error until a real implementation lands.
- **smb (`mk_file_smb_client_tree_smbclient`)**: the URI flowed into the smbclient `-c` script as `cd "{uri}"`, joined with other commands via `;`. A URI containing `;` or `"` could inject additional smbclient commands. Now rejected up front. Also reject `%`/`\n` in SMB credentials so a password can't escape the `-U user%pass` argument (secret-on-argv still warrants a follow-up, noted inline).
- **smb (`mk_file_smb_client_connect` / `_tree`)**: replaced `.unwrap()` on `SmbClient::new` and `list_dir` with `?`. Removed the dead `mk_file_smb_client_print_entry` helper and its `SmbStat` import.
- **file_share**: this module did not compile against the real `DBShareList`:
  - wrong field names (`mm_network_share_user`/`_password` vs `mm_share_auth_user`/`_password`) and
  - wrong version type (`Option<bool>` vs `i16`).
  Also, `format!("-o rw,guest,vers=1.0")` was being pushed as a single argv entry to `mount`, which expects `-o` and the option string as separate arguments. Rewrote to build `-o key=value,…` properly, validate credentials for `,`/`\n`/NUL so they can't inject mount options, and surface non-zero exits instead of silently printing stdout/stderr.
- **file**: `mk_directory_walk` ran synchronous `walkdir` directly on the async runtime. Moved the traversal into `tokio::task::spawn_blocking` so it no longer stalls a worker thread for the duration of the walk.

## Test plan
- [ ] `cargo check -p mk_lib_file --all-features` with Kellnr access.
- [ ] Exercise `mk_file_smb_client_tree_smbclient` with a URI containing `;` or `"` and confirm it errors instead of running.
- [ ] Mount a share via `mk_file_share_mount` against a CIFS test server (guest + authenticated) and confirm it actually mounts with the expected options.
- [ ] Attempt to mount with a password containing `,` and confirm the helper rejects it.
- [ ] Call `mk_directory_walk` from a single-threaded tokio runtime and confirm other tasks continue making progress.

https://claude.ai/code/session_0156KVpZNzCVtt2TwxxEmr3i