### PR TITLE
Refactor mkmediascanner: async I/O, improved error handling, and code organization

### DIFF
--- a/docker/core/mkmediascanner/Cargo.toml
+++ b/docker/core/mkmediascanner/Cargo.toml
@@ -22,6 +22,7 @@ mk_lib_file = { version = "0.0.212", registry = "kellnr", features = ["smb"] }
 mk_lib_logging = { version = "0.0.204", registry = "kellnr" }
 mk_lib_rabbitmq = { version = "0.0.207", registry = "kellnr" }
 
+amqprs = "2.1.3"
 chrono = { version = "0.4.43", features = ["serde"] }
 fancy-regex = "0.14.0"
 lazy_static = "1.5.0"

--- a/docker/core/mkmediascanner/Cargo.toml
+++ b/docker/core/mkmediascanner/Cargo.toml
@@ -18,8 +18,7 @@ codegen-units = 1
 [dependencies]
 mk_lib_common = { version = "0.0.203", registry = "kellnr" }
 mk_lib_database = { version = "0.0.235", registry = "kellnr" }
-mk_lib_file = { version = "0.0.212", registry = "kellnr", features=["smb"] }
-   # features=["nfs", "smb"] }
+mk_lib_file = { version = "0.0.212", registry = "kellnr", features = ["smb"] }
 mk_lib_logging = { version = "0.0.204", registry = "kellnr" }
 mk_lib_rabbitmq = { version = "0.0.207", registry = "kellnr" }
 
@@ -27,18 +26,9 @@ chrono = { version = "0.4.43", features = ["serde"] }
 fancy-regex = "0.14.0"
 lazy_static = "1.5.0"
 num-format = "0.4.4"
-reqwest = { version = "0.12.28", default-features = false, features = [
-    "json",
-    "rustls-tls",
-] }
-rustls = "0.23.27"
-serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.148"
-stdext = "0.3.3"
-sys-info = "0.9.1"
 tokio = { version = "1.49.0", features = ["full"] }
 uuid = { version = "1.19.0", features = ["serde", "v4", "v7"] }
-walkdir = "2.5.0"
 
 [dev-dependencies]
 tokio-test = "*"

--- a/docker/core/mkmediascanner/src/main.rs
+++ b/docker/core/mkmediascanner/src/main.rs
@@ -241,7 +241,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     json!({"error": error.to_string()}),
                 )
                 .await;
-                Vec::new()
+                // Don't ack: leave the trigger in-flight so the broker redelivers
+                // it after the DB recovers. Otherwise a transient outage silently
+                // drops the scan request.
+                continue;
             }
         };
 
@@ -403,12 +406,26 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     .await;
                 }
 
-                let already_known = mk_lib_database::mk_lib_database_library::mk_lib_database_library_file_exists(
+                // On DB error we skip rather than defaulting to "not present";
+                // otherwise a transient read outage would fan every file into
+                // an insert attempt and flood the queue with duplicates.
+                let already_known = match mk_lib_database::mk_lib_database_library::mk_lib_database_library_file_exists(
                     &sqlx_pool_ro,
                     &file_metadata.name,
                 )
                 .await
-                .unwrap_or(false);
+                {
+                    Ok(known) => known,
+                    Err(error) => {
+                        log_loki(
+                            "error",
+                            "library_file_exists failed; skipping file",
+                            json!({"path": file_metadata.name, "error": error.to_string()}),
+                        )
+                        .await;
+                        continue;
+                    }
+                };
                 if already_known {
                     continue;
                 }

--- a/docker/core/mkmediascanner/src/main.rs
+++ b/docker/core/mkmediascanner/src/main.rs
@@ -7,7 +7,7 @@ use std::collections::VecDeque;
 use std::error::Error;
 use std::ffi::OsStr;
 use std::path::Path;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 use tokio::process::Command;
 use uuid::Uuid;
 
@@ -237,13 +237,31 @@ async fn main() -> Result<(), Box<dyn Error>> {
             Err(error) => {
                 log_loki(
                     "error",
-                    "library_path_audit_read failed",
+                    "library_path_audit_read failed; nacking with requeue",
                     json!({"error": error.to_string()}),
                 )
                 .await;
-                // Don't ack: leave the trigger in-flight so the broker redelivers
-                // it after the DB recovers. Otherwise a transient outage silently
-                // drops the scan request.
+                // Brief backoff so we don't spin on a downed DB, then nack with
+                // requeue so the broker redelivers the trigger (either to us
+                // after recovery or to another worker).
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                if let Some(deliver) = msg.deliver {
+                    if let Err(nack_error) = rabbit_channel
+                        .basic_nack(amqprs::channel::BasicNackArguments::new(
+                            deliver.delivery_tag(),
+                            false,
+                            true,
+                        ))
+                        .await
+                    {
+                        log_loki(
+                            "error",
+                            "rabbitmq nack failed",
+                            json!({"error": nack_error.to_string()}),
+                        )
+                        .await;
+                    }
+                }
                 continue;
             }
         };

--- a/docker/core/mkmediascanner/src/main.rs
+++ b/docker/core/mkmediascanner/src/main.rs
@@ -1,27 +1,56 @@
-use chrono::prelude::*;
+use chrono::Utc;
 use fancy_regex::Regex;
 use lazy_static::lazy_static;
-use mk_lib_common;
-use mk_lib_database;
-use mk_lib_file;
-use mk_lib_rabbitmq;
 use num_format::{Locale, ToFormattedString};
 use serde_json::{Value, json};
+use std::collections::VecDeque;
 use std::error::Error;
 use std::ffi::OsStr;
 use std::path::Path;
-use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
+use tokio::process::Command;
 use uuid::Uuid;
 
+use mk_lib_common::mk_lib_common_enum_media_type::DLMediaType;
+use mk_lib_common::mk_lib_common_media_extension::{
+    GAME_EXTENSION, MEDIA_EXTENSION, MEDIA_EXTENSION_SKIP_FFMPEG, SUBTITLE_EXTENSION,
+};
+use mk_lib_database::mk_lib_database_library::DBLibraryAuditList;
+use mk_lib_database::mk_lib_database_network_share::DBShareList;
+use mk_lib_file::mk_lib_smb::{
+    File_Metadata, mk_file_smb_client_connect, mk_file_smb_client_disconnect,
+    mk_file_smb_client_tree, mk_file_smb_client_tree_smbclient,
+};
+
 lazy_static! {
-    static ref epoch: DateTime<Utc> = DateTime::<Utc>::from(UNIX_EPOCH);
+    static ref STACK_CD: Regex = Regex::new(r"(?i)-cd\d").unwrap();
+    static ref STACK_CD1: Regex = Regex::new(r"(?i)-cd1(?!\d)").unwrap();
+    static ref STACK_PART: Regex = Regex::new(r"(?i)-part\d").unwrap();
+    static ref STACK_PART1: Regex = Regex::new(r"(?i)-part1(?!\d)").unwrap();
+    static ref STACK_DVD: Regex = Regex::new(r"(?i)-dvd\d").unwrap();
+    static ref STACK_DVD1: Regex = Regex::new(r"(?i)-dvd1(?!\d)").unwrap();
+    static ref STACK_PT: Regex = Regex::new(r"(?i)-pt\d").unwrap();
+    static ref STACK_PT1: Regex = Regex::new(r"(?i)-pt1(?!\d)").unwrap();
+    static ref STACK_DISK: Regex = Regex::new(r"(?i)-disk\d").unwrap();
+    static ref STACK_DISK1: Regex = Regex::new(r"(?i)-disk1(?!\d)").unwrap();
+    static ref STACK_DISC: Regex = Regex::new(r"(?i)-disc\d").unwrap();
+    static ref STACK_DISC1: Regex = Regex::new(r"(?i)-disc1(?!\d)").unwrap();
 }
 
-fn mk_nfs_uri(
-    share_info: &mk_lib_database::mk_lib_database_network_share::DBShareList,
-    uri: &str,
-) -> String {
+async fn log_loki(level: &str, message: &str, payload: Value) {
+    if let Err(error) = mk_lib_logging::mk_lib_logging_loki::mk_logging_loki_push(json!({
+        "level": level,
+        "message": message,
+        "module": module_path!(),
+        "payload": payload,
+    }))
+    .await
+    {
+        eprintln!("loki push error: {error}");
+    }
+}
+
+fn mk_nfs_uri(share_info: &DBShareList, uri: &str) -> String {
     let share_path = share_info.mm_network_share_path.trim_start_matches('/');
     let path_part = uri.trim_start_matches('/');
     if path_part.is_empty() {
@@ -34,436 +63,513 @@ fn mk_nfs_uri(
     }
 }
 
-fn mk_nfs_tree(
-    share_info: &mk_lib_database::mk_lib_database_network_share::DBShareList,
+// Recursive listing via `nfs-ls -R`. Returns Ok(empty) for empty shares;
+// returns Err only when the command itself fails (missing path, auth, etc.).
+async fn mk_nfs_tree(
+    share_info: &DBShareList,
     uri: &str,
-) -> Result<Vec<mk_lib_file::mk_lib_smb::File_Metadata>, Box<dyn Error>> {
+) -> Result<Vec<File_Metadata>, Box<dyn Error>> {
     let output = Command::new("nfs-ls")
         .arg("-R")
         .arg(mk_nfs_uri(share_info, uri))
-        .output()?;
-    if output.status.success() == false {
-        return Err(format!("nfs-ls failed with status {:?}", output.status.code()).into());
+        .output()
+        .await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "nfs-ls failed with status {:?}: {}",
+            output.status.code(),
+            stderr.trim()
+        )
+        .into());
     }
     let stdout_data = String::from_utf8(output.stdout)?;
+    let base_prefix = mk_nfs_uri(share_info, "");
     let mut file_list = Vec::new();
     for line in stdout_data.lines() {
         let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed == "." || trimmed == ".." {
+        if trimmed.is_empty() {
             continue;
         }
-        let is_dir = trimmed.ends_with('/');
-        let normalized = trimmed.trim_end_matches('/');
-        file_list.push(mk_lib_file::mk_lib_smb::File_Metadata {
-            name: format!("/{}", normalized.trim_start_matches('/')),
+        // Drop the nfs://host/share prefix so downstream code sees a server-relative path.
+        let relative = trimmed
+            .strip_prefix(&base_prefix)
+            .unwrap_or(trimmed)
+            .trim_start_matches('/');
+        if relative.is_empty() || relative == "." || relative == ".." {
+            continue;
+        }
+        let is_dir = relative.ends_with('/');
+        let normalized = relative.trim_end_matches('/');
+        file_list.push(File_Metadata {
+            name: format!("/{normalized}"),
             directory: is_dir,
         });
-    }
-    if file_list.is_empty() {
-        return Err("nfs-ls returned no parsable entries".into());
     }
     Ok(file_list)
 }
 
+fn is_stacked_non_first(base_name: &str) -> bool {
+    let is_stacked = STACK_CD.is_match(base_name).unwrap_or(false)
+        || STACK_PART.is_match(base_name).unwrap_or(false)
+        || STACK_DVD.is_match(base_name).unwrap_or(false)
+        || STACK_PT.is_match(base_name).unwrap_or(false)
+        || STACK_DISK.is_match(base_name).unwrap_or(false)
+        || STACK_DISC.is_match(base_name).unwrap_or(false);
+    if !is_stacked {
+        return false;
+    }
+    let is_first = STACK_CD1.is_match(base_name).unwrap_or(false)
+        || STACK_PART1.is_match(base_name).unwrap_or(false)
+        || STACK_DVD1.is_match(base_name).unwrap_or(false)
+        || STACK_PT1.is_match(base_name).unwrap_or(false)
+        || STACK_DISK1.is_match(base_name).unwrap_or(false)
+        || STACK_DISC1.is_match(base_name).unwrap_or(false);
+    !is_first
+}
+
+fn path_contains_segment(path: &str, segment: &str) -> bool {
+    let forward = format!("/{segment}/");
+    let backward = format!("\\{segment}\\");
+    path.contains(&forward) || path.contains(&backward)
+}
+
+fn path_contains_prefix(path: &str, prefix: &str) -> bool {
+    let forward = format!("/{prefix}");
+    let backward = format!("\\{prefix}");
+    path.contains(&forward) || path.contains(&backward)
+}
+
+fn is_tv_class(media_class: i16) -> bool {
+    media_class == DLMediaType::TV
+        || media_class == DLMediaType::TV_EPISODE
+        || media_class == DLMediaType::TV_SEASON
+}
+
+// Decide the effective media class and whether the file should get a
+// Roku-thumbnail + ffprobe pass. Returns (new_class, generate_roku_thumb).
+fn classify_media(original_class: i16, file_extension: &str, file_path: &str) -> (i16, bool) {
+    if original_class == DLMediaType::GAME {
+        let new_class = if file_extension == "iso" {
+            DLMediaType::GAME_ISO
+        } else if file_extension == "chd" {
+            DLMediaType::GAME_CHD
+        } else {
+            DLMediaType::GAME_ROM
+        };
+        return (new_class, false);
+    }
+
+    if SUBTITLE_EXTENSION.contains(&file_extension) {
+        let new_class = if original_class == DLMediaType::MOVIE {
+            DLMediaType::MOVIE_SUBTITLE
+        } else if is_tv_class(original_class) {
+            DLMediaType::TV_SUBTITLE
+        } else {
+            original_class
+        };
+        return (new_class, false);
+    }
+
+    if path_contains_segment(file_path, "trailers") {
+        let new_class = if original_class == DLMediaType::MOVIE {
+            DLMediaType::MOVIE_TRAILER
+        } else if is_tv_class(original_class) {
+            DLMediaType::TV_TRAILER
+        } else {
+            original_class
+        };
+        return (new_class, true);
+    }
+
+    let is_theme = path_contains_prefix(file_path, "theme.")
+        || (path_contains_segment(file_path, "backdrops")
+            && path_contains_prefix(file_path, "theme."));
+    if is_theme {
+        let new_class = if original_class == DLMediaType::MOVIE {
+            DLMediaType::MOVIE_THEME
+        } else if is_tv_class(original_class) {
+            DLMediaType::TV_THEME
+        } else {
+            original_class
+        };
+        return (new_class, true);
+    }
+
+    if path_contains_segment(file_path, "extras") {
+        let new_class = if original_class == DLMediaType::MOVIE {
+            DLMediaType::MOVIE_EXTRAS
+        } else if is_tv_class(original_class) {
+            DLMediaType::TV_EXTRAS
+        } else {
+            original_class
+        };
+        return (new_class, true);
+    }
+
+    (original_class, true)
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // setup regex for finding media parts
-    let stack_cd = Regex::new(r"(?i)-cd\d").unwrap();
-    let stack_cd1 = Regex::new(r"(?i)-cd1(?!\d)").unwrap();
-    let stack_part = Regex::new(r"(?i)-part\d").unwrap();
-    let stack_part1 = Regex::new(r"(?i)-part1(?!\d)").unwrap();
-    let stack_dvd = Regex::new(r"(?i)-dvd\d").unwrap();
-    let stack_dvd1 = Regex::new(r"(?i)-dvd1(?!\d)").unwrap();
-    let stack_pt = Regex::new(r"(?i)-pt\d").unwrap();
-    let stack_pt1 = Regex::new(r"(?i)-pt1(?!\d)").unwrap();
-    let stack_disk = Regex::new(r"(?i)-disk\d").unwrap();
-    let stack_disk1 = Regex::new(r"(?i)-disk1(?!\d)").unwrap();
-    let stack_disc = Regex::new(r"(?i)-disc\d").unwrap();
-    let stack_disc1 = Regex::new(r"(?i)-disc1(?!\d)").unwrap();
-
-    // connect to db and do a version check
     let (sqlx_pool_rw, sqlx_pool_ro) =
-        mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120)
-            .await
-            .unwrap();
-    let _result = mk_lib_database::mk_lib_database_version::mk_lib_database_version_check(
+        mk_lib_database::mk_lib_database::mk_lib_database_open_pool(50, 120).await?;
+    let _ = mk_lib_database::mk_lib_database_version::mk_lib_database_version_check(
         &sqlx_pool_ro,
         false,
     )
     .await;
 
     let (_rabbit_connection, rabbit_channel) =
-        mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_connect("mkmediascanner")
-            .await
-            .unwrap();
-
+        mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_connect("mkmediascanner").await?;
     let mut rabbit_consumer =
         mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_consumer("mkmediascanner", &rabbit_channel)
-            .await
-            .unwrap();
+            .await?;
 
     while let Some(msg) = rabbit_consumer.recv().await {
-        if let Some(payload) = msg.content {
-            // determine directories to audit
-            for row_data in
-                mk_lib_database::mk_lib_database_library::mk_lib_database_library_path_audit_read(
-                    &sqlx_pool_ro,
+        // Message content is a wake-up signal; the actual list of paths comes from the DB.
+        let audit_rows = match mk_lib_database::mk_lib_database_library::mk_lib_database_library_path_audit_read(
+            &sqlx_pool_ro,
+        )
+        .await
+        {
+            Ok(rows) => rows,
+            Err(error) => {
+                log_loki(
+                    "error",
+                    "library_path_audit_read failed",
+                    json!({"error": error.to_string()}),
                 )
-                .await
-                .unwrap()
+                .await;
+                Vec::new()
+            }
+        };
+
+        for row_data in audit_rows {
+            let share_info = match mk_lib_database::mk_lib_database_network_share::mk_lib_database_network_share_detail(
+                &sqlx_pool_ro,
+                row_data.mm_media_dir_share_guid,
+            )
+            .await
             {
-                let share_info: mk_lib_database::mk_lib_database_network_share::DBShareList =
-                    mk_lib_database::mk_lib_database_network_share::mk_lib_database_network_share_detail(
-                    &sqlx_pool_ro,
-                    row_data.mm_media_dir_share_guid,
+                Ok(s) => s,
+                Err(error) => {
+                    log_loki(
+                        "error",
+                        "network_share_detail failed",
+                        json!({
+                            "share_guid": row_data.mm_media_dir_share_guid,
+                            "error": error.to_string(),
+                        }),
+                    )
+                    .await;
+                    continue;
+                }
+            };
+
+            let path_on_share = format!("/{}", row_data.mm_media_dir_path.trim_start_matches('/'));
+            let smb_client = mk_file_smb_client_connect(share_info.clone()).ok();
+
+            // Reachability + (SMB-only) mtime probe.
+            let (reachable, maybe_mtime): (bool, Option<SystemTime>) =
+                if let Some(c) = smb_client.as_ref() {
+                    match c.stat(path_on_share.clone()) {
+                        Ok(stat) => (true, Some(stat.modified)),
+                        Err(_) => (false, None),
+                    }
+                } else {
+                    match mk_nfs_tree(&share_info, &path_on_share).await {
+                        Ok(_) => (true, None),
+                        Err(_) => (false, None),
+                    }
+                };
+
+            if !reachable {
+                let _ = mk_lib_database::mk_lib_database_notification::mk_lib_database_notification_insert(
+                    &sqlx_pool_rw,
+                    format!("Unable to connect to share: {}", row_data.mm_media_dir_path),
+                    true,
                 )
-                .await
-                .unwrap();
-                // SMB first, then direct NFS listing (no host mount/PVC).
-                let smb_client =
-                    mk_lib_file::mk_lib_smb::mk_file_smb_client_connect(share_info.clone()).ok();
-                if smb_client.is_some() || mk_nfs_tree(&share_info, "/").is_ok() {
-                    // make sure the path still exists
-                    let data_stat = if let Some(smb_client) = smb_client.as_ref() {
-                        smb_client
-                            .stat(format!("/{}", row_data.mm_media_dir_path))
-                            .map(|file_stat| file_stat.modified)
-                            .map_err(|_| ())
-                    } else {
-                        Ok(SystemTime::now())
-                    };
-                    match data_stat {
-                        Ok(modified_time) => {
-                            let last_modified =
-                                mk_lib_common::mk_lib_common_date::system_time_to_date_time(
-                                    modified_time,
-                                );
-                            if last_modified > row_data.mm_media_dir_last_scanned {
-                                let _result = mk_lib_database::mk_lib_database_library::mk_lib_database_library_path_status_update(
-                                            &sqlx_pool_rw,
-                                            row_data.mm_media_dir_guid,
-                                            json!({"Status": "Added to scan", "Pct": 100}),
-                                        )
-                                        .await;
-                                let original_media_class = row_data.mm_media_dir_class_enum;
-                                // update the timestamp now so any other media added DURING this scan don't get skipped
-                                let _result = mk_lib_database::mk_lib_database_library::mk_lib_database_library_path_timestamp_update(
-                                            &sqlx_pool_rw,
-                                            row_data.mm_media_dir_guid,
-                                        )
-                                        .await;
-                                let _result = mk_lib_database::mk_lib_database_library::mk_lib_database_library_path_status_update(
-                                            &sqlx_pool_rw,
-                                            row_data.mm_media_dir_guid,
-                                            json!({"Status": "File search scan", "Pct": 0.0}),
-                                        )
-                                        .await;
-                                let mut file_data = if let Some(smb_client) = smb_client.as_ref() {
-                                    mk_lib_file::mk_lib_smb::mk_file_smb_client_tree_smbclient(
-                                        &share_info,
-                                        format!("/{}", row_data.mm_media_dir_path).as_str(),
-                                    )
-                                    .or_else(|_| {
-                                        mk_lib_file::mk_lib_smb::mk_file_smb_client_tree(
-                                            smb_client,
-                                            format!("/{}", row_data.mm_media_dir_path).as_str(),
-                                        )
-                                    })
-                                    .unwrap_or_default()
-                                } else {
-                                    mk_nfs_tree(
-                                        &share_info,
-                                        format!("/{}", row_data.mm_media_dir_path).as_str(),
-                                    )
-                                    .unwrap_or_default()
-                                };
-                                let mut total_scanned: u64 = 0;
-                                let mut total_files: u64 = 0;
-                                while file_data.len() > 0 {
-                                    let file_metadata = file_data[0].clone();
-                                    println!("meta: {:?}", file_metadata);
-                                    if file_metadata.directory == true {
-                                        let mut child_files = if let Some(smb_client) =
-                                            smb_client.as_ref()
-                                        {
-                                            mk_lib_file::mk_lib_smb::mk_file_smb_client_tree_smbclient(
-                                                        &share_info,
-                                                        format!("/{}", file_metadata.name).as_str(),
-                                                    )
-                                                    .or_else(|_| {
-                                                        mk_lib_file::mk_lib_smb::mk_file_smb_client_tree(
-                                                            smb_client,
-                                                            format!("/{}", file_metadata.name).as_str(),
-                                                        )
-                                                    })
-                                                    .unwrap_or_default()
-                                        } else {
-                                            mk_nfs_tree(
-                                                &share_info,
-                                                format!("/{}", file_metadata.name).as_str(),
-                                            )
-                                            .unwrap_or_default()
-                                        };
-                                        file_data.append(&mut child_files);
-                                    } else {
-                                        if mk_lib_database::mk_lib_database_library::mk_lib_database_library_file_exists(&sqlx_pool_ro, &file_metadata.name).await.unwrap() == false {
-                                        // set lower here so I can remove a lot of .lower() in the code below
-                                        let file_lower = &file_metadata.name.to_lowercase();
-                                        let file_extension = Path::new(&file_lower)
-                                            .extension()
-                                            .and_then(OsStr::to_str)
-                                            .unwrap();
-                                        println!("filelower: {} {}", file_lower, file_extension);
-                                        // checking subtitles for parts as need multiple files for multiple media files
-                                        if mk_lib_common::mk_lib_common_media_extension::MEDIA_EXTENSION.contains(&file_extension)
-                                            || mk_lib_common::mk_lib_common_media_extension::SUBTITLE_EXTENSION
-                                                .contains(&file_extension)
-                                            || mk_lib_common::mk_lib_common_media_extension::GAME_EXTENSION
-                                                .contains(&file_extension)
-                                            {
-                                            println!("Matched Extension");
-                                            let mut ffprobe_bif_data = true;
-                                            let mut save_dl_record = true;
-                                            total_files += 1;
-                                            // set here which MIGHT be overrode later
-                                            let mut new_class_type_uuid = original_media_class;
-                                            // check for "stacked" media file
-                                            let base_file_name = Path::new(&file_metadata.name)
-                                                .file_name()
-                                                .and_then(OsStr::to_str)
-                                                .unwrap();
-                                            // check to see if it's a "stacked" file
-                                            // including games since some are two or more discs
-                                            if stack_cd.is_match(&base_file_name).unwrap()
-                                                || stack_part.is_match(&base_file_name).unwrap()
-                                                || stack_dvd.is_match(&base_file_name).unwrap()
-                                                || stack_pt.is_match(&base_file_name).unwrap()
-                                                || stack_disk.is_match(&base_file_name).unwrap()
-                                                || stack_disc.is_match(&base_file_name).unwrap()
-                                            {
-                                                println!("WHAT!");
-                                                // check to see if it's part one or not
-                                                if stack_cd1.is_match(&base_file_name).unwrap() == false
-                                                    && stack_part1.is_match(&base_file_name).unwrap() == false
-                                                    && stack_dvd1.is_match(&base_file_name).unwrap() == false
-                                                    && stack_pt1.is_match(&base_file_name).unwrap() == false
-                                                    && stack_disk1.is_match(&base_file_name).unwrap() == false
-                                                    && stack_disc1.is_match(&base_file_name).unwrap() == false
-                                                {
-                                                    println!("WHAT2!");
-                                                    // it's not a part one here so, no DL record needed
-                                                    save_dl_record = false;
-                                                }
-                                            }
-                                            // video game data
-                                            // TODO look for cue/bin data as well
-                                            if original_media_class
-                                                == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::GAME
-                                            {
-                                                if file_extension == "iso" {
-                                                    new_class_type_uuid =
-                                                    mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::GAME_ISO;
-                                                } else {
-                                                    if file_extension == "chd" {
-                                                        new_class_type_uuid =
-                                                        mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::GAME_CHD;
-                                                    } else {
-                                                        new_class_type_uuid =
-                                                        mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::GAME_ROM;
-                                                    }
-                                                }
-                                                ffprobe_bif_data = false;
-                                            }
-                                            // set new media class for subtitles
-                                            else {
-                                                if mk_lib_common::mk_lib_common_media_extension::SUBTITLE_EXTENSION
-                                                    .contains(&file_extension)
-                                                {
-                                                    if original_media_class
-                                                        == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::MOVIE
-                                                    {
-                                                        new_class_type_uuid = mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::MOVIE_SUBTITLE;
-                                                    } else {
-                                                        if original_media_class == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV
-                                                            || original_media_class == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV_EPISODE
-                                                            || original_media_class == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV_SEASON {
-                                                            new_class_type_uuid = mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV_SUBTITLE;
-                                                        }
-                                                    }
-                                                    ffprobe_bif_data = false;
-                                                }
-                                                // set new media class for trailers or themes
-                                                else {
-                                                    if file_metadata.name.contains("/trailers/")
-                                                        || file_metadata.name.contains("\\trailers\\")
-                                                        || file_metadata.name.contains("/theme.")
-                                                        || file_metadata.name.contains("\\theme.")
-                                                    {
-                                                        if original_media_class
-                                                            == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::MOVIE
-                                                        {
-                                                            if file_metadata.name.contains("/trailers/")
-                                                                || file_metadata.name.contains("\\trailers\\")
-                                                            {
-                                                                new_class_type_uuid = mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::MOVIE_TRAILER;
-                                                            } else {
-                                                                new_class_type_uuid = mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::MOVIE_THEME;
-                                                            }
-                                                        } else {
-                                                            if original_media_class == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV
-                                                                || original_media_class == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV_EPISODE
-                                                                || original_media_class == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV_SEASON {
-                                                                if file_metadata.name.contains("/trailers/") || file_metadata.name.contains("\\trailers\\") {
-                                                                    new_class_type_uuid = mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV_TRAILER;
-                                                                } else {
-                                                                    new_class_type_uuid = mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV_THEME;
-                                                                }
-                                                            }
-                                                            // set new media class for extras
-                                                            else {
-                                                                if file_metadata.name.contains("/extras/")
-                                                                    || file_metadata.name.contains("\\extras\\")
-                                                                {
-                                                                    if original_media_class
-                                                                        == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::MOVIE
-                                                                    {
-                                                                        new_class_type_uuid = mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::MOVIE_EXTRAS;
-                                                                    } else {
-                                                                        if original_media_class == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV
-                                                                            || original_media_class == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV_EPISODE
-                                                                            || original_media_class == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV_SEASON {
-                                                                            new_class_type_uuid = mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV_EXTRAS;
-                                                                        }
-                                                                    }
-                                                                }
-                                                                // set new media class for backdrops (usually themes)
-                                                                else {
-                                                                    if file_metadata.name.contains("/backdrops/")
-                                                                        || file_metadata.name.contains("\\backdrops\\")
-                                                                    {
-                                                                        if file_metadata.name.contains("/theme.")
-                                                                            || file_metadata.name.contains("\\theme.")
-                                                                        {
-                                                                            if original_media_class == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::MOVIE {
-                                                                                new_class_type_uuid = mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::MOVIE_THEME;
-                                                                            } else {
-                                                                                if original_media_class == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV
-                                                                                    || original_media_class == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV_EPISODE
-                                                                                    || original_media_class == mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV_SEASON {
-                                                                                    new_class_type_uuid = mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::TV_THEME;
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                            // create media_json data
-                                            let media_json =
-                                                json!({ "Added": Utc::now().to_string() });
-                                            let media_id = Uuid::now_v7();
-                                            let _result = mk_lib_database::database_media::mk_lib_database_media::mk_lib_database_media_insert(
-                                                &sqlx_pool_rw,
-                                                media_id,
-                                                new_class_type_uuid as i16,
-                                                &file_metadata.name,
-                                                None,
-                                                json!({}),
-                                                media_json,
-                                            )
-                                            .await;
-                                            // verify ffprobe and bif should run on the data
-                                            if mk_lib_common::mk_lib_common_media_extension::MEDIA_EXTENSION_SKIP_FFMPEG.contains(&file_extension) == false
-                                                && mk_lib_common::mk_lib_common_media_extension::MEDIA_EXTENSION.contains(&file_extension) {
-                                                // Send a message so ffprobe runs
-                                                mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_publish(
-                                                    rabbit_channel.clone(),
-                                                    "mktranscode",
-                                                    json!({"Type": "FFMPEG", "Subtype": "Probe", "Media UUID": media_id, "Media Path": file_metadata.name}).to_string(),
-                                                )
-                                                .await.unwrap();
-                                                if ffprobe_bif_data == true && original_media_class != mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::MUSIC {
-                                                    // Send a message so roku thumbnail is generated
-                                                    mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_publish(
-                                                        rabbit_channel.clone(),
-                                                        "mktranscode",
-                                                        json!({"Type": "Roku", "Media UUID": media_id, "Media Path": file_metadata.name}).to_string(),
-                                                    )
-                                                    .await.unwrap();
-                                                }
-                                            }
-                                            // it should save a dl "Z" record for search/lookup/etc
-                                            if save_dl_record == true {
-                                                // media id begin and download que insert
-                                                let _result = mk_lib_database::database_metadata::mk_lib_database_metadata_download_queue::mk_lib_database_metadata_download_queue_insert(&sqlx_pool_rw,
-                                                                                                                                        "Z".to_string(),
-                                                                                                                                        new_class_type_uuid,
-                                                                                                                                        media_id,
-                                                                                                                                        None,
-                                                                                                                                        "Search".to_string(),
-                                                                                                                                        Some(&file_metadata.name)).await;
-                                            }
+                .await;
+                if let Some(c) = smb_client {
+                    mk_file_smb_client_disconnect(c);
+                }
+                continue;
+            }
+
+            // Only short-circuit when we actually know the share mtime (SMB). NFS
+            // callers always fall through and rely on the per-file dedup below.
+            if let Some(mtime) = maybe_mtime {
+                let last_modified =
+                    mk_lib_common::mk_lib_common_date::system_time_to_date_time(mtime);
+                if last_modified <= row_data.mm_media_dir_last_scanned {
+                    if let Some(c) = smb_client {
+                        mk_file_smb_client_disconnect(c);
+                    }
+                    continue;
+                }
+            }
+
+            let _ = mk_lib_database::mk_lib_database_library::mk_lib_database_library_path_status_update(
+                &sqlx_pool_rw,
+                row_data.mm_media_dir_guid,
+                json!({"Status": "Added to scan", "Pct": 100}),
+            )
+            .await;
+            // Bump timestamp up front so files added mid-scan aren't skipped next round.
+            let _ = mk_lib_database::mk_lib_database_library::mk_lib_database_library_path_timestamp_update(
+                &sqlx_pool_rw,
+                row_data.mm_media_dir_guid,
+            )
+            .await;
+            let _ = mk_lib_database::mk_lib_database_library::mk_lib_database_library_path_status_update(
+                &sqlx_pool_rw,
+                row_data.mm_media_dir_guid,
+                json!({"Status": "File search scan", "Pct": 0.0}),
+            )
+            .await;
+
+            // Collect every file under the library path. For SMB we prefer the
+            // recursive smbclient CLI (one subprocess total). If that fails,
+            // BFS via pavao one directory at a time. For NFS we use `nfs-ls -R`.
+            let files: Vec<File_Metadata> = if let Some(c) = smb_client.as_ref() {
+                match mk_file_smb_client_tree_smbclient(&share_info, &path_on_share) {
+                    Ok(entries) => entries,
+                    Err(cli_error) => {
+                        log_loki(
+                            "info",
+                            "smbclient recursive listing failed; falling back to pavao BFS",
+                            json!({"path": path_on_share, "error": cli_error.to_string()}),
+                        )
+                        .await;
+                        let mut collected: Vec<File_Metadata> = Vec::new();
+                        let mut queue: VecDeque<String> = VecDeque::new();
+                        queue.push_back(path_on_share.clone());
+                        while let Some(dir) = queue.pop_front() {
+                            match mk_file_smb_client_tree(c, &dir) {
+                                Ok(entries) => {
+                                    for entry in entries {
+                                        if entry.directory {
+                                            queue.push_back(entry.name.clone());
                                         }
+                                        collected.push(entry);
                                     }
-                                    }
-                                    file_data.remove(0);
                                 }
-                                total_scanned += 1;
-                                // end of for loop for each file in library
-                                // set to none so it doesn't show up anymore in admin status page
-                                mk_lib_database::mk_lib_database_library::mk_lib_database_library_path_status_update(
-                                            &sqlx_pool_rw,
-                                            row_data.mm_media_dir_guid,
-                                            json!({"Status": "File scan complete", "Pct": 100}),
-                                        )
-                                        .await
-                                        .unwrap();
-                                if total_files > 0 {
-                                    // add notification to admin status page
-                                    let _result = mk_lib_database::mk_lib_database_notification::mk_lib_database_notification_insert(
-                                                &sqlx_pool_rw,
-                                                format!(
-                                                    "{} file(s) added from {}",
-                                                    total_files.to_formatted_string(&Locale::en),
-                                                    row_data.mm_media_dir_path
-                                                ),
-                                                true,
-                                            )
-                                            .await;
+                                Err(error) => {
+                                    log_loki(
+                                        "warn",
+                                        "pavao list_dir failed",
+                                        json!({"path": dir, "error": error.to_string()}),
+                                    )
+                                    .await;
                                 }
                             }
                         }
-                        Err(_) => {
-                            // Lib path is not found on share
-                            let _result = mk_lib_database::mk_lib_database_notification::mk_lib_database_notification_insert(
-                                        &sqlx_pool_rw,
-                                        format!("Library path not found: {}", row_data.mm_media_dir_path),
-                                        true,
-                                    )
-                                    .await;
-                        }
-                    };
-                    if let Some(smb_client) = smb_client {
-                        mk_lib_file::mk_lib_smb::mk_file_smb_client_disconnect(smb_client);
+                        collected
                     }
-                } else {
-                    // Fail share login
-                    let _result = mk_lib_database::mk_lib_database_notification::mk_lib_database_notification_insert(
-                                &sqlx_pool_rw,
-                                format!("Unable to connect to share: {}", row_data.mm_media_dir_path),
-                                true,
+                }
+            } else {
+                match mk_nfs_tree(&share_info, &path_on_share).await {
+                    Ok(entries) => entries,
+                    Err(error) => {
+                        log_loki(
+                            "error",
+                            "nfs-ls recursive listing failed",
+                            json!({"path": path_on_share, "error": error.to_string()}),
+                        )
+                        .await;
+                        Vec::new()
+                    }
+                }
+            };
+
+            let total_candidates = files.iter().filter(|f| !f.directory).count().max(1) as f64;
+            let mut scanned: u64 = 0;
+            let mut total_files: u64 = 0;
+            let original_media_class = row_data.mm_media_dir_class_enum;
+
+            for file_metadata in files {
+                if file_metadata.directory {
+                    continue;
+                }
+                scanned += 1;
+                if scanned % 100 == 0 {
+                    let pct = (scanned as f64 / total_candidates) * 100.0;
+                    let _ = mk_lib_database::mk_lib_database_library::mk_lib_database_library_path_status_update(
+                        &sqlx_pool_rw,
+                        row_data.mm_media_dir_guid,
+                        json!({"Status": "File search scan", "Pct": pct}),
+                    )
+                    .await;
+                }
+
+                let already_known = mk_lib_database::mk_lib_database_library::mk_lib_database_library_file_exists(
+                    &sqlx_pool_ro,
+                    &file_metadata.name,
+                )
+                .await
+                .unwrap_or(false);
+                if already_known {
+                    continue;
+                }
+
+                let file_lower = file_metadata.name.to_lowercase();
+                let Some(file_extension) = Path::new(&file_lower)
+                    .extension()
+                    .and_then(OsStr::to_str)
+                    .map(str::to_owned)
+                else {
+                    continue;
+                };
+
+                let is_media = MEDIA_EXTENSION.contains(&file_extension.as_str());
+                let is_subtitle = SUBTITLE_EXTENSION.contains(&file_extension.as_str());
+                let is_game = GAME_EXTENSION.contains(&file_extension.as_str());
+                if !is_media && !is_subtitle && !is_game {
+                    continue;
+                }
+
+                total_files += 1;
+
+                let base_file_name = Path::new(&file_metadata.name)
+                    .file_name()
+                    .and_then(OsStr::to_str)
+                    .unwrap_or(&file_metadata.name);
+                let save_dl_record = !is_stacked_non_first(base_file_name);
+
+                let (new_class_type, generate_roku_thumb) =
+                    classify_media(original_media_class, &file_extension, &file_metadata.name);
+
+                let media_id = Uuid::now_v7();
+                let media_json = json!({ "Added": Utc::now().to_string() });
+                if let Err(error) = mk_lib_database::database_media::mk_lib_database_media::mk_lib_database_media_insert(
+                    &sqlx_pool_rw,
+                    media_id,
+                    new_class_type,
+                    &file_metadata.name,
+                    None,
+                    json!({}),
+                    media_json,
+                )
+                .await
+                {
+                    log_loki(
+                        "error",
+                        "media insert failed",
+                        json!({"path": file_metadata.name, "error": error.to_string()}),
+                    )
+                    .await;
+                    continue;
+                }
+
+                let needs_ffprobe = !MEDIA_EXTENSION_SKIP_FFMPEG
+                    .contains(&file_extension.as_str())
+                    && is_media;
+                if needs_ffprobe {
+                    if let Err(error) = mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_publish(
+                        rabbit_channel.clone(),
+                        "mktranscode",
+                        json!({
+                            "Type": "FFMPEG",
+                            "Subtype": "Probe",
+                            "Media UUID": media_id,
+                            "Media Path": file_metadata.name,
+                        })
+                        .to_string(),
+                    )
+                    .await
+                    {
+                        log_loki(
+                            "error",
+                            "ffprobe publish failed",
+                            json!({"media_id": media_id, "error": error.to_string()}),
+                        )
+                        .await;
+                    }
+                    if generate_roku_thumb && original_media_class != DLMediaType::MUSIC {
+                        if let Err(error) = mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_publish(
+                            rabbit_channel.clone(),
+                            "mktranscode",
+                            json!({
+                                "Type": "Roku",
+                                "Media UUID": media_id,
+                                "Media Path": file_metadata.name,
+                            })
+                            .to_string(),
+                        )
+                        .await
+                        {
+                            log_loki(
+                                "error",
+                                "roku publish failed",
+                                json!({"media_id": media_id, "error": error.to_string()}),
                             )
                             .await;
+                        }
+                    }
+                }
+
+                if save_dl_record {
+                    if let Err(error) = mk_lib_database::database_metadata::mk_lib_database_metadata_download_queue::mk_lib_database_metadata_download_queue_insert(
+                        &sqlx_pool_rw,
+                        "Z".to_string(),
+                        new_class_type,
+                        media_id,
+                        None,
+                        "Search".to_string(),
+                        Some(&file_metadata.name),
+                    )
+                    .await
+                    {
+                        log_loki(
+                            "error",
+                            "download queue insert failed",
+                            json!({"media_id": media_id, "error": error.to_string()}),
+                        )
+                        .await;
+                    }
                 }
             }
-            let _result = mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_ack(
-                &rabbit_channel,
-                msg.deliver.unwrap().delivery_tag(),
+
+            let _ = mk_lib_database::mk_lib_database_library::mk_lib_database_library_path_status_update(
+                &sqlx_pool_rw,
+                row_data.mm_media_dir_guid,
+                json!({"Status": "File scan complete", "Pct": 100}),
             )
             .await;
+
+            if total_files > 0 {
+                let _ = mk_lib_database::mk_lib_database_notification::mk_lib_database_notification_insert(
+                    &sqlx_pool_rw,
+                    format!(
+                        "{} file(s) added from {}",
+                        total_files.to_formatted_string(&Locale::en),
+                        row_data.mm_media_dir_path
+                    ),
+                    true,
+                )
+                .await;
+            }
+
+            if let Some(c) = smb_client {
+                mk_file_smb_client_disconnect(c);
+            }
+        }
+
+        if let Some(deliver) = msg.deliver {
+            if let Err(error) = mk_lib_rabbitmq::mk_lib_rabbitmq::rabbitmq_ack(
+                &rabbit_channel,
+                deliver.delivery_tag(),
+            )
+            .await
+            {
+                log_loki(
+                    "error",
+                    "rabbitmq_ack failed",
+                    json!({"error": error.to_string()}),
+                )
+                .await;
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
## Summary
This PR significantly refactors the media scanner to use async/await patterns throughout, improve error handling with structured logging, and reorganize code for better maintainability. The changes modernize the codebase while maintaining the same core functionality of scanning media libraries and queuing files for processing.

## Key Changes

- **Async I/O Migration**: Converted all file system operations and external command execution to async using `tokio::process::Command` instead of `std::process::Command`. Updated `mk_nfs_tree()` to be async.

- **Structured Logging**: Added `log_loki()` function for consistent error and info logging to Loki, replacing ad-hoc error handling with structured JSON payloads.

- **Improved Error Handling**: 
  - Replaced `.unwrap()` calls with proper error propagation using `?` operator
  - Added detailed error messages with context (e.g., stderr output from failed commands)
  - Graceful degradation when operations fail (e.g., fallback from smbclient to pavao BFS)

- **Code Organization**:
  - Moved regex patterns to `lazy_static!` block for better performance and clarity
  - Extracted `classify_media()` function to centralize media type classification logic
  - Extracted helper functions: `is_stacked_non_first()`, `path_contains_segment()`, `path_contains_prefix()`, `is_tv_class()`
  - Simplified imports with explicit type imports from library modules

- **Algorithm Improvements**:
  - Implemented BFS queue-based directory traversal for SMB fallback instead of recursive approach
  - Added progress percentage updates during file scanning (every 100 files)
  - Improved NFS listing to strip base prefix and handle empty shares gracefully
  - Better separation of concerns between SMB and NFS code paths

- **Robustness**:
  - Proper resource cleanup with `mk_file_smb_client_disconnect()` in all code paths
  - Mtime-based short-circuit optimization for SMB shares (skip if unchanged)
  - Per-file dedup check before processing to avoid duplicate entries
  - Detailed logging of failures at each step for debugging

## Notable Implementation Details

- The refactored `mk_nfs_tree()` now returns `Ok(empty_vec)` for empty shares instead of erroring, allowing proper handling of sparse directory structures
- Media classification is now centralized in `classify_media()`, reducing nested conditionals and improving testability
- Error handling preserves context throughout the call stack, making it easier to diagnose issues in production
- The main loop now uses a cleaner pattern with early continues instead of deeply nested if-else blocks

https://claude.ai/code/session_01CKKa5hBg4dgeFisCmJrjkU