### PR TITLE
Harden mk_lib_network: creds, panics, broken URL+CIDR

### DIFF
--- a/src/mk_lib_network/Cargo.toml
+++ b/src/mk_lib_network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mk_lib_network"
-version = "0.0.204"
+version = "0.0.205"
 edition = "2024"
 
 [profile.release]

--- a/src/mk_lib_network/src/mk_lib_network.rs
+++ b/src/mk_lib_network/src/mk_lib_network.rs
@@ -60,17 +60,19 @@ pub async fn mk_data_from_url_to_json_custom_headers(
 pub async fn mk_data_from_url_to_json(
     url: String,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
-    let retry_policy = ExponentialBackoff::builder().build_with_max_retries(100);
+    // 100 retries with exponential backoff would stall callers for hours on a
+    // permanent upstream failure; 3 attempts is plenty for transient blips.
+    let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
     let client = ClientBuilder::new(reqwest::Client::new())
         .with(RetryTransientMiddleware::new_with_policy(retry_policy))
         .build();
     let res: serde_json::Value = client
         .get(url)
         .timeout(Duration::from_secs(30))
-        .header(CONTENT_TYPE, "Content-Type: application/json")
+        .header(CONTENT_TYPE, "application/json")
         .header(
             USER_AGENT,
-            "User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0",
+            "Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0",
         )
         .send()
         .await?
@@ -166,24 +168,26 @@ pub async fn mk_download_file_from_url_tokio(
 }
 
 // wait_seconds - 120 typically
-pub async fn mk_network_service_available(host_dns: &str, host_port: &str, wait_seconds: &str) {
+pub async fn mk_network_service_available(
+    host_dns: &str,
+    host_port: &str,
+    wait_seconds: &str,
+) -> Result<(), std::io::Error> {
     let mut command_string = "/mediakraken/wait-for-it-bash.sh";
     if std::path::Path::new("/mediakraken/wait-for-it-ash-busybox130.sh").exists() {
         command_string = "/mediakraken/wait-for-it-ash-busybox130.sh";
     } else if std::path::Path::new("/mediakraken/wait-for-it-ash.sh").exists() {
         command_string = "/mediakraken/wait-for-it-ash.sh";
     }
-    if let Err(error) = std::process::Command::new(command_string)
+    tokio::process::Command::new(command_string)
         .arg("-h")
         .arg(host_dns)
         .arg("-p")
         .arg(host_port)
         .arg("-t")
         .arg(wait_seconds)
-        .spawn()
-    {
-        panic!("failed to launch wait script {command_string}: {error}");
-    }
+        .spawn()?;
+    Ok(())
 }
 
 // cargo test -- --show-output

--- a/src/mk_lib_network/src/mk_lib_network_email.rs
+++ b/src/mk_lib_network/src/mk_lib_network_email.rs
@@ -2,6 +2,12 @@
 
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{Message, SmtpTransport, Transport};
+use std::error::Error;
+
+/// SMTP relay host. Defaults to Gmail; override with `MK_SMTP_RELAY`.
+fn smtp_relay_host() -> String {
+    std::env::var("MK_SMTP_RELAY").unwrap_or_else(|_| "smtp.gmail.com".to_string())
+}
 
 pub async fn mk_lib_network_email_send(
     email_from: String,
@@ -11,26 +17,21 @@ pub async fn mk_lib_network_email_send(
     email_body: String,
     user_name: String,
     user_password: String,
-) {
+) -> Result<(), Box<dyn Error + Send + Sync>> {
     let email = Message::builder()
-        .from(email_from.parse().unwrap())
-        .reply_to(email_reply_to.parse().unwrap())
-        .to(email_to.parse().unwrap())
+        .from(email_from.parse().map_err(|e| format!("invalid From {email_from:?}: {e}"))?)
+        .reply_to(
+            email_reply_to
+                .parse()
+                .map_err(|e| format!("invalid Reply-To {email_reply_to:?}: {e}"))?,
+        )
+        .to(email_to.parse().map_err(|e| format!("invalid To {email_to:?}: {e}"))?)
         .subject(email_subject)
-        .body(String::from(email_body))
-        .unwrap();
+        .body(email_body)?;
 
-    let creds = Credentials::new(user_name.to_string(), user_password.to_string());
-
-    // Open a remote connection to gmail
-    let mailer = SmtpTransport::relay("smtp.gmail.com")
-        .unwrap()
-        .credentials(creds)
-        .build();
-
-    // Send the email
-    match mailer.send(&email) {
-        Ok(_) => println!("Email sent successfully!"),
-        Err(e) => panic!("Could not send email: {:?}", e),
-    }
+    let creds = Credentials::new(user_name, user_password);
+    let relay = smtp_relay_host();
+    let mailer = SmtpTransport::relay(&relay)?.credentials(creds).build();
+    mailer.send(&email)?;
+    Ok(())
 }

--- a/src/mk_lib_network/src/mk_lib_network_transmission.rs
+++ b/src/mk_lib_network/src/mk_lib_network_transmission.rs
@@ -1,11 +1,11 @@
 // https://github.com/j0rsa/transmission-rpc
 
 use serde::{Deserialize, Serialize};
+use transmission_rpc::TransClient;
 use transmission_rpc::types::{
     BasicAuth, Id, Nothing, Result, RpcResponse, SessionClose, Torrent, TorrentAction,
-    TorrentAddArgs, TorrentAddedOrDuplicate, TorrentGetField, TorrentStatus, Torrents,
+    TorrentAddArgs, TorrentAddedOrDuplicate, TorrentStatus, Torrents,
 };
-use transmission_rpc::TransClient;
 
 // https://docs.rs/transmission-rpc/0.4.2/transmission_rpc/types/struct.Torrent.html#structfield.added_date
 #[derive(Debug, Deserialize, Serialize)]
@@ -17,28 +17,32 @@ pub struct TorrentList {
     pub mm_torrent_percent_done: f32, // percent_done
 }
 
-pub async fn mk_network_transmission_login() -> Result<transmission_rpc::TransClient> {
-    let transmission_client = TransClient::with_auth(
-        //"http://mkprod:9091/transmission/rpc".parse().unwrap(),
-        "http://mkstack-transmission:9091/transmission/rpc"
-            .parse()
-            .unwrap(),
-        BasicAuth {
-            user: "admin".to_string(),
-            password: "metaman".to_string(),
-        },
-    );
-    Ok(transmission_client)
+const DEFAULT_TRANSMISSION_URL: &str = "http://mkstack-transmission:9091/transmission/rpc";
+
+/// Build a Transmission RPC client.
+///
+/// Reads `MK_TRANSMISSION_URL`, `MK_TRANSMISSION_USER`, and
+/// `MK_TRANSMISSION_PASSWORD` from the environment. The user and password are
+/// required; this returns an error if either is unset rather than baking
+/// credentials into the binary.
+pub async fn mk_network_transmission_login()
+-> std::result::Result<transmission_rpc::TransClient, Box<dyn std::error::Error + Send + Sync>> {
+    let url_str = std::env::var("MK_TRANSMISSION_URL")
+        .unwrap_or_else(|_| DEFAULT_TRANSMISSION_URL.to_string());
+    let url = url_str
+        .parse()
+        .map_err(|e| format!("invalid MK_TRANSMISSION_URL {url_str:?}: {e}"))?;
+    let user = std::env::var("MK_TRANSMISSION_USER")
+        .map_err(|_| "MK_TRANSMISSION_USER env var not set")?;
+    let password = std::env::var("MK_TRANSMISSION_PASSWORD")
+        .map_err(|_| "MK_TRANSMISSION_PASSWORD env var not set")?;
+    Ok(TransClient::with_auth(url, BasicAuth { user, password }))
 }
 
 pub async fn mk_network_transmission_close(
     mut transmission_client: transmission_rpc::TransClient,
 ) -> Result<()> {
-    let response: Result<RpcResponse<SessionClose>> = transmission_client.session_close().await;
-    match response {
-        Ok(_) => println!("Yay!"),
-        Err(_) => panic!("Oh no!"),
-    }
+    let _: RpcResponse<SessionClose> = transmission_client.session_close().await?;
     Ok(())
 }
 
@@ -77,12 +81,14 @@ pub async fn mk_network_transmission_list_torrents(
         .arguments
         .torrents
         .iter()
-        .map(|it| TorrentList {
-            mm_torrent_id: it.id.unwrap(),
-            mm_torrent_name: it.name.clone().unwrap(),
-            mm_torrent_status: format!("{:?}", TorrentStatus::from(it.status.unwrap())),
-            mm_torrent_size: it.total_size.unwrap(),
-            mm_torrent_percent_done: it.percent_done.unwrap(),
+        .filter_map(|it| {
+            Some(TorrentList {
+                mm_torrent_id: it.id?,
+                mm_torrent_name: it.name.clone()?,
+                mm_torrent_status: format!("{:?}", TorrentStatus::from(it.status?)),
+                mm_torrent_size: it.total_size?,
+                mm_torrent_percent_done: it.percent_done?,
+            })
         })
         .collect();
     Ok(torrent_rows)

--- a/src/mk_lib_network/src/mk_lib_network_upnp_easy.rs
+++ b/src/mk_lib_network/src/mk_lib_network_upnp_easy.rs
@@ -24,7 +24,7 @@ fn get_configs() -> Result<[UpnpConfig; 3], Box<dyn Error>> {
     };
 
     let config_address_range = UpnpConfig {
-        address: Some(Ipv4Cidr::from_str("192.168.0")?),
+        address: Some(Ipv4Cidr::from_str("192.168.0.0/24")?),
         port: 8081,
         protocol: PortMappingProtocol::TCP,
         duration: 3600,


### PR DESCRIPTION
## Summary

Hardening pass over `src/mk_lib_network`. Scoped to clear bugs and hardcoded secrets — left the nmap/rustscan share-scanning code alone, it needs a bigger refactor that belongs in its own PR.

**Hardcoded credentials**
- `mk_lib_network_transmission.rs` was shipping `admin` / `metaman` baked into the binary. Moved to `MK_TRANSMISSION_USER` / `MK_TRANSMISSION_PASSWORD`, plus `MK_TRANSMISSION_URL` for the RPC endpoint. `login()` now returns an error (instead of panicking on `parse().unwrap()`) if any of those are unset or malformed.

**Panics removed**
- `mk_network_transmission_close`: `panic!("Oh no!")` → `?`.
- `mk_network_transmission_list_torrents`: per-field `.unwrap()` cascade on optional torrent fields swapped for `filter_map` so one torrent missing a field no longer kills the whole listing.
- `mk_lib_network_email_send`: returned `()` and panicked on every failure. Now returns `Result` and propagates errors. Added `MK_SMTP_RELAY` env var (defaults to `smtp.gmail.com`).
- `mk_network_service_available`: `panic!` on spawn failure + blocking `std::process::Command` inside an async fn → returns `Result` and uses `tokio::process::Command`.

**Other bugs**
- `mk_lib_network_upnp_easy.rs`: `Ipv4Cidr::from_str("192.168.0")` isn't a valid CIDR — this would have errored the first time the range config was used. Corrected to `192.168.0.0/24`.
- `mk_data_from_url_to_json`: retry count was 100 (exponential backoff → literal hours of delay on a permanent upstream failure). Dropped to 3. Also fixed malformed header values — `header(CONTENT_TYPE, "Content-Type: application/json")` was sending `Content-Type: Content-Type: application/json`. Same for `User-Agent`.

**Out of scope (flagging for follow-up)**
- `mk_lib_network_share.rs` uses `std::process::Command` inside `async fn` for nmap / rustscan and has ~27 `.unwrap()` calls across XML/JSON parsing. Needs a proper rewrite (switch to `tokio::process::Command`, propagate errors, bounds-check the nmap XML traversal). Skipping in this PR to keep scope tight.
- `mk_lib_network_ldap.rs` only builds a connection string, no filter interpolation — no actual injection risk today.
- Generic HTTP wrappers (`mk_data_from_url_*`, `mk_download_file_*`) don't validate schemes or block private IPs; since this is a low-level networking helper crate, SSRF protection belongs at the caller (each provider/loader that takes a URL from config).

## Test plan

- [ ] `cargo test -p mk_lib_network` once kellnr is reachable
- [ ] Integration test: start a Transmission container, set the three env vars, call `mk_network_transmission_login` + `list_torrents`
- [ ] Verify `mk_network_transmission_login` with missing env vars returns a readable error instead of panicking
- [ ] Call `mk_lib_network_email_send` with an obviously bad From address and confirm the error propagates instead of aborting
- [ ] Call `upnp_open_ports` and confirm the range config no longer errors at startup

https://claude.ai/code/session_0156KVpZNzCVtt2TwxxEmr3i