### PR TITLE
Fix Loki query URL construction to use Url::parse_with_params

### DIFF
--- a/src/mk_lib_logging/src/mk_lib_logging_loki.rs
+++ b/src/mk_lib_logging/src/mk_lib_logging_loki.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-use reqwest::Client;
+use reqwest::{Client, Url};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
 use serde::Deserialize;
@@ -186,16 +186,24 @@ pub async fn mk_logging_loki_read(
 
     // FIX 2 & 3: Use `retrying_client()` (exponential back-off, same as push)
     // and add a 30-second timeout so the caller is never blocked indefinitely.
-    let resp: LokiResponse = retrying_client()
-        .get(LOKI_QUERY_URL)
-        .timeout(Duration::from_secs(30))       // FIX 2: was missing
-        .query(&[
+    // `reqwest_middleware::RequestBuilder` does not expose `.query()`, so build
+    // the URL with query parameters up front via `Url::parse_with_params`.
+    let start_str = start_ns.to_string();
+    let end_str = now_ns.to_string();
+    let url = Url::parse_with_params(
+        LOKI_QUERY_URL,
+        &[
             ("query", query.as_str()),
             ("limit", "100"),
             ("direction", "backward"),
-            ("start", &start_ns.to_string()),
-            ("end", &now_ns.to_string()),
-        ])
+            ("start", start_str.as_str()),
+            ("end", end_str.as_str()),
+        ],
+    )?;
+
+    let resp: LokiResponse = retrying_client()
+        .get(url)
+        .timeout(Duration::from_secs(30))
         .send()
         .await?
         .error_for_status()?


### PR DESCRIPTION
## Summary
Refactored the Loki read query to properly construct the URL with query parameters using `Url::parse_with_params` instead of relying on the `.query()` method, which is not exposed by `reqwest_middleware::RequestBuilder`.

## Key Changes
- Added `Url` import from `reqwest` crate
- Replaced inline `.query()` builder method with upfront URL construction using `Url::parse_with_params()`
- Extracted `start_ns` and `now_ns` string conversions into separate variables (`start_str` and `end_str`) to ensure proper lifetime management for the query parameters slice
- Maintained existing functionality: 30-second timeout and exponential backoff retry behavior

## Implementation Details
The change addresses a limitation where `reqwest_middleware::RequestBuilder` doesn't expose the `.query()` method. By constructing the complete URL with query parameters before passing it to the client, we maintain the same behavior while working within the constraints of the middleware wrapper. The string variables are kept in scope to ensure the string references in the query parameters slice remain valid.

https://claude.ai/code/session_013Gr5wCePjSmJgrv66HoXZ4