### PR TITLE
mk_lib_metadata: fix TMDB arg swap, panics, URL encoding

### DIFF
--- a/src/mk_lib_metadata/Cargo.toml
+++ b/src/mk_lib_metadata/Cargo.toml
@@ -44,6 +44,7 @@ soundcloud = "0.4.0"
 substring = "1.4.5"
 tokio = "1.49.0"
 tokio-util = { version = "0.7.18", features = ["compat"] }
+url = "2.5"
 torrent-name-parser = "0.12.1"
 twitch_api = { version = "0.7.2", features = [
     "client",

--- a/src/mk_lib_metadata/src/base.rs
+++ b/src/mk_lib_metadata/src/base.rs
@@ -341,12 +341,11 @@ pub async fn metadata_fetch(
     } else if provider_name == "themoviedb" {
         if download_data.mm_download_que_type == mk_lib_common_enum_media_type::DLMediaType::PERSON
         {
-            if env::var("DEBUG").unwrap() == "true" {
-                mk_lib_logging::mk_lib_logging_loki::mk_logging_loki_push(
+            if env::var("DEBUG").ok().as_deref() == Some("true") {
+                let _ = mk_lib_logging::mk_lib_logging_loki::mk_logging_loki_push(
                     json!({ "Type": "Person", "Module": std::module_path!(), "DL Guid": download_data.mm_download_guid, "Status": download_data.mm_download_status, "Provider": "themoviedb", "ID": download_data.mm_download_provider_id }),
-                    )
-                    .await
-                    .unwrap();
+                )
+                .await;
             }
             provider_tmdb::provider_tmdb_person_fetch(
                 sqlx_pool,

--- a/src/mk_lib_metadata/src/game.rs
+++ b/src/mk_lib_metadata/src/game.rs
@@ -8,76 +8,34 @@ pub async fn metadata_game_lookup(
     sqlx_pool: &sqlx::PgPool,
     download_data: &DBDownloadQueueByProviderList,
 ) -> Result<uuid::Uuid, Box<dyn Error>> {
-    let mut metadata_uuid = uuid::Uuid::nil(); // so not found checks verify later
     // TODO remove the file extension
-    metadata_uuid =
+    let download_path = download_data
+        .mm_download_path
+        .as_ref()
+        .ok_or("mm_download_path missing from download queue record")?;
+    let file_name = Path::new(download_path)
+        .file_name()
+        .ok_or("download path has no file component")?
+        .to_str()
+        .ok_or("download path is not valid UTF-8")?
+        .to_string();
+
+    let mut metadata_uuid =
         mk_lib_database::database_metadata::mk_lib_database_metadata_game::mk_lib_database_metadata_game_uuid_by_name_and_system(
-            &sqlx_pool,
-            Path::new(&download_data.mm_download_path.as_ref().unwrap())
-                .file_name()
-                .unwrap()
-                .to_os_string()
-                .into_string()
-                .unwrap(),
+            sqlx_pool,
+            file_name,
             "systemfakeshortname".to_string(),
         )
-        .await
-        .unwrap();
+        .await?;
+
     if metadata_uuid == uuid::Uuid::nil() {
-        let sha1_hash = mk_lib_hash::mk_lib_hash_sha1::mk_file_hash_sha1(
-            &download_data.mm_download_path.as_ref().unwrap(),
-        )
-        .await
-        .unwrap();
+        let sha1_hash =
+            mk_lib_hash::mk_lib_hash_sha1::mk_file_hash_sha1(download_path).await?;
         metadata_uuid =
             mk_lib_database::database_metadata::mk_lib_database_metadata_game::mk_lib_database_metadata_game_by_sha1(
-                &sqlx_pool, sha1_hash,
+                sqlx_pool, sha1_hash,
             )
-            .await
-            .unwrap();
+            .await?;
     }
     Ok(metadata_uuid)
 }
-
-/*
-
-pub async fn game_system_update():
-    data = await common_global.api_instance.com_meta_gamesdb_platform_list()[
-        'Data']['Platforms']['Platform']
-    print((type(data)), flush=True)
-    print(data, flush=True)
-    for game_system in data:
-        print(game_system, flush=True)
-        game_sys_detail = \
-            await \
-                common_global.api_instance.com_meta_gamesdb_platform_by_id(game_system['id'])[
-                    'Data'][
-                    'Platform']
-        print((type(game_sys_detail)), flush=True)
-        print(game_sys_detail, flush=True)
-        break
-
-
-pub async fn metadata_game_lookup(db_connection, download_data):
-    """
-    Lookup game metadata
-    """
-    metadata_uuid = None  // so not found checks verify later
-    // TODO determine short name/etc
-    for row_data in await db_connection.db_meta_game_by_name(download_data["Path"]):
-        // TODO handle more than one match
-        metadata_uuid = row_data["gi_id"]
-        break
-    if metadata_uuid == None:
-        // no matches by name
-        // search giantbomb since not matched above via DB or nfo/xml
-        // save the updated status
-        await db_connection.db_begin()
-        await db_connection.db_download_update(guid=download_data["mdq_id"],
-                                               status="Search")
-        // set provider last so it's not picked up by the wrong thread
-        await db_connection.db_download_update_provider("giantbomb", download_data["mdq_id"])
-        await db_connection.db_commit()
-    return metadata_uuid
-
- */

--- a/src/mk_lib_metadata/src/guessit.rs
+++ b/src/mk_lib_metadata/src/guessit.rs
@@ -12,13 +12,18 @@ pub async fn metadata_guessit(
 ) -> Result<Metadata, Box<dyn Error>> {
     let mut metadata_uuid: uuid::Uuid = uuid::Uuid::nil();
     // check for dupes by name/year
-    let file_name = Path::new(&download_data.mm_download_path.as_ref().unwrap())
+    let download_path = download_data
+        .mm_download_path
+        .as_ref()
+        .ok_or("mm_download_path missing from download queue record")?;
+    let file_name = Path::new(download_path)
         .file_name()
-        .unwrap()
-        .to_os_string()
-        .into_string()
-        .unwrap();
-    let guessit_data: Metadata = Metadata::from(&file_name).unwrap();
+        .ok_or("download path has no file component")?
+        .to_str()
+        .ok_or("download path is not valid UTF-8")?
+        .to_string();
+    let guessit_data: Metadata = Metadata::from(&file_name)
+        .map_err(|e| format!("torrent_name_parser failed on {}: {:?}", file_name, e))?;
     if guessit_data.title().len() > 0 {
         if guessit_data.year().is_some() {
             if guessit_data.title().to_lowercase() == metadata_last_title
@@ -40,9 +45,12 @@ pub async fn metadata_guessit(
             metadata_last_year = 0;
         }
     } else {
-        mk_lib_database::database_metadata::mk_lib_database_metadata_download_queue::mk_lib_database_metadata_download_queue_update_provider(&sqlx_pool,
-                                                                                                                 "ZZ".to_string(),
-                                                                                                                 download_data.mm_download_guid).await.unwrap();
+        mk_lib_database::database_metadata::mk_lib_database_metadata_download_queue::mk_lib_database_metadata_download_queue_update_provider(
+            sqlx_pool,
+            "ZZ".to_string(),
+            download_data.mm_download_guid,
+        )
+        .await?;
     }
     //Ok((metadata_uuid, guessit_data))
     Ok(guessit_data)

--- a/src/mk_lib_metadata/src/mk_lib_metadata_m3u8.rs
+++ b/src/mk_lib_metadata/src/mk_lib_metadata_m3u8.rs
@@ -9,8 +9,7 @@ const M3U_LINE_HEADER: &str = "EXTINF:";
 pub async fn mk_lib_metadata_m3u8_validate_playlist(
     playlist: &str,
 ) -> Result<MediaPlaylist, Box<dyn Error>> {
-    let valid_playlist: MediaPlaylist = playlist.parse::<MediaPlaylist>().unwrap();
-    Ok(valid_playlist)
+    Ok(playlist.parse::<MediaPlaylist>()?)
 }
 
 /*

--- a/src/mk_lib_metadata/src/provider/giant_bomb.rs
+++ b/src/mk_lib_metadata/src/provider/giant_bomb.rs
@@ -5,11 +5,13 @@ use mk_lib_network::mk_lib_network;
 pub async fn mk_provider_giant_bomb_platforms(
     api_key: String,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let url_result: serde_json::Value = mk_lib_network::mk_data_from_url_to_json(format!(
+    // NOTE: giant_bomb only accepts the api key as a query parameter; it is
+    // visible in proxy/server logs. Treat the key as low-sensitivity and rotate
+    // regularly.
+    let url_result = mk_lib_network::mk_data_from_url_to_json(format!(
         "https://www.giantbomb.com/api/platforms/?api_key={}",
         api_key
     ))
-    .await
-    .unwrap();
+    .await?;
     Ok(url_result)
 }

--- a/src/mk_lib_metadata/src/provider/imvdb.rs
+++ b/src/mk_lib_metadata/src/provider/imvdb.rs
@@ -2,9 +2,14 @@
 
 use mk_lib_network;
 use std::collections::HashMap;
+use url::form_urlencoded;
 
-const BASE_API_URL: &str = "http://imvdb.com/api/v1";
+const BASE_API_URL: &str = "https://imvdb.com/api/v1";
 const BASE_USER_AGENT: &str = "MediaKraken_0.1.6";
+
+fn url_encode(raw: &str) -> String {
+    form_urlencoded::byte_serialize(raw.as_bytes()).collect()
+}
 
 pub async fn provider_imvdb_video_fetch_by_id(
     sqlx_pool: &sqlx::PgPool,
@@ -24,7 +29,7 @@ pub async fn provider_imvdb_video_fetch_by_id(
         ),
         headers,
     )
-    .await.unwrap();
+    .await?;
     let metadata_uuid = uuid::Uuid::nil(); // so not found checks verify later
     Ok(metadata_uuid)
 }
@@ -41,8 +46,10 @@ pub async fn provider_imvdb_search_video_by_names(
     let headers = mk_lib_network::mk_lib_network::custom_headers(&custom_headers).await;
     let _result = mk_lib_network::mk_lib_network::mk_data_from_url_to_json_custom_headers(
         format!(
-            "{}/search/videos?q=/{}+{}",
-            BASE_API_URL, band_name.replace(" ", "+"), song_name.replace(" ", "+")
+            "{}/search/videos?q={}+{}",
+            BASE_API_URL,
+            url_encode(&band_name),
+            url_encode(&song_name)
         ),
         headers,
     )
@@ -60,10 +67,7 @@ pub async fn provider_imvdb_search_videos_by_band(
     custom_headers.insert(String::from("Accept"), String::from("application/json"));
     let headers = mk_lib_network::mk_lib_network::custom_headers(&custom_headers).await;
     let _result = mk_lib_network::mk_lib_network::mk_data_from_url_to_json_custom_headers(
-        format!(
-            "{}/search/entities?q=/{}",
-            BASE_API_URL, band_name.replace(" ", "+")
-        ),
+        format!("{}/search/entities?q={}", BASE_API_URL, url_encode(&band_name)),
         headers,
     )
     .await;

--- a/src/mk_lib_metadata/src/provider/shoutcast.rs
+++ b/src/mk_lib_metadata/src/provider/shoutcast.rs
@@ -8,20 +8,14 @@ pub async fn mk_provider_shoutcast_top500(
     api_key: String,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
     let url = format!("{}Top500?k={}", SHOUTCAST_API_URL, api_key);
-    let json_data = mk_lib_network::mk_lib_network::mk_data_from_url_to_json(url)
-        .await
-        .unwrap();
-    Ok(json_data)
+    Ok(mk_lib_network::mk_lib_network::mk_data_from_url_to_json(url).await?)
 }
 
 pub async fn mk_provider_shoutcast_genre_list(
     api_key: String,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
     let url = format!("{}genrelist?k={}", SHOUTCAST_API_URL, api_key);
-    let json_data = mk_lib_network::mk_lib_network::mk_data_from_url_to_json(url)
-        .await
-        .unwrap();
-    Ok(json_data)
+    Ok(mk_lib_network::mk_lib_network::mk_data_from_url_to_json(url).await?)
 }
 
 /*

--- a/src/mk_lib_metadata/src/provider/soundcloud.rs
+++ b/src/mk_lib_metadata/src/provider/soundcloud.rs
@@ -8,22 +8,25 @@ use tokio_util::compat::TokioAsyncWriteCompatExt;
 pub async fn provider_soundcloud_client(
     soundcloud_client_id: String,
 ) -> Result<Client, std::io::Error> {
-    let client_id = std::env::var(soundcloud_client_id).unwrap();
-    let client = Client::new(&client_id);
-    Ok(client)
+    let client_id = std::env::var(&soundcloud_client_id).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("soundcloud client id env var {} unset: {}", soundcloud_client_id, e),
+        )
+    })?;
+    Ok(Client::new(&client_id))
 }
 
 pub async fn provider_soundcloud_search(
     soundcloud_client: Client,
     band_name: String,
 ) -> Result<Vec<Track>, std::io::Error> {
-    let tracks = soundcloud_client
+    soundcloud_client
         .tracks()
         .query(Some(band_name))
         .get()
         .await
-        .unwrap();
-    Ok(tracks)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
 }
 
 pub async fn provider_soundcloud_track_download(

--- a/src/mk_lib_metadata/src/provider/televisiontunes.rs
+++ b/src/mk_lib_metadata/src/provider/televisiontunes.rs
@@ -1,43 +1,32 @@
 use mk_lib_network::mk_lib_network;
-use substring::Substring;
+use std::error::Error;
+use url::form_urlencoded;
 
 pub async fn provider_televisiontunes_theme_fetch(
     tv_show_name: String,
     tv_show_theme_path: String,
-) -> Result<uuid::Uuid, Box<dyn std::error::Error>> {
-    let mut metadata_uuid = uuid::Uuid::nil();
-    let base_url = "https://www.televisiontunes.com/".to_string();
-    let show_url = format!("{}{}", base_url, tv_show_name.replace(" ", "_"));
-    let response = reqwest::get(show_url).await?;
-    if response.status().is_success() {
-        let content = response.bytes().await?;
-        let content_string = std::str::from_utf8(&content).unwrap().to_string();
-        let dl_position = content_string.find("href=\"/song/download/").unwrap();
-        let data_content = content_string.substring(dl_position + 21, dl_position + 50);
-        let dl_end_position = data_content.find("\"").unwrap();
-        #[cfg(debug_assertions)]
-        {
-            // mk_lib_logging::mk_logging_post_elk(
-            //     std::module_path!(),
-            //     json!({ "tvtunes response": data_content.substring(0, dl_end_position) }),
-            // )
-            // .await
-            // .unwrap();
-        }
-        let dl_url = format!(
-            "{}{}{}",
-            base_url,
-            "song/download/",
-            data_content.substring(0, dl_end_position)
-        );
-        #[cfg(debug_assertions)]
-        {
-            // mk_lib_logging::mk_logging_post_elk(std::module_path!(), json!({ "dl_url": dl_url }))
-            //     .await
-            //     .unwrap();
-        }
-        let _result = mk_lib_network::mk_download_file_from_url(dl_url, &tv_show_theme_path).await;
-        metadata_uuid = uuid::Uuid::now_v7();
+) -> Result<uuid::Uuid, Box<dyn Error>> {
+    let base_url = "https://www.televisiontunes.com/";
+    let slug: String =
+        form_urlencoded::byte_serialize(tv_show_name.replace(' ', "_").as_bytes()).collect();
+    let show_url = format!("{}{}", base_url, slug);
+    let response = reqwest::get(&show_url).await?;
+    if !response.status().is_success() {
+        return Ok(uuid::Uuid::nil());
     }
-    Ok(metadata_uuid)
+    let body = response.text().await?;
+    const HREF_MARKER: &str = "href=\"/song/download/";
+    let dl_position = match body.find(HREF_MARKER) {
+        Some(pos) => pos,
+        None => return Ok(uuid::Uuid::nil()),
+    };
+    let tail = &body[dl_position + HREF_MARKER.len()..];
+    let dl_end_position = match tail.find('"') {
+        Some(pos) => pos,
+        None => return Ok(uuid::Uuid::nil()),
+    };
+    let dl_id = &tail[..dl_end_position];
+    let dl_url = format!("{}song/download/{}", base_url, dl_id);
+    mk_lib_network::mk_download_file_from_url(dl_url, &tv_show_theme_path).await?;
+    Ok(uuid::Uuid::now_v7())
 }

--- a/src/mk_lib_metadata/src/provider/thegamesdb.rs
+++ b/src/mk_lib_metadata/src/provider/thegamesdb.rs
@@ -2,110 +2,53 @@
 // https://cdn.thegamesdb.net/json/database-latest.json - db dump
 
 use mk_lib_network::mk_lib_network;
+use std::error::Error;
 
-/*
-{"code":200,"status":"Success","last_edit_id":922629,"data":{"count":93323,"games":[{"id":1,"game_title":"Halo: Combat Evolved","release_date":"2003-09-30","platform":1,"region_id":1,"country_id":0,"overview":"In Halo&#039;s twenty-sixth century setting, the player assumes the role of the Master Chief, a cybernetically enhanced super-soldier. The player is accompanied by Cortana, an artificial intelligence who occupies the Master Chief&#039;s neural interface. Players battle various aliens on foot and in vehicles as they attempt to uncover the secrets of the eponymous Halo, a ring-shaped artificial planet.","youtube":"dR3Hm8scbEw","players":16,"coop":"Yes","rating":"M - Mature 17+","developers":[1389,3423],"genres":[1,8],"publishers":[1],"alternates":null,"uids":null,"hashes":null},{"id":2,"game_title":"Crysis","release_date":"2007-11-13","platform":1,"region_id":0,"country_id":0,"overview":"From the makers of Far Cry, Crysis offers FPS fans the best-looking, most highly-evolving gameplay, requiring the player to use adaptive tactics and total customization of weapons and armor to survive in dynamic, hostile environments including Zero-G. \r\n\r\nEarth, 2019. A team of US scientists makes a frightening discovery on an island in the South China Sea. All contact with the team is lost when the North Korean Government quickly seals off the area. The United States responds by dispatching an elite team of Delta Force Operators to recon the situation. As tension rises between the two nations, a massive alien ship reveals itself in the middle of the island. The ship generates an immense force sphere that freezes a vast portion of the island and drastically alters the global weather system. Now the US and North Korea must join forces to battle the alien menace. With hope rapidly fading, you must fight epic battles through tropical jungle, frozen landscapes, and finally into the heart of the alien ship itself for the ultimate Zero G showdown.","youtube":"i3vO01xQ-DM","players":4,"coop":"No","rating":"M - Mature 17+","developers":[1970],"genres":[8],"publishers":[2],"alternates":null,"uids":null,"hashes":null}
- */
-
-pub async fn thegamesdb_database_fetch() {
-    let _json_data: serde_json::Value = mk_lib_network::mk_data_from_url_to_json(
+pub async fn thegamesdb_database_fetch() -> Result<serde_json::Value, Box<dyn Error>> {
+    let json_data = mk_lib_network::mk_data_from_url_to_json(
         "https://cdn.thegamesdb.net/json/database-latest.json".to_string(),
     )
-    .await
-    .unwrap();
+    .await?;
+    Ok(json_data)
 }
 
-pub async fn thegamesdb_platforms_read(api_key: String) {
-    let _json_data: serde_json::Value =
-        mk_lib_network::mk_data_from_url_to_json(format!("https://api.thegamesdb.net/v1/Platforms?apikey={}?fields=icon,console,controller,developer,manufacturer,media,cpu,memory,graphics,sound,maxcontrollers,display,overview,youtube", api_key)).await.unwrap();
+pub async fn thegamesdb_platforms_read(
+    api_key: String,
+) -> Result<serde_json::Value, Box<dyn Error>> {
+    // note: the two query params must be joined with '&', not '?'
+    let url = format!(
+        "https://api.thegamesdb.net/v1/Platforms?apikey={}&fields=icon,console,controller,developer,manufacturer,media,cpu,memory,graphics,sound,maxcontrollers,display,overview,youtube",
+        api_key
+    );
+    Ok(mk_lib_network::mk_data_from_url_to_json(url).await?)
 }
 
-pub async fn thegamesdb_games_updated(api_key: String, edit_id: String) {
-    let _json_data: serde_json::Value = mk_lib_network::mk_data_from_url_to_json(format!(
-        "https://api.thegamesdb.net/v1/Games/Updates?apikey={}?last_edit_id={}",
+pub async fn thegamesdb_games_updated(
+    api_key: String,
+    edit_id: String,
+) -> Result<serde_json::Value, Box<dyn Error>> {
+    let url = format!(
+        "https://api.thegamesdb.net/v1/Games/Updates?apikey={}&last_edit_id={}",
         api_key, edit_id
-    ))
-    .await
-    .unwrap();
+    );
+    Ok(mk_lib_network::mk_data_from_url_to_json(url).await?)
 }
 
-pub async fn thegamesdb_genre_read(api_key: String) {
-    let _json_data: serde_json::Value = mk_lib_network::mk_data_from_url_to_json(format!(
-        "https://api.thegamesdb.net/v1/Genres?apikey={}",
-        api_key
-    ))
-    .await
-    .unwrap();
+pub async fn thegamesdb_genre_read(api_key: String) -> Result<serde_json::Value, Box<dyn Error>> {
+    let url = format!("https://api.thegamesdb.net/v1/Genres?apikey={}", api_key);
+    Ok(mk_lib_network::mk_data_from_url_to_json(url).await?)
 }
 
-pub async fn thegamesdb_developers_read(api_key: String) {
-    let _json_data: serde_json::Value = mk_lib_network::mk_data_from_url_to_json(format!(
-        "https://api.thegamesdb.net/v1/Developers?apikey={}",
-        api_key
-    ))
-    .await
-    .unwrap();
+pub async fn thegamesdb_developers_read(
+    api_key: String,
+) -> Result<serde_json::Value, Box<dyn Error>> {
+    let url = format!("https://api.thegamesdb.net/v1/Developers?apikey={}", api_key);
+    Ok(mk_lib_network::mk_data_from_url_to_json(url).await?)
 }
 
-pub async fn thegamesdb_publishers_read(api_key: String) {
-    let _json_data: serde_json::Value = mk_lib_network::mk_data_from_url_to_json(format!(
-        "https://api.thegamesdb.net/v1/Publishers?apikey={}",
-        api_key
-    ))
-    .await
-    .unwrap();
+pub async fn thegamesdb_publishers_read(
+    api_key: String,
+) -> Result<serde_json::Value, Box<dyn Error>> {
+    let url = format!("https://api.thegamesdb.net/v1/Publishers?apikey={}", api_key);
+    Ok(mk_lib_network::mk_data_from_url_to_json(url).await?)
 }
-/*
-class CommonMetadataGamesDB:
-    """
-    Class for interfacing with theGamesDB
-    """
-
-    pub async fn com_meta_gamesdb_platform_by_id(self, platform_id):
-        """
-        Platform info by id
-        """
-        async with httpx.AsyncClient() as client:
-            return xmltodict.parse(await client.get(self.BASE_URL + 'GetPlatform.php?id=%s' % platform_id,
-                                                    headers=self.httpheaders,
-                                                    timeout=3.05))
-
-    pub async fn com_meta_gamesdb_games_by_name(self, game_name):
-        """
-        # 'mega man'
-        """
-        async with httpx.AsyncClient() as client:
-            return xmltodict.parse(await client.get(self.BASE_URL + 'GetGamesList.php?name=%s'
-                                                    % game_name.replace(' ', '%20'),
-                                                    headers=self.httpheaders,
-                                                    timeout=3.05))
-
-    pub async fn com_meta_gamesdb_games_by_id(self, game_id):
-        """
-        # game by id
-        """
-        async with httpx.AsyncClient() as client:
-            return xmltodict.parse(await client.get(self.BASE_URL + 'GetGamesList.php?id=%s' % game_id,
-                                                    headers=self.httpheaders,
-                                                    timeout=3.05))
-
-    pub async fn com_meta_gamesdb_games_art_by_id(self, game_id):
-        """
-        # game by id
-        """
-        async with httpx.AsyncClient() as client:
-            return xmltodict.parse(await client.get(self.BASE_URL + 'GetArt.php?id=%s' % game_id,
-                                                    headers=self.httpheaders,
-                                                    timeout=3.05))
-
-    pub async fn com_meta_gamesdb_games_by_platform_id(self, platform_id):
-        """
-        Games by platform id
-        """
-        async with httpx.AsyncClient() as client:
-            return xmltodict.parse(await client.get(self.BASE_URL + 'GetPlatformGames.php?platform=%s'
-                                                    % platform_id,
-                                                    headers=self.httpheaders,
-                                                    timeout=3.05))
-
- */

--- a/src/mk_lib_metadata/src/provider/tmdb.rs
+++ b/src/mk_lib_metadata/src/provider/tmdb.rs
@@ -15,6 +15,10 @@ const TMDB_RATE_LIMIT_STATUS_CODE: i64 = 25;
 const TMDB_RATE_LIMIT_RETRY_ATTEMPTS: u8 = 5;
 const TMDB_RATE_LIMIT_RETRY_DELAY_SECONDS: u64 = 2;
 
+fn debug_logging_enabled() -> bool {
+    env::var("DEBUG").ok().as_deref() == Some("true")
+}
+
 async fn tmdb_fetch_json_with_retry(
     url: String,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
@@ -91,7 +95,7 @@ pub async fn provider_tmdb_person_fetch(
     let result_json = provider_tmdb_person_fetch_by_id(tmdb_id, tmdb_api_key)
         .await
         .unwrap();
-    if env::var("DEBUG").unwrap() == "true" {
+    if debug_logging_enabled() {
         mk_lib_logging::mk_lib_logging_loki::mk_logging_loki_push(
             json!({ "Type": "Person", "Module": std::module_path!(), "Result": result_json }),
         )
@@ -102,7 +106,7 @@ pub async fn provider_tmdb_person_fetch(
         println!("Skip Person: {}", tmdb_id);
         return;
     }
-    if env::var("DEBUG").unwrap() == "true" {
+    if debug_logging_enabled() {
         mk_lib_logging::mk_lib_logging_loki::mk_logging_loki_push(
             json!({ "Type": "Person After", "Module": std::module_path!() }),
         )
@@ -287,37 +291,22 @@ pub async fn provider_tmdb_meta_info_build(
         .await
         .unwrap();
     let mut poster_file_path = String::new();
-    if result_json.get("poster_path").is_some() && !result_json["poster_path"].is_null() {
-        image_file_path += &result_json["poster_path"].as_str().unwrap().to_string();
-        //println!("ifilepath {}", image_file_path);
+    let poster_path_value = result_json
+        .get("poster_path")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            result_json
+                .pointer("/images/profiles/0/file_path")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+        });
+    if let Some(poster_rel) = poster_path_value {
+        image_file_path.push_str(&poster_rel);
         let _result = mk_lib_network::mk_download_file_from_url(
-            format!(
-                "https://image.tmdb.org/t/p/original{}",
-                &result_json["poster_path"].as_str().unwrap().to_string()
-            ),
-            &image_file_path,
-        )
-        .await;
-        let _result = mk_lib_image::mk_lib_image::mk_image_file_thumb(&image_file_path);
-        poster_file_path = image_file_path.clone();
-    } else if result_json["images"]["profiles"][0]
-        .get("file_path")
-        .is_some()
-        && !result_json["images"]["profiles"][0]["file_path"].is_null()
-    {
-        image_file_path += &result_json["images"]["profiles"][0]["file_path"]
-            .as_str()
-            .unwrap()
-            .to_string();
-        //println!("ifilepath {}", image_file_path);
-        let _result = mk_lib_network::mk_download_file_from_url(
-            format!(
-                "https://image.tmdb.org/t/p/original{}",
-                &result_json["images"]["profiles"][0]["file_path"]
-                    .as_str()
-                    .unwrap()
-                    .to_string()
-            ),
+            format!("https://image.tmdb.org/t/p/original{}", poster_rel),
             &image_file_path,
         )
         .await;
@@ -329,14 +318,15 @@ pub async fn provider_tmdb_meta_info_build(
         .await
         .unwrap();
     let mut backdrop_file_path = String::new();
-    if result_json.get("backdrop_path").is_some() && !result_json["backdrop_path"].is_null() {
-        image_file_path += &result_json["backdrop_path"].as_str().unwrap().to_string();
-        //println!("iifilepath {}", image_file_path);
+    if let Some(backdrop_rel) = result_json
+        .get("backdrop_path")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+    {
+        image_file_path.push_str(&backdrop_rel);
         let _result = mk_lib_network::mk_download_file_from_url(
-            format!(
-                "https://image.tmdb.org/t/p/original{}",
-                &result_json["backdrop_path"].as_str().unwrap().to_string()
-            ),
+            format!("https://image.tmdb.org/t/p/original{}", backdrop_rel),
             &image_file_path,
         )
         .await;
@@ -357,14 +347,13 @@ pub async fn provider_tmdb_meta_info_build(
 }
 
 pub async fn provider_tmdb_search(guessit_data: Metadata, media_type: i16, tmdb_api_key: &String) {
-    let mut search_text: String = guessit_data.title().to_string().replace(" ", "%20");
-    if guessit_data.year().is_some() {
-        search_text = format!(
-            "{}%20{}",
-            search_text,
-            guessit_data.year().unwrap().to_string()
-        );
+    let mut raw_query = guessit_data.title().to_string();
+    if let Some(year) = guessit_data.year() {
+        raw_query.push(' ');
+        raw_query.push_str(&year.to_string());
     }
+    let search_text: String =
+        url::form_urlencoded::byte_serialize(raw_query.as_bytes()).collect();
     match media_type {
         mk_lib_common_enum_media_type::DLMediaType::MOVIE
         | mk_lib_common_enum_media_type::DLMediaType::MOVIE_EXTRAS
@@ -374,10 +363,9 @@ pub async fn provider_tmdb_search(guessit_data: Metadata, media_type: i16, tmdb_
             let _url_result = tmdb_fetch_json_with_retry(format!(
                 "https://api.themoviedb.org/3/search/movie\
                 ?api_key={}&include_adult=1&query={}",
-                search_text, tmdb_api_key
+                tmdb_api_key, search_text
             ))
-            .await
-            .unwrap();
+            .await;
         }
         mk_lib_common_enum_media_type::DLMediaType::TV
         | mk_lib_common_enum_media_type::DLMediaType::TV_EPISODE
@@ -389,19 +377,17 @@ pub async fn provider_tmdb_search(guessit_data: Metadata, media_type: i16, tmdb_
             let _url_result = tmdb_fetch_json_with_retry(format!(
                 "https://api.themoviedb.org/3/search/tv\
                 ?api_key={}&include_adult=1&query={}",
-                search_text, tmdb_api_key
+                tmdb_api_key, search_text
             ))
-            .await
-            .unwrap();
+            .await;
         }
         mk_lib_common_enum_media_type::DLMediaType::PERSON => {
             let _url_result = tmdb_fetch_json_with_retry(format!(
                 "https://api.themoviedb.org/3/search/person\
                 ?api_key={}&include_adult=1&query={}",
-                search_text, tmdb_api_key
+                tmdb_api_key, search_text
             ))
-            .await
-            .unwrap();
+            .await;
         }
         _ => eprintln!("provider_tmdb_search type does not equal any value"),
     }


### PR DESCRIPTION
## Summary

Hardens `src/mk_lib_metadata`, the crate that fetches metadata from the various provider APIs. The biggest wins are a real bug in `provider_tmdb_search` (the api key and the search term were swapped, so every search URL shipped the title as `api_key=` and the real key as `query=`) and a malformed `thegamesdb` URL where two `?` characters were concatenated.

### Bugs fixed
- **`provider/tmdb.rs`** — argument order swap in all three `search/{movie,tv,person}` URLs. This would have made every TMDB search request fail.
- **`provider/thegamesdb.rs`** — `?apikey={}?fields=` → `&fields=`. Same pattern in the `Games/Updates` URL (`?apikey={}?last_edit_id=` → `&last_edit_id=`).
- **`provider/televisiontunes.rs`** — the HTML parser used `Substring::substring(pos+21, pos+50)` and then searched for `"` inside that fixed 29-char window; a download id longer than 29 chars silently panicked, and anything wrong on the page (missing anchor, non-UTF8 bytes, moved markup) panicked with `unwrap()`. Rewrote to walk from the marker forward and return `Uuid::nil()` on any mismatch.

### Panic-to-error conversions
- `guessit.rs`, `game.rs`: replace chained unwraps on `mm_download_path → file_name → to_str` with `?`-style propagation.
- `base.rs`: stop panicking when `DEBUG` env var is unset; the loki push result is now discarded with `let _` instead of unwrapped.
- `provider/tmdb.rs`: same `env::var("DEBUG").unwrap()` fix via a tiny `debug_logging_enabled()` helper; collapse chained `poster_path`/`backdrop_path`/`images.profiles[0].file_path` unwraps into `.and_then(Value::as_str)` chains that skip gracefully when the JSON shape differs.
- `provider/soundcloud.rs`: return `io::Error` for missing env var instead of panicking; propagate search errors instead of `.unwrap()`.
- `provider/giant_bomb.rs`, `provider/shoutcast.rs`, `provider/thegamesdb.rs`: propagate network/JSON errors instead of `.unwrap()`.
- `mk_lib_metadata_m3u8.rs`: propagate `MediaPlaylist::parse` error.
- `provider/imvdb.rs`: `.unwrap()` on the primary `video_fetch_by_id` call becomes `?`.

### URL-encoding cleanups
- `provider/tmdb.rs`: search query built with `url::form_urlencoded::byte_serialize` so titles with `&`, `#`, `=`, non-ASCII, etc. survive. (Previously only spaces were replaced with `%20`.)
- `provider/televisiontunes.rs`: show name percent-encoded before being glued into the URL.
- `provider/imvdb.rs`: band/song names percent-encoded the same way; dropped the bogus leading `/` in the query (`q=/{}` → `q={}`). Also bumped the `imvdb.com` base URL to `https://`.

### Misc
- Doc-annotated `giant_bomb` mentioning that the key appears in URLs and should be treated as low-sensitivity/rotated.
- Added `url = "2.5"` to `Cargo.toml` for the percent-encoding helpers.

## Test plan
- [ ] `cargo check -p mk_lib_metadata`
- [ ] `cargo test -p mk_lib_metadata`
- [ ] Smoke-test TMDB search in a dev build — previously `search_text` was going to `api_key=` so these calls should start returning real results.
- [ ] Smoke-test `thegamesdb_platforms_read` / `thegamesdb_games_updated` to confirm the URL fix yields a 200.

https://claude.ai/code/session_0156KVpZNzCVtt2TwxxEmr3i