### PR TITLE
Fix file download path ownership in mkdownload

### DIFF
--- a/docker/core/mkdownload/src/main.rs
+++ b/docker/core/mkdownload/src/main.rs
@@ -116,7 +116,7 @@ async fn process_message(json_message: Value) -> Result<(), TaskError> {
 
             mk_lib_network::mk_lib_network::mk_download_file_from_url(
                 url.to_string(),
-                &local_save_path.to_string_lossy(),
+                &local_save_path.to_string_lossy().into_owned(),
             )
             .await
             .map_err(|e| format!("file download failed: {e}"))?;


### PR DESCRIPTION
## Summary
Fixed a potential lifetime issue in the file download functionality by converting the borrowed string reference to an owned `String`.

## Key Changes
- Modified the `mk_download_file_from_url` call to pass an owned string instead of a borrowed reference
- Changed `&local_save_path.to_string_lossy()` to `&local_save_path.to_string_lossy().into_owned()`

## Implementation Details
The `to_string_lossy()` method returns a `Cow<str>` which can be either borrowed or owned. By explicitly calling `into_owned()`, we ensure the function receives a stable, owned `String` reference rather than a potentially temporary borrowed reference. This prevents potential issues with string lifetime management and ensures the path remains valid throughout the async download operation.

https://claude.ai/code/session_01YSFE2ELuE6vuNmdacqyAB6