### PR TITLE
Refactor theater controller UI with media categories and configurable API

### DIFF
--- a/src_app/theater_controller_pi/Cargo.toml
+++ b/src_app/theater_controller_pi/Cargo.toml
@@ -10,19 +10,6 @@ lto = true
 codegen-units = 1
 
 [dependencies]
-mk_lib_network = { version = "0.0.204", registry = "kellnr" }
-
-crossbeam = "0.8.4"
 crossbeam-channel = "0.5.15"
 fltk = { version = "1.5.22", features = ["fltk-bundled"] }
 fltk-theme = "0.7.9"
-reqwest = { version = "0.13.2", default-features = false, features = [
-    "json",
-    "rustls-tls",
-] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-stdext = "0.3.3"
-
-[dev-dependencies]
-tokio-test = "*"

--- a/src_app/theater_controller_pi/src/main.rs
+++ b/src_app/theater_controller_pi/src/main.rs
@@ -1,4 +1,4 @@
-use crossbeam_channel::unbounded;
+use crossbeam_channel::{Sender, unbounded};
 use fltk::{
     app,
     button::Button,
@@ -8,19 +8,82 @@ use fltk::{
 };
 use fltk_theme::{SchemeType, WidgetScheme};
 use std::{
+    env,
     error::Error,
     io::{Read, Write},
-    net::TcpStream,
+    net::{TcpStream, ToSocketAddrs},
     path::Path,
+    time::Duration,
 };
 
-const THEATER_THIN_API_ADDR: &str = "127.0.0.1:7878";
+const DEFAULT_THEATER_THIN_API_ADDR: &str = "127.0.0.1:7878";
+const THEATER_THIN_API_ADDR_ENV: &str = "THEATER_THIN_API_ADDR";
+const TCP_TIMEOUT: Duration = Duration::from_secs(5);
+
+const FILTER_VIDEO: &str = "Videos\t*.{mp4,mkv,avi,mov,webm,m4v,ts,wmv,flv,mpg,mpeg}";
+const FILTER_AUDIO: &str = "Audio\t*.{mp3,flac,ogg,wav,m4a,aac,opus,wma}";
+const FILTER_IMAGE: &str = "Images\t*.{png,jpg,jpeg,gif,bmp,webp,tiff}";
+const FILTER_ANY: &str = "All files\t*";
+
+#[derive(Debug, Clone, Copy)]
+enum MediaCategory {
+    InProgress,
+    New,
+    Movie,
+    Tv,
+    Game,
+    Theater,
+    Music,
+    LiveTv,
+    HomeVideo,
+    Internet,
+    MusicVideo,
+    Pictures,
+    Radio,
+    Books,
+}
+
+impl MediaCategory {
+    fn label(self) -> &'static str {
+        match self {
+            Self::InProgress => "In Progress",
+            Self::New => "New Additions",
+            Self::Movie => "Movies",
+            Self::Tv => "TV Shows",
+            Self::Game => "Games",
+            Self::Theater => "Any Media",
+            Self::Music => "Music",
+            Self::LiveTv => "Live TV",
+            Self::HomeVideo => "Home Video",
+            Self::Internet => "Internet",
+            Self::MusicVideo => "Music Videos",
+            Self::Pictures => "Pictures",
+            Self::Radio => "Radio",
+            Self::Books => "Books",
+        }
+    }
+
+    fn filter(self) -> Option<&'static str> {
+        match self {
+            Self::InProgress
+            | Self::New
+            | Self::Movie
+            | Self::Tv
+            | Self::HomeVideo
+            | Self::MusicVideo => Some(FILTER_VIDEO),
+            Self::Theater => Some(FILTER_ANY),
+            Self::Music => Some(FILTER_AUDIO),
+            Self::Pictures => Some(FILTER_IMAGE),
+            Self::Game | Self::LiveTv | Self::Internet | Self::Radio | Self::Books => None,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 enum UiMsg {
     ShowSettings,
     ShowMenu,
-    PlaySelected,
+    PlayCategory(MediaCategory),
     Pause,
     Resume,
     Stop,
@@ -40,8 +103,25 @@ fn make_image_button(
     Ok(button)
 }
 
+fn wire_category(button: &mut Button, sender: &Sender<UiMsg>, category: MediaCategory) {
+    button.set_tooltip(category.label());
+    let sender = sender.clone();
+    button.set_callback(move |_| {
+        let _ = sender.send(UiMsg::PlayCategory(category));
+    });
+}
+
+fn wire_msg(button: &mut Button, sender: &Sender<UiMsg>, msg: UiMsg) {
+    let sender = sender.clone();
+    button.set_callback(move |_| {
+        let _ = sender.send(msg);
+    });
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
-    // Load images
+    let api_addr = env::var(THEATER_THIN_API_ADDR_ENV)
+        .unwrap_or_else(|_| DEFAULT_THEATER_THIN_API_ADDR.to_string());
+
     let bytes_image_rectangle =
         include_bytes!("../../../docker/core/mkwebaxum/static/image/rectangles_black.png");
     let bytes_image_new = include_bytes!("../../../docker/core/mkwebaxum/static/image/new.png");
@@ -71,9 +151,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     let bytes_image_return =
         include_bytes!("../../../docker/core/mkwebaxum/static/image/navigation/return.png");
 
-    let _server_list =
-        mk_lib_network::mk_lib_network_mediakraken::mk_lib_network_find_mediakraken_server();
-
     let app = app::App::default().with_scheme(app::Scheme::Gleam);
 
     let theme = WidgetScheme::new(SchemeType::Fluent);
@@ -81,26 +158,25 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let (sender, receiver) = unbounded::<UiMsg>();
 
-    // Menu window
     let mut window_menu = Window::default().with_size(800, 480);
 
-    let _button_in_progress = make_image_button(0, 0, 133, 96, bytes_image_rectangle)?;
-    let _button_new = make_image_button(0, 96, 133, 96, bytes_image_new)?;
-    let _button_movie = make_image_button(0, 192, 133, 96, bytes_image_movie_ticket)?;
-    let _button_tv = make_image_button(0, 288, 133, 96, bytes_image_television)?;
-    let _button_game = make_image_button(0, 384, 133, 96, bytes_image_vid_game)?;
+    let mut button_in_progress = make_image_button(0, 0, 133, 96, bytes_image_rectangle)?;
+    let mut button_new = make_image_button(0, 96, 133, 96, bytes_image_new)?;
+    let mut button_movie = make_image_button(0, 192, 133, 96, bytes_image_movie_ticket)?;
+    let mut button_tv = make_image_button(0, 288, 133, 96, bytes_image_television)?;
+    let mut button_game = make_image_button(0, 384, 133, 96, bytes_image_vid_game)?;
 
-    let mut button_demo = make_image_button(133, 0, 532, 384, bytes_image_theater)?;
+    let mut button_theater = make_image_button(133, 0, 532, 384, bytes_image_theater)?;
 
-    let _button_music = make_image_button(133, 384, 133, 96, bytes_image_headphone)?;
-    let _button_live_tv = make_image_button(266, 384, 133, 96, bytes_image_television_live)?;
-    let _button_home_video = make_image_button(399, 384, 133, 96, bytes_image_vid_camera)?;
-    let _button_internet = make_image_button(532, 384, 133, 96, bytes_image_earth)?;
+    let mut button_music = make_image_button(133, 384, 133, 96, bytes_image_headphone)?;
+    let mut button_live_tv = make_image_button(266, 384, 133, 96, bytes_image_television_live)?;
+    let mut button_home_video = make_image_button(399, 384, 133, 96, bytes_image_vid_camera)?;
+    let mut button_internet = make_image_button(532, 384, 133, 96, bytes_image_earth)?;
 
-    let _button_music_video = make_image_button(666, 0, 133, 96, bytes_image_music_video)?;
-    let _button_pictures = make_image_button(666, 96, 133, 96, bytes_image_photo)?;
-    let _button_radio = make_image_button(666, 192, 133, 96, bytes_image_radio)?;
-    let _button_books = make_image_button(666, 288, 133, 96, bytes_image_books)?;
+    let mut button_music_video = make_image_button(666, 0, 133, 96, bytes_image_music_video)?;
+    let mut button_pictures = make_image_button(666, 96, 133, 96, bytes_image_photo)?;
+    let mut button_radio = make_image_button(666, 192, 133, 96, bytes_image_radio)?;
+    let mut button_books = make_image_button(666, 288, 133, 96, bytes_image_books)?;
     let mut button_settings = make_image_button(666, 384, 133, 96, bytes_image_settings)?;
 
     window_menu.end();
@@ -108,103 +184,60 @@ fn main() -> Result<(), Box<dyn Error>> {
     window_menu.fullscreen(true);
     window_menu.show();
 
-    // Settings window
-    let mut window_settings = Window::default().with_size(800, 480);
+    let mut window_playback = Window::default().with_size(800, 480);
     let mut button_pause = Button::new(133, 96, 532, 64, "Pause");
     let mut button_resume = Button::new(133, 192, 532, 64, "Resume");
     let mut button_stop = Button::new(133, 288, 532, 64, "Stop");
-    let mut button_settings_back = make_image_button(666, 384, 133, 96, bytes_image_return)?;
+    let mut button_playback_back = make_image_button(666, 384, 133, 96, bytes_image_return)?;
 
     button_pause.set_tooltip("Pause playback on theater_thin");
     button_resume.set_tooltip("Resume playback on theater_thin");
     button_stop.set_tooltip("Stop playback on theater_thin");
+    button_playback_back.set_tooltip("Back to menu");
 
-    window_settings.end();
-    window_settings.make_resizable(true);
-    window_settings.fullscreen(true);
-    window_settings.hide();
+    window_playback.end();
+    window_playback.make_resizable(true);
+    window_playback.fullscreen(true);
+    window_playback.hide();
 
-    {
-        let sender = sender.clone();
-        button_settings.set_callback(move |_| {
-            let _ = sender.send(UiMsg::ShowSettings);
-        });
-    }
+    wire_category(&mut button_in_progress, &sender, MediaCategory::InProgress);
+    wire_category(&mut button_new, &sender, MediaCategory::New);
+    wire_category(&mut button_movie, &sender, MediaCategory::Movie);
+    wire_category(&mut button_tv, &sender, MediaCategory::Tv);
+    wire_category(&mut button_game, &sender, MediaCategory::Game);
+    wire_category(&mut button_theater, &sender, MediaCategory::Theater);
+    wire_category(&mut button_music, &sender, MediaCategory::Music);
+    wire_category(&mut button_live_tv, &sender, MediaCategory::LiveTv);
+    wire_category(&mut button_home_video, &sender, MediaCategory::HomeVideo);
+    wire_category(&mut button_internet, &sender, MediaCategory::Internet);
+    wire_category(&mut button_music_video, &sender, MediaCategory::MusicVideo);
+    wire_category(&mut button_pictures, &sender, MediaCategory::Pictures);
+    wire_category(&mut button_radio, &sender, MediaCategory::Radio);
+    wire_category(&mut button_books, &sender, MediaCategory::Books);
 
-    {
-        let sender = sender.clone();
-        button_demo.set_callback(move |_| {
-            let _ = sender.send(UiMsg::PlaySelected);
-        });
-    }
+    button_settings.set_tooltip("Playback controls");
+    wire_msg(&mut button_settings, &sender, UiMsg::ShowSettings);
 
-    {
-        let sender = sender.clone();
-        button_pause.set_callback(move |_| {
-            let _ = sender.send(UiMsg::Pause);
-        });
-    }
-
-    {
-        let sender = sender.clone();
-        button_resume.set_callback(move |_| {
-            let _ = sender.send(UiMsg::Resume);
-        });
-    }
-
-    {
-        let sender = sender.clone();
-        button_stop.set_callback(move |_| {
-            let _ = sender.send(UiMsg::Stop);
-        });
-    }
-
-    {
-        let sender = sender.clone();
-        button_settings_back.set_callback(move |_| {
-            let _ = sender.send(UiMsg::ShowMenu);
-        });
-    }
+    wire_msg(&mut button_pause, &sender, UiMsg::Pause);
+    wire_msg(&mut button_resume, &sender, UiMsg::Resume);
+    wire_msg(&mut button_stop, &sender, UiMsg::Stop);
+    wire_msg(&mut button_playback_back, &sender, UiMsg::ShowMenu);
 
     while app.wait() {
         if let Ok(msg) = receiver.try_recv() {
             match msg {
                 UiMsg::ShowSettings => {
                     window_menu.hide();
-                    window_settings.show();
+                    window_playback.show();
                 }
                 UiMsg::ShowMenu => {
-                    window_settings.hide();
+                    window_playback.hide();
                     window_menu.show();
                 }
-                UiMsg::PlaySelected => {
-                    if let Some(path) = pick_media_file() {
-                        if Path::new(&path).exists() {
-                            let encoded_path = url_encode(&path);
-                            let endpoint = format!("/api/play?path={encoded_path}");
-                            match send_theater_thin_post(&endpoint) {
-                                Ok((status, body)) if status.starts_with("HTTP/1.1 200") => {
-                                    message_default(&format!("theater_thin playing:\n{path}"));
-                                }
-                                Ok((status, body)) => {
-                                    alert_default(&format!(
-                                        "theater_thin play failed:\n{status}\n{body}"
-                                    ));
-                                }
-                                Err(error) => {
-                                    alert_default(&format!(
-                                        "Unable to reach theater_thin API:\n{error}"
-                                    ));
-                                }
-                            }
-                        } else {
-                            alert_default("Selected file does not exist.");
-                        }
-                    }
-                }
-                UiMsg::Pause => handle_simple_api("/api/pause", "Paused", "pause"),
-                UiMsg::Resume => handle_simple_api("/api/resume", "Resumed", "resume"),
-                UiMsg::Stop => handle_simple_api("/api/stop", "Stopped", "stop"),
+                UiMsg::PlayCategory(category) => handle_play_category(category, &api_addr),
+                UiMsg::Pause => handle_simple_api(&api_addr, "/api/pause", "Paused", "pause"),
+                UiMsg::Resume => handle_simple_api(&api_addr, "/api/resume", "Resumed", "resume"),
+                UiMsg::Stop => handle_simple_api(&api_addr, "/api/stop", "Stopped", "stop"),
             }
         }
     }
@@ -212,10 +245,44 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn pick_media_file() -> Option<String> {
+fn handle_play_category(category: MediaCategory, api_addr: &str) {
+    let Some(filter) = category.filter() else {
+        alert_default(&format!(
+            "{} playback is not yet supported from theater_controller_pi.",
+            category.label()
+        ));
+        return;
+    };
+
+    let Some(path) = pick_media_file(category.label(), filter) else {
+        return;
+    };
+
+    if !Path::new(&path).exists() {
+        alert_default("Selected file does not exist.");
+        return;
+    }
+
+    let endpoint = format!("/api/play?path={}", url_encode(&path));
+    match send_theater_thin_post(api_addr, &endpoint) {
+        Ok((200, _)) => {
+            message_default(&format!("theater_thin playing:\n{path}"));
+        }
+        Ok((code, body)) => {
+            alert_default(&format!(
+                "theater_thin play failed:\nHTTP {code}\n{body}"
+            ));
+        }
+        Err(error) => {
+            alert_default(&format!("Unable to reach theater_thin API:\n{error}"));
+        }
+    }
+}
+
+fn pick_media_file(category_label: &str, filter: &str) -> Option<String> {
     let mut chooser = NativeFileChooser::new(FileDialogType::BrowseFile);
-    chooser.set_title("Select media file to play in theater_thin");
-    chooser.set_filter("*.*");
+    chooser.set_title(&format!("Select {category_label} file to play in theater_thin"));
+    chooser.set_filter(filter);
     chooser.show();
 
     let selected = chooser.filename();
@@ -226,14 +293,14 @@ fn pick_media_file() -> Option<String> {
     }
 }
 
-fn handle_simple_api(endpoint: &str, success_title: &str, action_name: &str) {
-    match send_theater_thin_post(endpoint) {
-        Ok((status, body)) if status.starts_with("HTTP/1.1 200") => {
+fn handle_simple_api(api_addr: &str, endpoint: &str, success_title: &str, action_name: &str) {
+    match send_theater_thin_post(api_addr, endpoint) {
+        Ok((200, _)) => {
             message_default(&format!("{success_title} theater_thin playback."));
         }
-        Ok((status, body)) => {
+        Ok((code, body)) => {
             alert_default(&format!(
-                "Failed to {action_name} on theater_thin:\n{status}\n{body}"
+                "Failed to {action_name} on theater_thin:\nHTTP {code}\n{body}"
             ));
         }
         Err(error) => {
@@ -242,12 +309,24 @@ fn handle_simple_api(endpoint: &str, success_title: &str, action_name: &str) {
     }
 }
 
-fn send_theater_thin_post(endpoint: &str) -> Result<(String, String), String> {
-    let mut stream = TcpStream::connect(THEATER_THIN_API_ADDR)
-        .map_err(|error| format!("connect {THEATER_THIN_API_ADDR} failed: {error}"))?;
+fn send_theater_thin_post(api_addr: &str, endpoint: &str) -> Result<(u16, String), String> {
+    let socket_addr = api_addr
+        .to_socket_addrs()
+        .map_err(|error| format!("resolve {api_addr} failed: {error}"))?
+        .next()
+        .ok_or_else(|| format!("no addresses resolved for {api_addr}"))?;
+
+    let mut stream = TcpStream::connect_timeout(&socket_addr, TCP_TIMEOUT)
+        .map_err(|error| format!("connect {api_addr} failed: {error}"))?;
+    stream
+        .set_read_timeout(Some(TCP_TIMEOUT))
+        .map_err(|error| format!("set read timeout failed: {error}"))?;
+    stream
+        .set_write_timeout(Some(TCP_TIMEOUT))
+        .map_err(|error| format!("set write timeout failed: {error}"))?;
 
     let request = format!(
-        "POST {endpoint} HTTP/1.1\r\nHost: {THEATER_THIN_API_ADDR}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
+        "POST {endpoint} HTTP/1.1\r\nHost: {api_addr}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
     );
 
     stream
@@ -259,15 +338,25 @@ fn send_theater_thin_post(endpoint: &str) -> Result<(String, String), String> {
         .read_to_string(&mut response)
         .map_err(|error| format!("read response failed: {error}"))?;
 
+    parse_http_response(&response)
+}
+
+fn parse_http_response(response: &str) -> Result<(u16, String), String> {
     let mut sections = response.splitn(2, "\r\n\r\n");
     let header = sections.next().unwrap_or_default();
     let body = sections.next().unwrap_or_default().to_string();
     let status_line = header
         .lines()
         .next()
-        .unwrap_or("HTTP/1.1 500 Invalid response");
-
-    Ok((status_line.to_string(), body))
+        .ok_or_else(|| "empty response".to_string())?;
+    let code_str = status_line
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| format!("malformed status line: {status_line}"))?;
+    let code: u16 = code_str
+        .parse()
+        .map_err(|_| format!("invalid status code: {code_str}"))?;
+    Ok((code, body))
 }
 
 fn url_encode(input: &str) -> String {
@@ -285,4 +374,62 @@ fn url_encode(input: &str) -> String {
         }
     }
     encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn url_encode_leaves_unreserved_chars_alone() {
+        assert_eq!(url_encode("abcXYZ-._~"), "abcXYZ-._~");
+    }
+
+    #[test]
+    fn url_encode_percent_encodes_reserved_chars() {
+        assert_eq!(url_encode("/path to/file"), "%2Fpath%20to%2Ffile");
+        assert_eq!(url_encode("a+b&c=d"), "a%2Bb%26c%3Dd");
+    }
+
+    #[test]
+    fn url_encode_handles_non_ascii() {
+        // U+00E9 é -> UTF-8 bytes 0xC3 0xA9
+        assert_eq!(url_encode("caf\u{00e9}"), "caf%C3%A9");
+    }
+
+    #[test]
+    fn parse_http_response_extracts_code_and_body() {
+        let raw = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"ok\":true}";
+        let (code, body) = parse_http_response(raw).expect("parse");
+        assert_eq!(code, 200);
+        assert_eq!(body, "{\"ok\":true}");
+    }
+
+    #[test]
+    fn parse_http_response_handles_http_1_0() {
+        let raw = "HTTP/1.0 404 Not Found\r\n\r\nnope";
+        let (code, body) = parse_http_response(raw).expect("parse");
+        assert_eq!(code, 404);
+        assert_eq!(body, "nope");
+    }
+
+    #[test]
+    fn parse_http_response_rejects_malformed_status() {
+        assert!(parse_http_response("").is_err());
+        assert!(parse_http_response("HTTP/1.1\r\n\r\n").is_err());
+        assert!(parse_http_response("HTTP/1.1 NOPE OK\r\n\r\n").is_err());
+    }
+
+    #[test]
+    fn media_category_filters_are_consistent() {
+        assert!(MediaCategory::Movie.filter().is_some());
+        assert!(MediaCategory::Music.filter().is_some());
+        assert!(MediaCategory::Pictures.filter().is_some());
+        assert!(MediaCategory::Theater.filter().is_some());
+        assert!(MediaCategory::Game.filter().is_none());
+        assert!(MediaCategory::Radio.filter().is_none());
+        assert!(MediaCategory::Books.filter().is_none());
+        assert!(MediaCategory::Internet.filter().is_none());
+        assert!(MediaCategory::LiveTv.filter().is_none());
+    }
 }

--- a/src_app/theater_controller_pi/src/main.rs
+++ b/src_app/theater_controller_pi/src/main.rs
@@ -309,15 +309,36 @@ fn handle_simple_api(api_addr: &str, endpoint: &str, success_title: &str, action
     }
 }
 
-fn send_theater_thin_post(api_addr: &str, endpoint: &str) -> Result<(u16, String), String> {
-    let socket_addr = api_addr
+fn connect_with_timeout(api_addr: &str) -> Result<TcpStream, String> {
+    let addrs = api_addr
         .to_socket_addrs()
-        .map_err(|error| format!("resolve {api_addr} failed: {error}"))?
-        .next()
-        .ok_or_else(|| format!("no addresses resolved for {api_addr}"))?;
+        .map_err(|error| format!("resolve {api_addr} failed: {error}"))?;
 
-    let mut stream = TcpStream::connect_timeout(&socket_addr, TCP_TIMEOUT)
-        .map_err(|error| format!("connect {api_addr} failed: {error}"))?;
+    let mut last_error: Option<String> = None;
+    let mut tried = 0;
+
+    for socket_addr in addrs {
+        tried += 1;
+        match TcpStream::connect_timeout(&socket_addr, TCP_TIMEOUT) {
+            Ok(stream) => return Ok(stream),
+            Err(error) => {
+                last_error = Some(format!("{socket_addr}: {error}"));
+            }
+        }
+    }
+
+    if tried == 0 {
+        Err(format!("no addresses resolved for {api_addr}"))
+    } else {
+        Err(format!(
+            "connect {api_addr} failed: {}",
+            last_error.unwrap_or_else(|| "unknown error".to_string())
+        ))
+    }
+}
+
+fn send_theater_thin_post(api_addr: &str, endpoint: &str) -> Result<(u16, String), String> {
+    let mut stream = connect_with_timeout(api_addr)?;
     stream
         .set_read_timeout(Some(TCP_TIMEOUT))
         .map_err(|error| format!("set read timeout failed: {error}"))?;


### PR DESCRIPTION
## Summary
This PR refactors the theater controller UI to support multiple media categories with appropriate file filters, adds environment variable configuration for the API address, improves error handling with proper HTTP status code parsing, and includes comprehensive unit tests.

## Key Changes
- **Media Categories**: Introduced `MediaCategory` enum with 14 categories (Movies, TV, Music, Pictures, etc.), each with appropriate file filters and display labels
- **Configurable API Address**: Added support for `THEATER_THIN_API_ADDR` environment variable with fallback to default `127.0.0.1:7878`
- **Enhanced Networking**: 
  - Replaced hardcoded address with configurable `api_addr` parameter throughout
  - Added TCP connection timeout (5 seconds) and read/write timeouts
  - Improved socket address resolution with proper error handling
- **HTTP Response Parsing**: Refactored response handling to extract and return numeric HTTP status codes instead of string status lines
- **UI Improvements**:
  - Renamed "Settings" window to "Playback" window for clarity
  - Replaced generic "PlaySelected" message with `PlayCategory(MediaCategory)` for category-specific handling
  - Added helper functions `wire_category()` and `wire_msg()` to reduce callback boilerplate
  - File picker now shows category-specific titles and filters
- **Code Quality**:
  - Added comprehensive unit tests for URL encoding, HTTP response parsing, and media category filters
  - Removed unused dependencies (`mk_lib_network`, `reqwest`, `serde`, `tokio-test`)
  - Simplified error messages and status code handling
- **Removed Features**: Eliminated server discovery functionality and unused async/networking dependencies

## Notable Implementation Details
- Media categories without file filters (Games, Radio, Books, etc.) show an alert indicating unsupported playback
- HTTP status codes are now properly parsed as `u16` values for cleaner error handling
- File dialog filters use FLTK's native format with multiple file extensions per category
- All button callbacks now use the new `wire_*` helper functions for consistency

https://claude.ai/code/session_019Pd51Gts1CqSGsJcX9NXT7