### PR TITLE
Improve error handling for Roku SSDP field map creation

### DIFF
--- a/src/mk_lib_hardware/src/mk_lib_hardware_roku.rs
+++ b/src/mk_lib_hardware/src/mk_lib_hardware_roku.rs
@@ -11,7 +11,9 @@ pub async fn mk_lib_hardware_roku_discover() -> Result<Vec<Url>, Box<dyn std::er
     let mut request = SearchRequest::new();
     request.set(Man);
     request.set(MX(5));
-    request.set(ST::Target(ssdp::FieldMap::new("roku:ecp")?));
+    request.set(ST::Target(
+        ssdp::FieldMap::new("roku:ecp").ok_or("invalid SSDP field map for roku:ecp")?,
+    ));
     let mut urls = Vec::new();
     for (res, _) in request.multicast()? {
         let Some(loc) = res.get_raw("Location") else {


### PR DESCRIPTION
## Summary
Updated error handling in the Roku device discovery function to provide more descriptive error messages when SSDP field map creation fails.

## Key Changes
- Changed `ssdp::FieldMap::new("roku:ecp")?` to use explicit error handling with `ok_or()` instead of relying on the `?` operator
- Added a descriptive error message: "invalid SSDP field map for roku:ecp" to clarify what went wrong during field map creation
- Reformatted the `ST::Target` assignment across multiple lines for improved readability

## Implementation Details
The change converts an implicit error propagation pattern to an explicit one, allowing for a custom error message that provides better context when the Roku ECP (External Control Protocol) SSDP field map initialization fails. This improves debuggability when device discovery encounters issues.

https://claude.ai/code/session_01YJ7MVEn388ueAVSjMQArRn