### PR TITLE
Harden mk_lib_hardware: compile fixes, panic removal, hardcoded creds

### DIFF
--- a/src/mk_lib_hardware/src/mk_lib_hardware_arduino.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_arduino.rs
@@ -1,17 +1,9 @@
 // https://github.com/Rahix/avr-hal
-
-use panic_halt as _;
-
-pub async fn mk_lib_hardware_arduino_blink(pins: pinmsthis, blink_delay: u16, blink_times: u64) {
-    let mut led = pins.d13.into_output().downgrade();
-    for _ in 0..blink_times {
-        led.toggle();
-        arduino_hal::delay_ms(blink_delay);
-    }
-}
-
-pub async fn mk_lib_hardware_arduino_get_pins() {
-    let device_pins = arduino_hal::Peripherals::take().unwrap();
-    let pins = arduino_hal::pins!(device_pins);
-    Ok(pins)
-}
+//
+// Stub for future Arduino support.
+//
+// The original body referenced `panic_halt`, `arduino_hal`, and an
+// undefined `pinmsthis` type, none of which are declared in
+// Cargo.toml. Enabling the `arduino` feature therefore broke the
+// build. Keep the public API surface empty until a real
+// implementation (and the matching deps) lands.

--- a/src/mk_lib_hardware/src/mk_lib_hardware_arduino_SPL06_007.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_arduino_SPL06_007.rs
@@ -1,5 +1,5 @@
 // https://github.com/roxgib/SPL06-007
-
-use arduino_hal::prelude::*;
-use panic_halt as _;
-use spl06_007::Barometer;
+//
+// Stub for future SPL06-007 barometer support. The original imports
+// referenced `arduino_hal` and `panic_halt`, which are not declared
+// as dependencies. Leave empty until both the code and the deps land.

--- a/src/mk_lib_hardware/src/mk_lib_hardware_global_cache.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_global_cache.rs
@@ -8,8 +8,7 @@ pub async fn mk_hardware_global_cache_api(
     let json_data = mk_lib_network::mk_lib_network::mk_data_from_url_to_json(
         format!("http://{}/api?expand=all", device_ip).to_string(),
     )
-    .await
-    .unwrap();
+    .await?;
     Ok(json_data)
 }
 
@@ -19,8 +18,7 @@ pub async fn mk_hardware_global_cache_api_host(
     let json_data = mk_lib_network::mk_lib_network::mk_data_from_url_to_json(
         format!("http://{}/api/host?expand=all", device_ip).to_string(),
     )
-    .await
-    .unwrap();
+    .await?;
     Ok(json_data)
 }
 
@@ -30,8 +28,7 @@ pub async fn mk_hardware_global_cache_api_host_id(
     let json_data = mk_lib_network::mk_lib_network::mk_data_from_url_to_json(
         format!("http://{}/api/host/id?expand=all", device_ip).to_string(),
     )
-    .await
-    .unwrap();
+    .await?;
     Ok(json_data)
 }
 
@@ -41,8 +38,7 @@ pub async fn mk_hardware_global_cache_api_host_id_unit(
     let json_data = mk_lib_network::mk_lib_network::mk_data_from_url_to_json(
         format!("http://{}/api/host/id/unit?expand=all", device_ip).to_string(),
     )
-    .await
-    .unwrap();
+    .await?;
     Ok(json_data)
 }
 
@@ -52,8 +48,7 @@ pub async fn mk_hardware_global_cache_api_leds(
     let json_data = mk_lib_network::mk_lib_network::mk_data_from_url_to_json(
         format!("http://{}/api/host/LEDs?expand=all", device_ip).to_string(),
     )
-    .await
-    .unwrap();
+    .await?;
     Ok(json_data)
 }
 
@@ -64,8 +59,7 @@ pub async fn mk_hardware_global_cache_api_leds_detail(
     let json_data = mk_lib_network::mk_lib_network::mk_data_from_url_to_json(
         format!("http://{}/api/host/LEDs/{}?expand=all", device_ip, led_number).to_string(),
     )
-    .await
-    .unwrap();
+    .await?;
     Ok(json_data)
 }
 
@@ -77,8 +71,7 @@ pub async fn mk_hardware_global_cache_api_host_config(
     let json_data = mk_lib_network::mk_lib_network::mk_data_from_url_to_json(
         format!("http://{}/api/host/config?expand=all", device_ip).to_string(),
     )
-    .await
-    .unwrap();
+    .await?;
     Ok(json_data)
 }
 
@@ -90,8 +83,7 @@ pub async fn mk_hardware_global_cache_api_host_config_network(
     let json_data = mk_lib_network::mk_lib_network::mk_data_from_url_to_json(
         format!("http://{}/api/host/config/network?expand=all", device_ip).to_string(),
     )
-    .await
-    .unwrap();
+    .await?;
     Ok(json_data)
 }
 
@@ -103,8 +95,7 @@ pub async fn mk_hardware_global_cache_api_host_storage(
     let json_data = mk_lib_network::mk_lib_network::mk_data_from_url_to_json(
         format!("http://{}/api/host/storage", device_ip).to_string(),
     )
-    .await
-    .unwrap();
+    .await?;
     Ok(json_data)
 }
 
@@ -118,8 +109,7 @@ pub async fn mk_hardware_global_cache_api_host_storage_files(
     let json_data = mk_lib_network::mk_lib_network::mk_data_from_url_to_json(
         format!("http://{}/api/host/storage/files", device_ip).to_string(),
     )
-    .await
-    .unwrap();
+    .await?;
     Ok(json_data)
 }
 
@@ -130,8 +120,7 @@ pub async fn mk_hardware_global_cache_api_host_storage_file_retrieve(
     let json_data = mk_lib_network::mk_lib_network::mk_data_from_url_to_json(
         format!("http://{}/api/host/storage/files/{}", device_ip, file_path).to_string(),
     )
-    .await
-    .unwrap();
+    .await?;
     Ok(json_data)
 }
 
@@ -145,8 +134,7 @@ pub async fn mk_hardware_global_cache_api_host_modules(
     let json_data = mk_lib_network::mk_lib_network::mk_data_from_url_to_json(
         format!("http://{}/api/host/modules?expand=all", device_ip).to_string(),
     )
-    .await
-    .unwrap();
+    .await?;
     Ok(json_data)
 }
 
@@ -157,8 +145,7 @@ pub async fn mk_hardware_global_cache_api_host_module_detail(
     let json_data = mk_lib_network::mk_lib_network::mk_data_from_url_to_json(
         format!("http://{}/api/host/modules/{}", device_ip, module_number).to_string(),
     )
-    .await
-    .unwrap();
+    .await?;
     Ok(json_data)
 }
 

--- a/src/mk_lib_hardware/src/mk_lib_hardware_phue.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_phue.rs
@@ -6,15 +6,23 @@ use huelib::Color;
 use huelib::{bridge, Bridge};
 use std::net::IpAddr;
 
+/// Register a device name on the Philips Hue bridge and return the
+/// bridge-assigned client key.
+///
+/// `device_name` is shown in the Hue app's "connected apps" list and
+/// is used purely for identification; pick a short label identifying
+/// the installation (e.g. a hostname). The bridge's link button must
+/// be pressed before calling this.
 pub async fn mk_hardware_phue_register_username(
     bridge_ip: IpAddr,
+    device_name: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let client_key = bridge::register_user(bridge_ip, "mediakraken").unwrap();
+    let client_key = bridge::register_user(bridge_ip, device_name)?;
     Ok(client_key)
 }
 
 pub async fn mk_hardware_phue_bridge_discover() -> Result<Vec<IpAddr>, Box<dyn std::error::Error>> {
-    let hub_ip_addresses = bridge::discover_nupnp().unwrap();
+    let hub_ip_addresses = bridge::discover_nupnp()?;
     Ok(hub_ip_addresses)
 }
 
@@ -23,7 +31,7 @@ pub async fn mk_hardware_phue_bridge_discover_lights(
     client_key: String,
 ) -> Result<Vec<Light>, Box<dyn std::error::Error>> {
     let bridge = Bridge::new(bridge_ip, client_key);
-    let lights = bridge.get_all_lights().unwrap();
+    let lights = bridge.get_all_lights()?;
     Ok(lights)
 }
 
@@ -33,7 +41,7 @@ pub async fn mk_hardware_phue_bridge_remove_light(
     light_id: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let bridge = Bridge::new(bridge_ip, client_key);
-    let _result = bridge.delete_light(light_id);
+    bridge.delete_light(light_id)?;
     Ok(())
 }
 
@@ -45,12 +53,16 @@ pub async fn mk_hardware_phue_bridge_set_light(
     light_brightness: Option<u64>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let bridge = Bridge::new(bridge_ip, client_key);
-    let light_modifier = light::StateModifier::new()
+    let mut modifier = light::StateModifier::new()
         .with_on(true)
-        .with_saturation(Adjust::Override(light_saturation.unwrap() as u8))
-        .with_alert(Alert::Select)
-        .with_brightness(Adjust::Decrement(light_brightness.unwrap() as u8));
-    let _response = bridge.set_light_state(light_id, &light_modifier).unwrap();
+        .with_alert(Alert::Select);
+    if let Some(sat) = light_saturation {
+        modifier = modifier.with_saturation(Adjust::Override(sat.min(u8::MAX as u64) as u8));
+    }
+    if let Some(bri) = light_brightness {
+        modifier = modifier.with_brightness(Adjust::Decrement(bri.min(u8::MAX as u64) as u8));
+    }
+    bridge.set_light_state(light_id, &modifier)?;
     Ok(())
 }
 
@@ -65,7 +77,7 @@ pub async fn mk_hardware_phue_bridge_set_color(
         .with_on(true)
         .with_color(Color::from_hex(light_color)?)
         .with_alert(Alert::Select);
-    let _response = bridge.set_light_state(light_id, &light_modifier).unwrap();
+    bridge.set_light_state(light_id, &light_modifier)?;
     Ok(())
 }
 
@@ -77,6 +89,6 @@ pub async fn mk_hardware_phue_bridge_set_light_onoff(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let bridge = Bridge::new(bridge_ip, client_key);
     let light_modifier = light::StateModifier::new().with_on(light_on);
-    let _response = bridge.set_light_state(light_id, &light_modifier).unwrap();
+    bridge.set_light_state(light_id, &light_modifier)?;
     Ok(())
 }

--- a/src/mk_lib_hardware/src/mk_lib_hardware_pi.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_pi.rs
@@ -1,8 +1,8 @@
 use rascam::*;
 use rppal::gpio::Gpio;
-use serde_json::json;
 use std::error::Error;
-use stdext::function_name;
+use std::fs::File;
+use std::io::Write;
 use tokio::time::{sleep, Duration};
 
 // let gpio = Gpio::new()?;
@@ -25,20 +25,22 @@ pub async fn mk_lib_hardware_pi_led_flash(
     }
 }
 
-pub async fn mk_lib_hardware_pi_take_image(image_file_name: String) {
-    let info = info().unwrap();
-    if info.cameras.len() > 0 {
-        #[cfg(debug_assertions)]
-        {
-            mk_lib_logging::mk_logging_post_elk(std::module_path!(), json!({ "info": info })).await.unwrap();
-        }
-        simple_sync(&info.cameras[0], image_file_name);
+pub async fn mk_lib_hardware_pi_take_image(image_file_name: String) -> Result<(), Box<dyn Error>> {
+    let info = info()?;
+    if info.cameras.is_empty() {
+        return Err("no cameras detected".into());
     }
-}
-
-async fn simple_sync(info: &CameraInfo, image_file_name: String) {
-    let mut camera = SimpleCamera::new(info.clone()).unwrap();
-    camera.activate().unwrap();
-    let b = camera.take_one().unwrap();
-    File::create(image_file_name).unwrap().write_all(&b).unwrap();
+    let camera_info = info.cameras[0].clone();
+    // rascam performs synchronous MMAL/camera I/O; keep it off the async
+    // runtime so taking a photo doesn't stall other tasks on this worker.
+    tokio::task::spawn_blocking(move || -> Result<(), Box<dyn Error + Send + Sync>> {
+        let mut camera = SimpleCamera::new(camera_info)?;
+        camera.activate()?;
+        let b = camera.take_one()?;
+        let mut file = File::create(&image_file_name)?;
+        file.write_all(&b)?;
+        Ok(())
+    })
+    .await?
+    .map_err(Into::into)
 }

--- a/src/mk_lib_hardware/src/mk_lib_hardware_pi_dht11.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_pi_dht11.rs
@@ -1,41 +1,8 @@
 // https://github.com/Xavientois/rppal-dht11-rs
-
-use rppal::{
-    gpio::{Gpio, Mode},
-    hal::Delay,
-};
-use rppal_dht11::{Dht11, Measurement};
-use serde_json::json;
-use stdext::function_name;
-
-//const DHT11_PIN: u8 = 17;
-
-pub async fn mk_lib_hardware_dht11_get_reading(dht11_pin: u8) {
-    let pin = Gpio::new()
-        .unwrap()
-        .get(dht11_pin)
-        .unwrap()
-        .into_io(Mode::Output);
-    let mut dht11 = Dht11::new(pin);
-    let mut delay = Delay::new();
-    loop {
-        match dht11.perform_measurement_with_retries(&mut delay, 20) {
-            Ok(Measurement {
-                temperature,
-                humidity,
-            }) => {
-                let (temperature, humidity) = (temperature as f64 / 10.0, humidity as f64 / 10.0);
-                // #[cfg(debug_assertions)]
-                // {
-                //     mk_lib_logging::mk_logging_post_elk(
-                //         std::module_path!(),
-                //         json!({ "Temp": temperature, "Hum": humidity }),
-                //     )
-                //     .await
-                //     .unwrap();
-                // }
-            }
-            Err(e) => eprintln!("Failed to perform measurement: {e:?}"),
-        }
-    }
-}
+//
+// Stub for future DHT11 reader support on the Pi.
+//
+// The original body depended on `rppal-dht11` (commented out in
+// Cargo.toml) and `stdext::function_name` (not declared as a dep),
+// so the `raspberry` feature failed to build. Keep this empty until
+// the real deps are added.

--- a/src/mk_lib_hardware/src/mk_lib_hardware_pi_lcd_i2c.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_pi_lcd_i2c.rs
@@ -1,14 +1,8 @@
 // https://github.com/guanicoe/LiquidCrystal_I2C-rs
-
-use rppal::{gpio::Gpio, i2c::I2c};
-
-//static LCD_ADDRESS: u8 = 0x27;
-
-async fn mk_lib_hardware_i2c_lcd(lcd_address: u8, lcd_text: String) {
-    let mut i2c = I2c::new().unwrap();
-    let mut delay = rppal::hal::Delay;
-    let mut lcd = screen::Lcd::new(&mut i2c, lcd_address, &mut delay).unwrap();
-    lcd.set_display(screen::Display::On).unwrap();
-    lcd.set_backlight(screen::Backlight::On).unwrap();
-    lcd.print(lcd_text).unwrap();
-}
+//
+// Stub for future I2C LCD support on the Pi.
+//
+// The original body referenced a `screen` crate and `rppal::hal::Delay`
+// which are not declared in Cargo.toml, so enabling the `raspberry`
+// feature broke the build. Keep this empty until the real deps and
+// implementation land.

--- a/src/mk_lib_hardware/src/mk_lib_hardware_roku.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_roku.rs
@@ -7,23 +7,24 @@ use ssdp::header::{HeaderMut, HeaderRef, Man, MX, ST};
 use ssdp::message::{Multicast, SearchRequest};
 use url::Url;
 
-pub async fn mk_lib_hardware_roku_discover() -> Vec<Url> {
+pub async fn mk_lib_hardware_roku_discover() -> Result<Vec<Url>, Box<dyn std::error::Error>> {
     let mut request = SearchRequest::new();
     request.set(Man);
     request.set(MX(5));
-    request.set(ST::Target(ssdp::FieldMap::new("roku:ecp").unwrap()));
-    request
-        .multicast()
-        .expect("could not send SSDP query")
-        .into_iter()
-        .map(|(res, _)| {
-            let loc = res
-                .get_raw("Location")
-                .expect("could not read Location header from SSDP");
-            Url::parse(&String::from_utf8_lossy(&loc[0]))
-                .expect("could not parse Location header URL")
-        })
-        .collect()
+    request.set(ST::Target(ssdp::FieldMap::new("roku:ecp")?));
+    let mut urls = Vec::new();
+    for (res, _) in request.multicast()? {
+        let Some(loc) = res.get_raw("Location") else {
+            continue;
+        };
+        if let Some(first) = loc.first() {
+            match Url::parse(&String::from_utf8_lossy(first)) {
+                Ok(u) => urls.push(u),
+                Err(e) => eprintln!("skipping unparseable SSDP Location {first:?}: {e}"),
+            }
+        }
+    }
+    Ok(urls)
 }
 
 pub async fn mk_lib_hardware_roku_command(
@@ -48,8 +49,7 @@ pub async fn mk_lib_hardware_roku_command(
             "{}keypress/{}",
             roku_url, roku_command
         ))
-        .await
-        .unwrap();
+        .await?;
     }
     Ok(request_json)
 }
@@ -60,8 +60,7 @@ pub async fn mk_lib_hardware_roku_app_list(
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
     let request_json: serde_json::Value =
         mk_lib_network::mk_data_from_url_to_json(format!("{}:{}/query/apps", roku_addr, roku_port))
-            .await
-            .unwrap();
+            .await?;
     Ok(request_json)
 }
 
@@ -74,8 +73,7 @@ pub async fn mk_lib_hardware_roku_app_launch(
         "{}:{}/launch/{}",
         roku_addr, roku_port, roku_app_id
     ))
-    .await
-    .unwrap();
+    .await?;
     Ok(request_json)
 }
 
@@ -85,12 +83,11 @@ pub async fn mk_lib_hardware_roku_icon_save(
     roku_app_id: String,
     file_path: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let _result = mk_lib_network::mk_download_file_from_url(
+    mk_lib_network::mk_download_file_from_url(
         format!("{}:{}/query/icon/{}", roku_addr, roku_port, roku_app_id),
         &file_path,
     )
-    .await
-    .unwrap();
+    .await?;
     Ok(())
 }
 
@@ -100,11 +97,10 @@ pub async fn mk_lib_hardware_roku_touch_sreen(
     x_pos: u16,
     y_pos: u16,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let _result = mk_lib_network::mk_data_from_url(format!(
+    mk_lib_network::mk_data_from_url(format!(
         "{}:{}/input?touch.0.x={}.0&touch.0.y={}.0&touch.0.op=down",
         roku_addr, roku_port, x_pos, y_pos
     ))
-    .await
-    .unwrap();
+    .await?;
     Ok(())
 }

--- a/src/mk_lib_hardware/src/mk_lib_hardware_yeelight.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_yeelight.rs
@@ -5,33 +5,12 @@ use yeelib_rs::{Light, YeeClient};
 
 pub async fn mk_hardware_yeelight_brightness() {}
 
-pub async fn mk_hardware_yeelight_discover() -> Result<(), Box<dyn std::error::Error>> {
+pub async fn mk_hardware_yeelight_discover() -> Result<Vec<Light>, Box<dyn std::error::Error>> {
     let client = YeeClient::new()?;
-    let mut res: Vec<Light> = loop {
-        let lights = client.find_lights(Duration::from_secs(1));
-        // sometimes, it doesn't find anything, so rerun
-        if lights.len() == 0 {
-            #[cfg(debug_assertions)]
-            {
-                // mk_lib_logging::mk_logging_post_elk(
-                //     std::module_path!(),
-                //     json!({ "YeeClient": "zero" }),
-                // )
-                // .await
-                // .unwrap();
-            }
-        } else {
-            break lights;
-        }
-    };
-    let _light = res.get_mut(0).unwrap();
-    // #[cfg(debug_assertions)]
-    // {
-    //     mk_lib_logging::mk_logging_post_elk(std::module_path!(), json!({ "light": light }))
-    //         .await
-    //         .unwrap();
-    // }
-    Ok(())
+    // Yeelight discovery is advertised as best-effort; return an empty
+    // list rather than looping forever so callers can decide whether to
+    // retry or surface "no lights found" to the user.
+    Ok(client.find_lights(Duration::from_secs(1)))
 }
 
 pub async fn mk_hardware_yeelight_power() {}


### PR DESCRIPTION
## Summary
Focused pass on the highest-value issues in `mk_lib_hardware`. This crate has roughly 35 modules; I targeted the ones that either (a) broke the build under a feature flag or (b) contained `.unwrap()` calls on network / device responses.

**Compile fixes (feature-gated modules that previously wouldn't build):**
- `mk_lib_hardware_arduino` and `mk_lib_hardware_arduino_SPL06_007` referenced `arduino_hal`, `panic_halt`, and an undefined `pinmsthis` type. None of them are declared in Cargo.toml, so enabling the `arduino` feature failed. Reduced both to stubs documenting the missing deps.
- `mk_lib_hardware_pi_lcd_i2c` and `mk_lib_hardware_pi_dht11` referenced a `screen` crate, `rppal::hal::Delay`, a commented-out `rppal-dht11` dep, and an undeclared `stdext::function_name`, so the `raspberry` feature failed too. Same treatment.
- `mk_lib_hardware_pi` was missing `std::fs::File` / `std::io::Write` imports and imported unused / undeclared `stdext::function_name` / `mk_lib_logging`. Fixed imports; moved the synchronous rascam camera work into `tokio::task::spawn_blocking` so capture doesn't stall the async runtime.

**Panic removal on network/device responses:**
- `global_cache`: 13 `.await.unwrap()` on HTTP calls → `?`.
- `roku`: SSDP discovery now returns `Result<Vec<Url>>` and skips unparseable Location headers instead of panicking on the first bad one; all `.await.unwrap()` on device calls → `?`.
- `phue`: replaced `.unwrap()` on bridge discovery, light list, delete/set calls; fixed the `light_saturation.unwrap()` and `light_brightness.unwrap()` calls that would panic whenever the caller passed `None`; saturate into `u8` instead of truncating with `as`.
- `yeelight`: discovery returns the list (possibly empty) instead of looping forever when the first scan finds nothing and then panicking on `get_mut(0).unwrap()`.

**Hardcoded credential:**
- `phue::mk_hardware_phue_register_username` no longer hardcodes `"mediakraken"` as the Hue app identifier — callers pass it, which matches how the Hue bridge's "connected apps" list is supposed to be used.

**Out of scope for this PR** (still has `.unwrap()` calls worth a later pass): `sonos`, `samsung`, `synology`, `tivo`, `marantz`, `onkyo`, `vizio`, `wemo`, `yamaha`, `lenbrook`, `hdhomerun`, `crestron`, `tripplite`, `nut`, `sane`, `twain`, `appletv`, `ampro`, `firetv`, `chromecast`, `pioneer`, `lg`, `alexa`.

**Note**: the prior scope mentioned removing a Python file — I looked and there are no `.py` files under `mk_lib_hardware/`.

## Test plan
- [ ] `cargo check -p mk_lib_hardware` (default features) against the Kellnr registry.
- [ ] `cargo check -p mk_lib_hardware --features arduino` — should now at least compile (modules are empty stubs).
- [ ] `cargo check -p mk_lib_hardware --features raspberry` on a Pi build environment.
- [ ] Exercise `mk_hardware_phue_register_username` against a real bridge with the new `device_name` parameter (behavior is otherwise unchanged if callers pass `"mediakraken"`).
- [ ] Call `mk_lib_hardware_roku_discover` on a network with both Roku and non-Roku SSDP responders; confirm the new implementation returns the Roku URLs and logs (to stderr) any with malformed Location headers rather than panicking.

https://claude.ai/code/session_0156KVpZNzCVtt2TwxxEmr3i