### PR TITLE
Tidy mk_lib_image: wire up HTML renderer, trim unused dep

### DIFF
--- a/src/mk_lib_image/Cargo.toml
+++ b/src/mk_lib_image/Cargo.toml
@@ -13,7 +13,7 @@ codegen-units = 1
 mk_lib_logging = { version = "0.0.204", registry = "kellnr" }
 
 image = "0.25.10"
-serde_json = "1.0.149"
+tokio = { version = "1.49.0", features = ["rt"] }
 wkhtmlapp = "1.1.0"
 
 [dev-dependencies]

--- a/src/mk_lib_image/src/lib.rs
+++ b/src/mk_lib_image/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod mk_lib_image;
+pub mod mk_lib_image_html;

--- a/src/mk_lib_image/src/mk_lib_image_html.rs
+++ b/src/mk_lib_image/src/mk_lib_image_html.rs
@@ -1,12 +1,21 @@
+use std::error::Error;
 use wkhtmlapp::{ImageBuilder, Source};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let html_content = "<h1>Hello, World!</h1><p>This is some HTML.</p>";
-    let output_path = "output.png";
-    ImageBuilder::new(Source::Html(html_content.to_string()))
-        .output_file(output_path)
-        .build()?
-        .run()?;
-    println!("HTML rendered to image: {}", output_path);
-    Ok(())
+/// Render the supplied HTML fragment to an image file at `output_path`.
+///
+/// `wkhtmlapp` drives the (synchronous) `wkhtmltoimage` binary, so this
+/// function performs blocking work via `tokio::task::spawn_blocking` to
+/// keep the async runtime free for other tasks.
+pub async fn mk_lib_image_render_html(
+    html_content: String,
+    output_path: String,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    tokio::task::spawn_blocking(move || -> Result<(), Box<dyn Error + Send + Sync>> {
+        ImageBuilder::new(Source::Html(html_content))
+            .output_file(&output_path)
+            .build()?
+            .run()?;
+        Ok(())
+    })
+    .await?
 }


### PR DESCRIPTION
## Summary
- **`mk_lib_image_html.rs`** contained a bare `fn main()` that was not listed in `lib.rs` — so the file was never compiled into the crate and `wkhtmlapp` was a dependency with no in-crate caller. Converted the body to a proper `mk_lib_image_render_html(html_content, output_path)` function that drives the (synchronous) `wkhtmltoimage` binary inside `tokio::task::spawn_blocking`, and registered the module in `lib.rs` so the public API actually exposes HTML rendering.
- **Cargo.toml**: dropped `serde_json` (declared but never referenced) and added `tokio` with only the `rt` feature for the new `spawn_blocking` call.
- `mk_image_file_resize` and `mk_image_file_thumb` in `mk_lib_image.rs` are already well-behaved (explicit input validation, `?` for errors, no panics), so this PR does not touch them.

If the old `fn main()` was intended as a standalone demo rather than a library function, the better move would be to relocate it into `examples/mk_lib_image_html.rs` and drop `wkhtmlapp` from `[dependencies]` entirely. Happy to redo it that way — tell me which shape you want.

## Test plan
- [ ] `cargo check -p mk_lib_image` against the Kellnr registry.
- [ ] Call `mk_lib_image_render_html` with a small HTML snippet on a build host that has `wkhtmltoimage` installed; confirm the PNG is written.
- [ ] Confirm `wkhtmltoimage` is available in every service container that links this crate (examples fail at runtime otherwise).

https://claude.ai/code/session_0156KVpZNzCVtt2TwxxEmr3i