### PR TITLE
Document mk_lib_filler as an intentional no-op crate

### DIFF
--- a/src/mk_lib_filler/src/lib.rs
+++ b/src/mk_lib_filler/src/lib.rs
@@ -1,3 +1,14 @@
+//! # mk_lib_filler
+//!
+//! Intentionally a no-op crate. It exists so every service Dockerfile can
+//! depend on the same set of `mk_lib_*` crates from the Kellnr registry
+//! without conditionals: a service that would otherwise have no workspace
+//! dependencies still pulls `mk_lib_filler` in, keeping the build graph and
+//! the docker `.gitignore`s uniform.
+//!
+//! If a future refactor lets services drop unused `mk_lib_*` deps
+//! individually, this crate can be retired. Until then, leave the body
+//! empty — adding any real work here ships to every service.
 pub mod mk_lib_filler;
 
 pub use mk_lib_filler::mk_lib_filler;


### PR DESCRIPTION
## Summary
`mk_lib_filler` exposes a single empty async function (`mk_lib_filler() -> Ok(())`) and has no dependencies. Grepping the repo shows every service Dockerfile's `.gitignore` lists `mk_lib_filler` alongside the other `mk_lib_*` crates, so the crate appears to exist as a placeholder that keeps each service's build graph uniform — a service with no real `mk_lib_*` deps can still depend on this one without conditionals.

Adds a crate-level doc comment documenting that rationale and flagging that a future refactor enabling per-service dep pruning should retire the crate.

If that reading is wrong and this crate is genuinely orphaned, we should delete it instead — happy to do that as a follow-up if you confirm nothing in the private registry consumes it.

## Test plan
- [ ] `cargo doc -p mk_lib_filler` renders the new crate-level comment.
- [ ] Confirm with the platform owner whether `mk_lib_filler` is still required by any service build; if not, delete it as a follow-up.

https://claude.ai/code/session_0156KVpZNzCVtt2TwxxEmr3i