### PR TITLE
Refactor mkrabbitconsume: simplify shutdown and remove legacy code

### DIFF
--- a/docker/core/mkrabbitconsume/Cargo.toml
+++ b/docker/core/mkrabbitconsume/Cargo.toml
@@ -17,22 +17,10 @@ codegen-units = 1
 
 [dependencies]
 mk_lib_database = { version = "0.0.235", registry = "kellnr" }
-mk_lib_logging = { version = "0.0.204", registry = "kellnr" }
-mk_lib_network = { version = "0.0.204", registry = "kellnr" }
 mk_lib_rabbitmq = { version = "0.0.207", registry = "kellnr" }
 
-chrono = { version = "0.4.43", features = ["serde"] }
-reqwest = { version = "0.12.28", default-features = false, features = [
-    "json",
-    "rustls-tls",
-] }
-rustls = "0.23.27"
-serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.148"
-stdext = "0.3.3"
-sys-info = "0.9.1"
 tokio = { version = "1.49.0", features = ["full"] }
-uuid = { version = "1.19.0", features = ["serde", "v4", "v7"] }
 
 [dev-dependencies]
 tokio-test = "*"

--- a/docker/core/mkrabbitconsume/src/main.rs
+++ b/docker/core/mkrabbitconsume/src/main.rs
@@ -2,181 +2,81 @@ use mk_lib_database;
 use mk_lib_rabbitmq;
 use serde_json::Value;
 use std::error::Error;
-use tokio::sync::Notify;
+use tokio::signal;
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // connect to db and do a version check
     let (_sqlx_pool_rw, sqlx_pool_ro) =
-        mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120)
-            .await
-            .unwrap();
+        mk_lib_database::mk_lib_database::mk_lib_database_open_pool(1, 120).await?;
     mk_lib_database::mk_lib_database_version::mk_lib_database_version_check(&sqlx_pool_ro, false)
-        .await;
+        .await?;
     let _option_config_json =
-        &mk_lib_database::mk_lib_database_option_status::mk_lib_database_option_read(&sqlx_pool_ro)
+        mk_lib_database::mk_lib_database_option_status::mk_lib_database_option_read(&sqlx_pool_ro)
             .await?;
 
     let (_rabbit_connection, rabbit_channel) =
-        mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_connect("mkrabbitconsume")
-            .await
-            .unwrap();
+        mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_connect("mkrabbitconsume").await?;
 
-    // Declare the queue.
     let mut rabbit_consumer =
         mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_consumer("mkrabbitconsume", &rabbit_channel)
-            .await
-            .unwrap();
+            .await?;
 
-    tokio::spawn(async move {
-        while let Some(msg) = rabbit_consumer.recv().await {
-            if let Some(payload) = msg.content {
-                let _json_message: Value = match serde_json::from_slice(&payload) {
-                    Ok(message) => message,
-                    Err(_) => continue,
+    loop {
+        tokio::select! {
+            _ = shutdown_signal() => {
+                eprintln!("mkrabbitconsume: shutdown signal received");
+                return Ok(());
+            }
+            msg = rabbit_consumer.recv() => {
+                let Some(msg) = msg else {
+                    eprintln!("mkrabbitconsume: rabbit consumer closed");
+                    return Ok(());
                 };
 
-                /*
-                Do I actually launch a docker swarm container that checks for cuda
-                and then that launches the slave container with ffmpeg
+                if let Some(payload) = msg.content {
+                    match serde_json::from_slice::<Value>(&payload) {
+                        Ok(_json_message) => {
+                            // TODO: implement playback dispatch (cast/hdhomerun/hls/web/roku).
+                            // Previously a Python translation lived here; it has been removed
+                            // while the port is pending.
+                        }
+                        Err(error) => {
+                            eprintln!("mkrabbitconsume: malformed payload ({error})");
+                        }
+                    }
+                }
 
-                # this is for the debian one
-                docker run -it --rm $(ls /dev/nvidia* | xargs -I{} echo "--device={}") $(ls /usr/lib/x86_64-linux-gnu/{libcuda,libnvidia}* | xargs -I{} echo "-v {}:{}:ro") mediakraken/mkslavenvidiadebian
-
-                --device /dev/nvidia0:/dev/nvidia0 \
-                --device /dev/nvidiactl:/dev/nvidiactl \
-
-                The minimum required Nvidia driver for nvenc is 378.13 or newer from ffmpeg error
-                """
-                if body != None:
-                    json_message = json.loads(body)
-                    if json_message["Type"] == "Playback":
-                        if json_message["Subtype"] == "Play":
-                            # to address the 30 char name limit for container
-                            name_container = (json_message["User"] + "_"
-                                              + str(uuid.uuid4()).replace("-", ""))[:30]
-                            // TODO only for now until I get the device for websessions (cookie perhaps?)
-                            if "Device" in json_message:
-                                define_new_container = (name_container, json_message["Device"])
-                            else:
-                                define_new_container = (name_container, None)
-                            if json_message["User"] in mk_containers:
-                                user_activity_list = mk_containers[json_message["User"]]
-                                user_activity_list.append(define_new_container)
-                                mk_containers[json_message["User"]] = user_activity_list
-                            else:
-                                # "double list" so each one is it"s own instance
-                                mk_containers[json_message["User"]] = (define_new_container)
-                            container_command = None
-                            if json_message["Device"] == "Cast":
-                                # should only need to check for subs on initial play command
-                                if "Subtitle" in json_message:
-                                    subtitle_command = " -subtitles " + json_message["Subtitle"]
-                                else:
-                                    subtitle_command = ""
-                                return_video_container, return_video_codec, return_audio_codec, return_audio_channels \
-                                    = common_device_capability.com_device_compat_best_fit(
-                                    device_type="Chromecast",
-                                    device_model=None,
-                                    video_container=None,
-                                    video_codec=None,
-                                    audio_codec=None,
-                                    audio_channels=None)
-                                // TODO take number of channels into account
-                                // TODO take the video codec into account
-                                container_command = "castnow --tomp4 --ffmpeg-acodec ac3 --ffmpeg-movflags " \
-                                                    "frag_keyframe+empty_moov+faststart --address " \
-                                                    + json_message["Target"] + " --myip " \
-                                                    + docker_inst.com_docker_info()["Swarm"]["NodeAddr"] \
-                                                    + subtitle_command + " \"" + json_message["Data"] + "\""
-                                hwaccel = False
-                                docker_inst.com_docker_run_cast(hwaccel=hwaccel,
-                                                                name_container=name_container,
-                                                                container_command=container_command)
-                            else if json_message["Device"] == "HDHomerun":
-                                # stream from hdhomerun
-                                container_command = "ffmpeg -i http://" + json_message["IP"] \
-                                                    + ":5004/auto/v" + json_message["Channel"] \
-                                                    + "?transcode=" + json_message[
-                                                        "Quality"] + "-vcodec copy" \
-                                                    + "./static/streams/" + \
-                                                    json_message["Channel"] + ".m3u8"
-                            else if json_message["Device"] == "HLS":
-                                # stream to hls
-                                // TODO take the video codec into account
-                                container_command = "ffmpeg -i \"" + json_message["Input File"] \
-                                                    + "\" -vcodec libx264 -preset veryfast" \
-                                                    + " -acodec aac -ac:a:0 2 -vbr 5 " \
-                                                    + json_message["Audio Track"] \
-                                                    + "-vf " + json_message["Subtitle Track"] \
-                                                    + " yadif=0:0:0 " \
-                                                    + json_message["Target UUID"]
-                            else if json_message["Device"] == "Roku":
-                                pass
-                            else if json_message["Device"] == "Web":
-                                # stream to web
-                                container_command = "ffmpeg -v fatal {ss_string}" \
-                                                    + " -i ".format(**locals()) \
-                                                    + json_message["Data"] \
-                                                    + "-c:a aac -strict experimental -ac 2 -b:a 64k" \
-                                                      " -c:v libx264 -pix_fmt yuv420p" \
-                                                      " -profile:v high -level 4.0" \
-                                                      " -preset ultrafast -trellis 0" \
-                                                      " -crf 31 -vf scale=w=trunc(oh*a/2)*2:h=480" \
-                                                      " -shortest -f mpegts" \
-                                                      " -output_ts_offset {output_ts_offset:.6f}" \
-                                                      " -t {t:.6f} pipe:%d.ts".format(**locals())
-                            else:
-                                common_logging_elasticsearch_httpx.com_es_httpx_post(
-                                    message_type="critical", message_text=
-                                    {"stuff": "unknown subtype"})
-                            if container_command != None:
-                                hwaccel = False
-                                docker_inst.com_docker_run_slave(hwaccel=hwaccel,
-                                                                 port_mapping=None,
-                                                                 name_container=name_container,
-                                                                 container_command=container_command)
-                        else if json_message["Subtype"] == "Stop":
-                            # this will force stop the container and then delete it
-                            common_logging_elasticsearch_httpx.com_es_httpx_post(message_type="info",
-                                                                                 message_text={
-                                                                                     "user stop":
-                                                                                         mk_containers[
-                                                                                             json_message[
-                                                                                                 "User"]]})
-                            docker_inst.com_docker_delete_container(
-                                container_image_name=mk_containers[json_message["User"]])
-                        else if json_message["Subtype"] == "Pause":
-                            if json_message["Device"] == "Cast":
-                                pass
-
-                            # if json_message["Device Type"] == "Slave":
-                            #     if json_message["Command"] == "Chapter Back":
-                            #         pass
-                            #     else if json_message["Command"] == "Chapter Forward":
-                            #         pass
-                            #     else if json_message["Command"] == "Fast Forward":
-                            #         pass
-                            #     else if json_message["Command"] == "Pause":
-                            #         pass
-                            #     else if json_message["Command"] == "Play":
-                            #         pass
-                            #     else if json_message["Command"] == "Rewind":
-                            #         pass
-                            #     else if json_message["Command"] == "Stop":
-                            #         os.killpg(self.proc_ffmpeg_stream.pid, signal.SIGTERM)
-                             */
-                if let Some(delivery) = msg.deliver {
-                    let _result = mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_ack(
+                if let Some(deliver) = msg.deliver {
+                    if let Err(error) = mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_ack(
                         &rabbit_channel,
-                        delivery.delivery_tag(),
+                        deliver.delivery_tag(),
                     )
-                    .await;
+                    .await
+                    {
+                        eprintln!("mkrabbitconsume: rabbit ack failed ({error})");
+                    }
                 }
             }
         }
-    });
-    let guard = Notify::new();
-    guard.notified().await;
-    Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
Refactored the mkrabbitconsume service to implement proper graceful shutdown handling and removed a large block of legacy/commented-out Python translation code that was pending implementation.

## Key Changes
- **Graceful shutdown**: Replaced the `Notify`-based blocking mechanism with a proper `tokio::select!` loop that handles both Ctrl+C and SIGTERM signals
- **Improved error handling**: Changed from `.unwrap()` calls to the `?` operator for better error propagation throughout the main function
- **Simplified message processing**: Converted the spawned task into a main loop with `tokio::select!` for cleaner control flow
- **Removed legacy code**: Deleted ~100 lines of commented-out Python translation code related to playback dispatch (cast/hdhomerun/hls/web/roku devices)
- **Better logging**: Added informative error messages for shutdown signals, consumer closure, malformed payloads, and RabbitMQ acknowledgment failures
- **Cleaned up dependencies**: Removed unused crate dependencies (mk_lib_logging, mk_lib_network, chrono, reqwest, rustls, serde, stdext, sys-info, uuid)

## Implementation Details
- The new `shutdown_signal()` async function centralizes signal handling logic
- Message processing now uses pattern matching with `let Some(msg) = msg else` for clearer intent
- Error handling for RabbitMQ acknowledgment is now explicit with error logging instead of silently discarding results
- Database pool size reduced from 50 to 1 connection since this is a consumer service

https://claude.ai/code/session_01UC5eYZ4kJb3fo4RNJoLVZE