### PR TITLE
Update wkhtmlapp API usage for HTML image rendering

### DIFF
--- a/src/mk_lib_image/Cargo.toml
+++ b/src/mk_lib_image/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mk_lib_image"
-version = "0.0.202"
+version = "0.0.203"
 edition = "2024"
 
 [profile.release]

--- a/src/mk_lib_image/src/mk_lib_image_html.rs
+++ b/src/mk_lib_image/src/mk_lib_image_html.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use wkhtmlapp::{ImageBuilder, Source};
+use wkhtmlapp::{ImgApp, WkhtmlInput};
 
 /// Render the supplied HTML fragment to an image file at `output_path`.
 ///
@@ -11,10 +11,8 @@ pub async fn mk_lib_image_render_html(
     output_path: String,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     tokio::task::spawn_blocking(move || -> Result<(), Box<dyn Error + Send + Sync>> {
-        ImageBuilder::new(Source::Html(html_content))
-            .output_file(&output_path)
-            .build()?
-            .run()?;
+        let mut image_app = ImgApp::new()?;
+        image_app.run(WkhtmlInput::Html(&html_content), &output_path)?;
         Ok(())
     })
     .await?


### PR DESCRIPTION
## Summary
Updated the HTML to image rendering implementation to use the new `wkhtmlapp` API, replacing the builder pattern with a direct `ImgApp` interface.

## Key Changes
- Replaced `ImageBuilder` and `Source` imports with `ImgApp` and `WkhtmlInput`
- Refactored rendering logic from builder pattern to imperative API:
  - Changed from `ImageBuilder::new(Source::Html(html_content)).output_file(&output_path).build()?.run()?` 
  - To `ImgApp::new()?.run(WkhtmlInput::Html(&html_content), &output_path)?`
- Bumped version from 0.0.202 to 0.0.203

## Implementation Details
The new API simplifies the rendering flow by:
- Creating an `ImgApp` instance directly with error handling
- Passing both the HTML input and output path to a single `run()` method call
- Reducing the number of intermediate builder steps and method chains

https://claude.ai/code/session_018yom35F7bDEXurxDrz2mj1