### PR TITLE
Tidy mk_lib_hash: unify error type, drop unused deps, add docs

### DIFF
--- a/src/mk_lib_hash/Cargo.toml
+++ b/src/mk_lib_hash/Cargo.toml
@@ -10,18 +10,13 @@ lto = true
 codegen-units = 1
 
 [dependencies]
-mk_lib_file = { version = "0.0.212", registry = "kellnr" }
-mk_lib_logging = { version = "0.0.204", registry = "kellnr" }
-
 blake3 = "1.8.3"
 crc32fast = "1.5.0"
-digest = "0.10.7"
 #ed2k = { git = "https://github.com/runfalk/ed2k-rs" }
 ed2k = { version = "0.3.0", registry = "kellnr" }
 md-5 = "0.10.6"
-serde_json = "1.0.149"
 sha1 = "0.10.6"
-tokio = { version = "1.49.0", features = ["full"] }
+tokio = { version = "1.49.0", features = ["fs", "io-util"] }
 
 [dev-dependencies]
 tokio-test = "*"

--- a/src/mk_lib_hash/src/mk_lib_hash_blake3.rs
+++ b/src/mk_lib_hash/src/mk_lib_hash_blake3.rs
@@ -3,6 +3,8 @@
 use crate::hash_file_reader::read_file_chunks;
 use std::error::Error;
 
+/// Compute the BLAKE3 digest of `file_to_read` and return it as a lowercase
+/// hex string. Streams the file through a fixed-size buffer.
 pub async fn mk_file_hash_blake3(file_to_read: &str) -> Result<String, Box<dyn Error>> {
     let mut hasher = blake3::Hasher::new();
     read_file_chunks(file_to_read, |chunk| {

--- a/src/mk_lib_hash/src/mk_lib_hash_crc32.rs
+++ b/src/mk_lib_hash/src/mk_lib_hash_crc32.rs
@@ -2,6 +2,8 @@ use crate::hash_file_reader::read_file_chunks;
 use crc32fast::Hasher;
 use std::error::Error;
 
+/// Compute the CRC32 checksum of `file_to_read` and return it as a
+/// lowercase hex string. Streams the file through a fixed-size buffer.
 pub async fn mk_file_hash_crc32(file_to_read: &str) -> Result<String, Box<dyn Error>> {
     let mut hasher = Hasher::new();
     read_file_chunks(file_to_read, |chunk| hasher.update(chunk)).await?;

--- a/src/mk_lib_hash/src/mk_lib_hash_ed2k.rs
+++ b/src/mk_lib_hash/src/mk_lib_hash_ed2k.rs
@@ -3,6 +3,12 @@
 use ed2k::Ed2k;
 use std::error::Error;
 
+/// Compute the eD2k hash of `file_to_read` and return it as a hex string.
+///
+/// Unlike the other hashes in this crate, eD2k is computed by the `ed2k`
+/// crate using synchronous file I/O, so this function does not stream
+/// through `read_file_chunks`. A future refactor could wrap it in
+/// `tokio::task::spawn_blocking` for large files.
 pub async fn mk_file_hash_ed2k(file_to_read: &str) -> Result<String, Box<dyn Error>> {
     let ed2k: Ed2k = Ed2k::from_path(file_to_read)?;
     Ok(format!("{}", ed2k))

--- a/src/mk_lib_hash/src/mk_lib_hash_md5.rs
+++ b/src/mk_lib_hash/src/mk_lib_hash_md5.rs
@@ -2,6 +2,13 @@ use crate::hash_file_reader::read_file_chunks;
 use md5::{Digest, Md5};
 use std::error::Error;
 
+/// Compute the MD5 digest of `file_to_read` and return it as a lowercase
+/// hex string. Streams the file through a fixed-size buffer.
+///
+/// MD5 is not cryptographically secure; use `mk_file_hash_blake3` or
+/// `mk_file_hash_sha1` for anything that needs collision resistance.
+/// MD5 remains appropriate for compatibility with external tooling that
+/// expects MD5 (e.g. file-identification databases).
 pub async fn mk_file_hash_md5(file_to_read: &str) -> Result<String, Box<dyn Error>> {
     let mut hasher = Md5::new();
     read_file_chunks(file_to_read, |chunk| hasher.update(chunk)).await?;

--- a/src/mk_lib_hash/src/mk_lib_hash_sha1.rs
+++ b/src/mk_lib_hash/src/mk_lib_hash_sha1.rs
@@ -1,8 +1,11 @@
 use crate::hash_file_reader::read_file_chunks;
 use sha1::{Digest, Sha1};
-use std::io;
+use std::error::Error;
 
-pub async fn mk_file_hash_sha1(file_to_read: &str) -> io::Result<String> {
+/// Compute the SHA-1 digest of `file_to_read` and return it as a lowercase
+/// hex string. Streams the file through a fixed-size buffer so the full
+/// contents never sit in memory.
+pub async fn mk_file_hash_sha1(file_to_read: &str) -> Result<String, Box<dyn Error>> {
     let mut hasher = Sha1::new();
     read_file_chunks(file_to_read, |chunk| hasher.update(chunk)).await?;
     let hash = hasher.finalize();


### PR DESCRIPTION
## Summary
Small cleanup pass on `mk_lib_hash` — the code itself was already in decent shape, so this is mostly consistency and dependency hygiene.

- **Error type**: `mk_file_hash_sha1` returned `io::Result<String>` while the other four hashers returned `Result<String, Box<dyn Error>>`. Unified on the latter so callers can handle all five uniformly.
- **Unused deps**: dropped `mk_lib_file`, `mk_lib_logging`, `digest`, and `serde_json` from `Cargo.toml` — none of them are referenced anywhere in the crate source. `md-5` and `sha1` re-export the `Digest` trait themselves.
- **Tokio feature set**: narrowed from `full` to `fs` + `io-util`, which is what the `hash_file_reader` helper actually needs.
- **Docs**: added a short `///` doc comment on each public function stating the return format, the streaming behavior, and — for MD5 — the "don't use for security" caveat.

## Test plan
- [ ] `cargo check -p mk_lib_hash` against the Kellnr registry.
- [ ] `cargo test -p mk_lib_hash` — existing `test_mk_file_hash_*` tests should still pass (behavior unchanged).
- [ ] Grep downstream consumers for the old `io::Result<String>` signature on `mk_file_hash_sha1` in case anyone was matching on `io::Error` specifically.

https://claude.ai/code/session_0156KVpZNzCVtt2TwxxEmr3i