### PR TITLE
Refactor theater_thin HTTP API with security and reliability improvements

### DIFF
--- a/src_app/theater_thin/Cargo.toml
+++ b/src_app/theater_thin/Cargo.toml
@@ -12,13 +12,4 @@ codegen-units = 1
 [dependencies]
 mk_lib_network = { version = "0.0.204", registry = "kellnr" }
 fltk = { version = "1.5.22", features = ["fltk-bundled"] }
-reqwest = { version = "0.13.2", default-features = false, features = [
-    "json",
-    "rustls-tls",
-] }
-serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-stdext = "0.3.3"
-
-[dev-dependencies]
-tokio-test = "*"

--- a/src_app/theater_thin/src/main.rs
+++ b/src_app/theater_thin/src/main.rs
@@ -1,72 +1,171 @@
 use fltk::{app, enums::Color, prelude::*, window};
-use mk_lib_network;
+use serde_json::{Value, json};
 use std::{
     collections::HashMap,
-    fs,
-    io::{Read, Write},
+    env, fs,
+    io::{ErrorKind, Read, Write},
     net::{TcpListener, TcpStream},
     os::unix::net::UnixStream,
-    path::Path,
+    path::{Path, PathBuf},
     process::{Child, Command},
     sync::{Arc, Mutex},
     thread,
+    time::{Duration, Instant},
 };
 
 const HTTP_BIND_ADDR: &str = "127.0.0.1:7878";
-const MPV_IPC_PATH: &str = "/tmp/theater_thin_mpv.sock";
+const ALLOWED_HOSTS: &[&str] = &[
+    "127.0.0.1",
+    "127.0.0.1:7878",
+    "localhost",
+    "localhost:7878",
+];
+const REQUEST_HEADER_LIMIT: usize = 8 * 1024;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const MPV_READY_TIMEOUT: Duration = Duration::from_secs(10);
+const MPV_SOCKET_WRITE_TIMEOUT: Duration = Duration::from_secs(2);
+const MEDIA_ROOT_ENV: &str = "THEATER_THIN_MEDIA_ROOT";
+const AUTH_TOKEN_ENV: &str = "THEATER_THIN_TOKEN";
+
+struct MpvController {
+    child: Mutex<Option<Child>>,
+    socket_path: PathBuf,
+}
+
+impl MpvController {
+    fn spawn(window_handle: u64, socket_path: PathBuf) -> std::io::Result<Self> {
+        let _ = fs::remove_file(&socket_path);
+        let child = Command::new("mpv")
+            .arg(format!("--wid={window_handle}"))
+            .arg("--idle=yes")
+            .arg("--force-window=yes")
+            .arg(format!("--input-ipc-server={}", socket_path.display()))
+            .spawn()?;
+        Ok(Self {
+            child: Mutex::new(Some(child)),
+            socket_path,
+        })
+    }
+
+    fn wait_ready(&self) -> Result<(), String> {
+        let deadline = Instant::now() + MPV_READY_TIMEOUT;
+        loop {
+            if self.socket_path.exists() && UnixStream::connect(&self.socket_path).is_ok() {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err("mpv IPC socket did not become ready".to_string());
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    fn send(&self, command: &str) -> Result<(), String> {
+        if matches!(self.child.lock(), Ok(guard) if guard.is_none()) {
+            return Err("mpv is not running".to_string());
+        }
+        let mut stream = UnixStream::connect(&self.socket_path)
+            .map_err(|e| format!("connect: {e}"))?;
+        let _ = stream.set_write_timeout(Some(MPV_SOCKET_WRITE_TIMEOUT));
+        stream
+            .write_all(command.as_bytes())
+            .map_err(|e| format!("write: {e}"))?;
+        Ok(())
+    }
+
+    fn shutdown(&self) {
+        if let Ok(mut guard) = self.child.lock() {
+            if let Some(mut child) = guard.take() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
+        let _ = fs::remove_file(&self.socket_path);
+    }
+}
+
+impl Drop for MpvController {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+fn runtime_socket_path() -> PathBuf {
+    let dir = env::var_os("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(env::temp_dir);
+    dir.join(format!("theater_thin_mpv_{}.sock", std::process::id()))
+}
+
+fn media_root() -> Option<PathBuf> {
+    env::var_os(MEDIA_ROOT_ENV)
+        .map(PathBuf::from)
+        .and_then(|p| p.canonicalize().ok())
+}
+
+fn auth_token() -> Option<String> {
+    env::var(AUTH_TOKEN_ENV).ok().filter(|s| !s.is_empty())
+}
 
 fn main() {
-    let _server_list =
-        mk_lib_network::mk_lib_network_mediakraken::mk_lib_network_find_mediakraken_server();
+    // mpv --wid only works with X11 windows; warn early on Wayland-only sessions.
+    if env::var_os("WAYLAND_DISPLAY").is_some() && env::var_os("DISPLAY").is_none() {
+        eprintln!("warning: running under Wayland without XWayland; mpv embedding will not work");
+    }
+
+    let _ = mk_lib_network::mk_lib_network_mediakraken::mk_lib_network_find_mediakraken_server();
 
     let app = app::App::default().with_scheme(app::AppScheme::Gtk);
     let mut win = window::Window::new(100, 100, 800, 600, "Media Player");
-
-    // Inner window used as embedded media player target.
     let mut mpv_win = window::Window::new(10, 10, 780, 520, "");
     mpv_win.end();
     mpv_win.set_color(Color::Black);
-
     win.end();
     win.show();
     win.make_resizable(true);
 
+    let socket_path = runtime_socket_path();
     let handle = mpv_win.raw_handle();
-    let mpv_child = start_mpv(handle as u64);
-    let mpv_child_shared = Arc::new(Mutex::new(mpv_child));
+    let controller = match MpvController::spawn(handle as u64, socket_path) {
+        Ok(c) => Arc::new(c),
+        Err(e) => {
+            eprintln!("Failed to launch mpv: {e}");
+            return;
+        }
+    };
 
-    run_http_api(Arc::clone(&mpv_child_shared));
+    if let Err(e) = controller.wait_ready() {
+        eprintln!("mpv readiness check failed: {e}");
+    }
+
+    let token = auth_token();
+    let media_root = media_root();
+    if media_root.is_none() {
+        eprintln!("warning: {MEDIA_ROOT_ENV} not set; /api/play will be rejected");
+    }
+    if token.is_none() {
+        eprintln!("warning: {AUTH_TOKEN_ENV} not set; control endpoints will be rejected");
+    }
+
+    run_http_api(Arc::clone(&controller), token, media_root);
 
     if let Err(error) = app.run() {
         eprintln!("Application exited with error: {error}");
     }
+
+    controller.shutdown();
 }
 
-fn start_mpv(window_handle: u64) -> Option<Child> {
-    let _ = fs::remove_file(MPV_IPC_PATH);
-
-    let mut command = Command::new("mpv");
-    command
-        .arg(format!("--wid={window_handle}"))
-        .arg("--idle=yes")
-        .arg("--force-window=yes")
-        .arg(format!("--input-ipc-server={MPV_IPC_PATH}"));
-
-    match command.spawn() {
-        Ok(child) => Some(child),
-        Err(error) => {
-            eprintln!("Failed to launch mpv: {error}");
-            None
-        }
-    }
-}
-
-fn run_http_api(mpv_child: Arc<Mutex<Option<Child>>>) {
+fn run_http_api(
+    controller: Arc<MpvController>,
+    token: Option<String>,
+    media_root: Option<PathBuf>,
+) {
     thread::spawn(move || {
         let listener = match TcpListener::bind(HTTP_BIND_ADDR) {
-            Ok(listener) => listener,
-            Err(error) => {
-                eprintln!("Failed to bind HTTP API at {HTTP_BIND_ADDR}: {error}");
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("Failed to bind HTTP API at {HTTP_BIND_ADDR}: {e}");
                 return;
             }
         };
@@ -74,13 +173,21 @@ fn run_http_api(mpv_child: Arc<Mutex<Option<Child>>>) {
         for stream_result in listener.incoming() {
             match stream_result {
                 Ok(stream) => {
-                    if let Err(error) = handle_client(stream, &mpv_child) {
-                        eprintln!("HTTP API request failed: {error}");
-                    }
+                    let controller = Arc::clone(&controller);
+                    let token = token.clone();
+                    let media_root = media_root.clone();
+                    thread::spawn(move || {
+                        if let Err(e) = handle_client(
+                            stream,
+                            &controller,
+                            token.as_deref(),
+                            media_root.as_deref(),
+                        ) {
+                            eprintln!("HTTP API request failed: {e}");
+                        }
+                    });
                 }
-                Err(error) => {
-                    eprintln!("Failed to accept HTTP client: {error}");
-                }
+                Err(e) => eprintln!("Failed to accept HTTP client: {e}"),
             }
         }
     });
@@ -88,160 +195,266 @@ fn run_http_api(mpv_child: Arc<Mutex<Option<Child>>>) {
 
 fn handle_client(
     mut stream: TcpStream,
-    mpv_child: &Arc<Mutex<Option<Child>>>,
-) -> Result<(), std::io::Error> {
-    let mut buffer = [0_u8; 4096];
-    let bytes_read = stream.read(&mut buffer)?;
-    if bytes_read == 0 {
+    controller: &MpvController,
+    token: Option<&str>,
+    media_root: Option<&Path>,
+) -> std::io::Result<()> {
+    stream.set_read_timeout(Some(REQUEST_TIMEOUT))?;
+    stream.set_write_timeout(Some(REQUEST_TIMEOUT))?;
+
+    let raw = read_request_head(&mut stream)?;
+    if raw.is_empty() {
         return Ok(());
     }
-
-    let request = String::from_utf8_lossy(&buffer[..bytes_read]);
-    let mut lines = request.lines();
+    let head = String::from_utf8_lossy(&raw);
+    let mut lines = head.lines();
     let Some(request_line) = lines.next() else {
         return Ok(());
     };
 
-    let mut request_parts = request_line.split_whitespace();
-    let method = request_parts.next().unwrap_or_default();
-    let target = request_parts.next().unwrap_or_default();
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or_default();
+    let target = parts.next().unwrap_or_default();
+
+    let mut host_ok = false;
+    let mut auth_header: Option<String> = None;
+    for line in lines {
+        if line.is_empty() {
+            break;
+        }
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.trim();
+        match name.trim().to_ascii_lowercase().as_str() {
+            "host" => {
+                if ALLOWED_HOSTS.iter().any(|h| h.eq_ignore_ascii_case(value)) {
+                    host_ok = true;
+                }
+            }
+            "authorization" => auth_header = Some(value.to_string()),
+            _ => {}
+        }
+    }
+
+    if !host_ok {
+        return write_response(
+            &mut stream,
+            "400 Bad Request",
+            &json!({"error": "invalid or missing Host header"}).to_string(),
+        );
+    }
 
     let (path, query) = split_target(target);
     let query_map = parse_query(query);
 
-    let (status_line, body) = route_request(method, path, &query_map, mpv_child);
+    let (status, body) = route_request(
+        method,
+        path,
+        &query_map,
+        controller,
+        token,
+        auth_header.as_deref(),
+        media_root,
+    );
+    write_response(&mut stream, status, &body)
+}
 
-    let response = format!(
-        "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+fn read_request_head(stream: &mut TcpStream) -> std::io::Result<Vec<u8>> {
+    let mut buf = Vec::with_capacity(1024);
+    let mut chunk = [0u8; 1024];
+    loop {
+        if buf.len() > REQUEST_HEADER_LIMIT {
+            return Err(std::io::Error::new(
+                ErrorKind::InvalidData,
+                "request headers exceed limit",
+            ));
+        }
+        let n = stream.read(&mut chunk)?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+    }
+    Ok(buf)
+}
+
+fn write_response(stream: &mut TcpStream, status: &str, body: &str) -> std::io::Result<()> {
+    let resp = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
         body.len()
     );
-    stream.write_all(response.as_bytes())?;
-    stream.flush()?;
-
-    Ok(())
+    stream.write_all(resp.as_bytes())?;
+    stream.flush()
 }
 
 fn route_request(
     method: &str,
     path: &str,
     query: &HashMap<String, String>,
-    mpv_child: &Arc<Mutex<Option<Child>>>,
+    controller: &MpvController,
+    token: Option<&str>,
+    auth_header: Option<&str>,
+    media_root: Option<&Path>,
 ) -> (&'static str, String) {
+    if method == "GET" && path == "/api/health" {
+        return (
+            "200 OK",
+            json!({"status": "ok", "service": "theater_thin"}).to_string(),
+        );
+    }
+
+    if !is_authorized(token, auth_header) {
+        return (
+            "401 Unauthorized",
+            json!({"error": "unauthorized"}).to_string(),
+        );
+    }
+
     match (method, path) {
-        ("GET", "/api/health") => (
-            "HTTP/1.1 200 OK",
-            "{\"status\":\"ok\",\"service\":\"theater_thin\"}".to_string(),
-        ),
         ("POST", "/api/play") => {
             let Some(path_param) = query.get("path") else {
                 return (
-                    "HTTP/1.1 400 Bad Request",
-                    "{\"error\":\"missing required query parameter: path\"}".to_string(),
+                    "400 Bad Request",
+                    json!({"error": "missing required query parameter: path"}).to_string(),
                 );
             };
-
-            if !Path::new(path_param).exists() {
+            let Some(root) = media_root else {
                 return (
-                    "HTTP/1.1 400 Bad Request",
-                    format!(
-                        "{{\"error\":\"file not found\",\"path\":{}}}",
-                        to_json_string(path_param)
-                    ),
+                    "503 Service Unavailable",
+                    json!({"error": "media root not configured"}).to_string(),
                 );
-            }
-
-            let command = format!(
-                "{{\"command\":[\"loadfile\",{} ,\"replace\"]}}\n",
-                to_json_string(path_param)
-            );
-
-            match send_mpv_ipc_command(&command, mpv_child) {
-                Ok(()) => (
-                    "HTTP/1.1 200 OK",
-                    format!("{{\"status\":\"playing\",\"path\":{}}}", to_json_string(path_param)),
-                ),
-                Err(error) => (
-                    "HTTP/1.1 500 Internal Server Error",
-                    format!(
-                        "{{\"error\":\"failed to send play command\",\"detail\":{}}}",
-                        to_json_string(&error)
-                    ),
-                ),
-            }
+            };
+            let resolved = match resolve_within(root, path_param) {
+                Ok(p) => p,
+                Err(e) => {
+                    return (
+                        "400 Bad Request",
+                        json!({"error": "invalid path", "detail": e}).to_string(),
+                    );
+                }
+            };
+            let cmd = json!({
+                "command": ["loadfile", resolved.to_string_lossy(), "replace"],
+            })
+            .to_string()
+                + "\n";
+            send_with_status(
+                controller,
+                &cmd,
+                "playing",
+                json!({"path": resolved.to_string_lossy()}),
+            )
         }
-        ("POST", "/api/pause") => {
-            let command = "{\"command\":[\"set_property\",\"pause\",true]}\n";
-            match send_mpv_ipc_command(command, mpv_child) {
-                Ok(()) => ("HTTP/1.1 200 OK", "{\"status\":\"paused\"}".to_string()),
-                Err(error) => (
-                    "HTTP/1.1 500 Internal Server Error",
-                    format!(
-                        "{{\"error\":\"failed to pause\",\"detail\":{}}}",
-                        to_json_string(&error)
-                    ),
-                ),
-            }
-        }
-        ("POST", "/api/resume") => {
-            let command = "{\"command\":[\"set_property\",\"pause\",false]}\n";
-            match send_mpv_ipc_command(command, mpv_child) {
-                Ok(()) => ("HTTP/1.1 200 OK", "{\"status\":\"resumed\"}".to_string()),
-                Err(error) => (
-                    "HTTP/1.1 500 Internal Server Error",
-                    format!(
-                        "{{\"error\":\"failed to resume\",\"detail\":{}}}",
-                        to_json_string(&error)
-                    ),
-                ),
-            }
-        }
-        ("POST", "/api/stop") => {
-            let command = "{\"command\":[\"stop\"]}\n";
-            match send_mpv_ipc_command(command, mpv_child) {
-                Ok(()) => ("HTTP/1.1 200 OK", "{\"status\":\"stopped\"}".to_string()),
-                Err(error) => (
-                    "HTTP/1.1 500 Internal Server Error",
-                    format!(
-                        "{{\"error\":\"failed to stop\",\"detail\":{}}}",
-                        to_json_string(&error)
-                    ),
-                ),
-            }
-        }
+        ("POST", "/api/pause") => send_with_status(
+            controller,
+            &json!({"command": ["set_property", "pause", true]}).to_string(),
+            "paused",
+            Value::Null,
+        ),
+        ("POST", "/api/resume") => send_with_status(
+            controller,
+            &json!({"command": ["set_property", "pause", false]}).to_string(),
+            "resumed",
+            Value::Null,
+        ),
+        ("POST", "/api/stop") => send_with_status(
+            controller,
+            &json!({"command": ["stop"]}).to_string(),
+            "stopped",
+            Value::Null,
+        ),
         _ => (
-            "HTTP/1.1 404 Not Found",
-            "{\"error\":\"not found\",\"supported\":[\"GET /api/health\",\"POST /api/play?path=<file>\",\"POST /api/pause\",\"POST /api/resume\",\"POST /api/stop\"]}".to_string(),
+            "404 Not Found",
+            json!({
+                "error": "not found",
+                "supported": [
+                    "GET /api/health",
+                    "POST /api/play?path=<file>",
+                    "POST /api/pause",
+                    "POST /api/resume",
+                    "POST /api/stop",
+                ],
+            })
+            .to_string(),
         ),
     }
 }
 
-fn send_mpv_ipc_command(
+fn send_with_status(
+    controller: &MpvController,
     command: &str,
-    mpv_child: &Arc<Mutex<Option<Child>>>,
-) -> Result<(), String> {
-    {
-        let lock = mpv_child
-            .lock()
-            .map_err(|_| "mpv process state lock poisoned".to_string())?;
-        if lock.is_none() {
-            return Err("mpv is not running".to_string());
+    ok_status: &str,
+    extra: Value,
+) -> (&'static str, String) {
+    let payload = if !command.ends_with('\n') {
+        format!("{command}\n")
+    } else {
+        command.to_string()
+    };
+    match controller.send(&payload) {
+        Ok(()) => {
+            let mut value = json!({"status": ok_status});
+            if let (Some(obj), Some(extra_obj)) = (value.as_object_mut(), extra.as_object()) {
+                for (k, v) in extra_obj {
+                    obj.insert(k.clone(), v.clone());
+                }
+            }
+            ("200 OK", value.to_string())
         }
+        Err(e) => (
+            "500 Internal Server Error",
+            json!({"error": "mpv command failed", "detail": e}).to_string(),
+        ),
     }
+}
 
-    let mut stream = UnixStream::connect(MPV_IPC_PATH)
-        .map_err(|error| format!("failed to connect to mpv socket: {error}"))?;
-    stream
-        .write_all(command.as_bytes())
-        .map_err(|error| format!("failed to write to mpv socket: {error}"))?;
-    Ok(())
+fn is_authorized(expected: Option<&str>, header: Option<&str>) -> bool {
+    let Some(expected) = expected else {
+        return false;
+    };
+    let Some(header) = header else {
+        return false;
+    };
+    let provided = header.strip_prefix("Bearer ").unwrap_or(header).trim();
+    constant_time_eq(expected.as_bytes(), provided.as_bytes())
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+fn resolve_within(root: &Path, requested: &str) -> Result<PathBuf, String> {
+    let candidate = Path::new(requested);
+    let joined = if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        root.join(candidate)
+    };
+    let canonical = joined
+        .canonicalize()
+        .map_err(|e| format!("canonicalize: {e}"))?;
+    if !canonical.starts_with(root) {
+        return Err("path escapes media root".to_string());
+    }
+    if !canonical.is_file() {
+        return Err("not a regular file".to_string());
+    }
+    Ok(canonical)
 }
 
 fn split_target(target: &str) -> (&str, &str) {
-    if let Some((path, query)) = target.split_once('?') {
-        (path, query)
-    } else {
-        (target, "")
-    }
+    target.split_once('?').unwrap_or((target, ""))
 }
 
 fn parse_query(query: &str) -> HashMap<String, String> {
@@ -250,56 +463,40 @@ fn parse_query(query: &str) -> HashMap<String, String> {
         if pair.is_empty() {
             continue;
         }
-
-        let (key, value) = if let Some((key, value)) = pair.split_once('=') {
-            (key, value)
-        } else {
-            (pair, "")
-        };
-
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
         map.insert(url_decode(key), url_decode(value));
     }
     map
 }
 
 fn url_decode(value: &str) -> String {
-    let mut output = String::new();
-    let mut chars = value.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-        if ch == '%' {
-            let hi = chars.next();
-            let lo = chars.next();
-            match (hi, lo) {
-                (Some(hi), Some(lo)) => {
-                    let hex = [hi, lo].iter().collect::<String>();
-                    match u8::from_str_radix(&hex, 16) {
-                        Ok(byte) => output.push(char::from(byte)),
-                        Err(_) => {
-                            output.push('%');
-                            output.push(hi);
-                            output.push(lo);
-                        }
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or("");
+                match u8::from_str_radix(hex, 16) {
+                    Ok(byte) => {
+                        out.push(byte);
+                        i += 3;
+                    }
+                    Err(_) => {
+                        out.push(b'%');
+                        i += 1;
                     }
                 }
-                _ => output.push('%'),
             }
-        } else if ch == '+' {
-            output.push(' ');
-        } else {
-            output.push(ch);
+            other => {
+                out.push(other);
+                i += 1;
+            }
         }
     }
-
-    output
-}
-
-fn to_json_string(input: &str) -> String {
-    let escaped = input
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t");
-    format!("\"{escaped}\"")
+    String::from_utf8_lossy(&out).into_owned()
 }


### PR DESCRIPTION
## Summary
This PR significantly refactors the theater_thin media player application to improve security, reliability, and code maintainability. The changes include implementing proper HTTP request handling, adding authentication support, path validation, and better mpv process management.

## Key Changes

- **HTTP Request Handling**: Replaced simple buffer-based reading with proper header parsing that respects size limits and timeouts. Added support for reading complete HTTP headers with `\r\n\r\n` detection.

- **Security Improvements**:
  - Added Host header validation against an allowlist to prevent Host header injection attacks
  - Implemented token-based authentication via `Authorization: Bearer <token>` header
  - Added constant-time comparison for token validation to prevent timing attacks
  - Implemented path traversal protection with `resolve_within()` that validates requested files stay within the configured media root

- **Configuration via Environment Variables**:
  - `THEATER_THIN_MEDIA_ROOT`: Configurable media directory (required for `/api/play`)
  - `THEATER_THIN_TOKEN`: Optional authentication token for control endpoints
  - `XDG_RUNTIME_DIR`: Used for mpv socket path (falls back to temp directory)

- **MpvController Struct**: Refactored mpv process management into a dedicated struct with:
  - Proper lifecycle management (spawn, wait_ready, send, shutdown)
  - Automatic cleanup via Drop trait
  - Timeout-based readiness checking
  - Write timeout enforcement on socket operations

- **Improved Error Handling**:
  - Added request timeouts (5 seconds for HTTP, 2 seconds for mpv socket writes)
  - Better error messages with context
  - Proper HTTP status codes and JSON error responses
  - Request header size limit (8KB) to prevent memory exhaustion

- **API Enhancements**:
  - `/api/health` now returns before authentication check
  - `/api/play` validates file paths and prevents directory traversal
  - All control endpoints (`/api/pause`, `/api/resume`, `/api/stop`) require authentication
  - Consistent JSON response formatting using `serde_json`

- **Code Quality**:
  - Replaced manual JSON string construction with `serde_json::json!` macro
  - Simplified URL decoding implementation
  - Removed unused dependencies (reqwest, serde, stdext, tokio-test)
  - Better separation of concerns with dedicated helper functions
  - Per-client request handling in separate threads

- **Platform Awareness**: Added early warning for Wayland-only sessions where mpv embedding won't work

## Notable Implementation Details

- Socket path is now per-process (`theater_thin_mpv_{pid}.sock`) to support multiple instances
- HTTP responses properly include Content-Length and Connection headers
- Request parsing is defensive against malformed input
- Media root path is canonicalized to prevent symlink-based escapes

https://claude.ai/code/session_01E29eMZmpPWYdFjh9o8qw6w