### PR TITLE
Fix calibre installation by adding python3 and edge/main repository

### DIFF
--- a/docker/core/mktranscode/Dockerfile
+++ b/docker/core/mktranscode/Dockerfile
@@ -405,7 +405,11 @@ ADD alpine-minirootfs-x86_64.tar.gz /
 COPY --from=cargo-build-mktranscode /mediakraken/deps/* /
 
 RUN apk update && apk add --no-cache cifs-utils nfs-utils \
- && apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing calibre \
+ && apk add --no-cache \
+      --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main \
+      --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
+      --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing \
+      python3 calibre \
  && rm -rf /var/cache/apk/*
 
 # Import from builder.


### PR DESCRIPTION
## Summary
Updated the mktranscode Dockerfile to resolve calibre installation issues by explicitly adding python3 as a dependency and including the Alpine edge/main repository in the apk add command.

## Key Changes
- Added `python3` as an explicit package dependency alongside `calibre`
- Added `--repository=https://dl-cdn.alpinelinux.org/alpine/edge/main` to the apk repositories
- Reformatted the apk add command for better readability by splitting repository flags and packages across multiple lines

## Implementation Details
The change addresses a dependency resolution issue where calibre requires python3, which may not be automatically resolved when only specifying the edge/community and edge/testing repositories. By explicitly including python3 and adding the edge/main repository, we ensure all required dependencies are available during the package installation phase.

https://claude.ai/code/session_014NUfSnWNj48kxrMqtdre4a