### PR TITLE
Refactor theater_full UI layout to use Flex containers

### DIFF
--- a/src_app/theater_full/Cargo.toml
+++ b/src_app/theater_full/Cargo.toml
@@ -14,13 +14,4 @@ mk_lib_network = { version = "0.0.204", registry = "kellnr" }
 
 fltk = { version = "1.5.22", features = ["fltk-bundled"] }
 fltk-theme = "0.7.9"
-reqwest = { version = "0.13.2", default-features = false, features = [
-    "json",
-    "rustls-tls",
-] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-stdext = "0.3.3"
-
-[dev-dependencies]
-tokio-test = "*"
+tokio = { version = "1.49.0", features = ["rt"] }

--- a/src_app/theater_full/src/main.rs
+++ b/src_app/theater_full/src/main.rs
@@ -1,7 +1,28 @@
-use fltk::{app, button::Button, image::PngImage, prelude::*, window::Window};
+use fltk::{
+    app,
+    button::Button,
+    dialog,
+    group::Flex,
+    image::PngImage,
+    prelude::*,
+    window::Window,
+};
 use fltk_theme::{SchemeType, WidgetScheme};
-use mk_lib_network;
 use std::error::Error;
+
+const WINDOW_W: i32 = 800;
+const WINDOW_H: i32 = 480;
+const SIDE_COL_W: i32 = WINDOW_W / 6;
+const BOTTOM_ROW_H: i32 = WINDOW_H / 5;
+
+macro_rules! asset {
+    ($name:literal) => {
+        include_bytes!(concat!(
+            "../../../docker/core/mkwebaxum/static/image/",
+            $name
+        ))
+    };
+}
 
 fn set_button_image(
     button: &mut Button,
@@ -15,116 +36,93 @@ fn set_button_image(
     Ok(())
 }
 
-fn make_image_button(
-    x: i32,
-    y: i32,
-    w: i32,
-    h: i32,
-    label: &str,
-    image_bytes: &[u8],
-) -> Result<Button, Box<dyn Error>> {
-    let mut button = Button::new(x, y, w, h, label);
-    set_button_image(&mut button, image_bytes, w, h)?;
+fn make_image_button(label: &str, image_bytes: &[u8]) -> Result<Button, Box<dyn Error>> {
+    let mut button = Button::default().with_label(label);
+    set_button_image(&mut button, image_bytes, SIDE_COL_W, BOTTOM_ROW_H)?;
     Ok(button)
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    // load images
-    let bytes_image_rectangle =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/rectangles_black.png");
-    let bytes_image_new =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/new.png");
-    let bytes_image_movie_ticket =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/movie_ticket.png");
-    let bytes_image_television =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/television.png");
-    let bytes_image_vid_game =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/vid_game.png");
-    let bytes_image_theater =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/theater.png");
-    let bytes_image_headphone =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/headphone.png");
-    let bytes_image_television_live =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/television_live.png");
-    let bytes_image_vid_camera =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/vid_camera.png");
-    let bytes_image_earth =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/earth.png");
-    let bytes_image_music_video = include_bytes!(
-        "../../../docker/core/mkwebaxum/static/image/listening-music-video-clip-with-auricular.png"
+fn run() -> Result<(), Box<dyn Error>> {
+    let runtime = tokio::runtime::Builder::new_current_thread().build()?;
+    let _server = runtime.block_on(
+        mk_lib_network::mk_lib_network_mediakraken::mk_lib_network_find_mediakraken_server(),
     );
-    let bytes_image_photo =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/photo.png");
-    let bytes_image_radio =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/radio.png");
-    let bytes_image_books =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/books.png");
-    let bytes_image_settings =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/settings.png");
-    let bytes_image_return =
-        include_bytes!("../../../docker/core/mkwebaxum/static/image/navigation/return.png");
-
-    let _server_list =
-        mk_lib_network::mk_lib_network_mediakraken::mk_lib_network_find_mediakraken_server();
 
     let app = app::App::default().with_scheme(app::Scheme::Gleam);
+    WidgetScheme::new(SchemeType::Fluent).apply();
 
-    let theme = WidgetScheme::new(SchemeType::Fluent);
-    theme.apply();
+    let mut window_menu = Window::default()
+        .with_size(WINDOW_W, WINDOW_H)
+        .with_label("MediaKraken Theater");
 
-    // main menu window
-    let mut window_menu = Window::default().with_size(800, 480);
+    let mut outer = Flex::default_fill().row();
+    outer.set_margin(0);
+    outer.set_pad(0);
 
-    // left column
-    let _button_in_progress =
-        make_image_button(0, 0, 133, 96, "In Progress", bytes_image_rectangle)?;
-    let _button_new =
-        make_image_button(0, 96, 133, 96, "New", bytes_image_new)?;
-    let _button_movie =
-        make_image_button(0, 192, 133, 96, "Movie", bytes_image_movie_ticket)?;
-    let _button_tv =
-        make_image_button(0, 288, 133, 96, "TV", bytes_image_television)?;
-    let _button_game =
-        make_image_button(0, 384, 133, 96, "Games", bytes_image_vid_game)?;
+    let mut left_col = Flex::default().column();
+    left_col.set_pad(0);
+    let _button_in_progress = make_image_button("In Progress", asset!("rectangles_black.png"))?;
+    let _button_new = make_image_button("New", asset!("new.png"))?;
+    let _button_movie = make_image_button("Movie", asset!("movie_ticket.png"))?;
+    let _button_tv = make_image_button("TV", asset!("television.png"))?;
+    let _button_game = make_image_button("Games", asset!("vid_game.png"))?;
+    left_col.end();
 
-    // center
-    let _button_demo =
-        make_image_button(133, 0, 532, 384, "Demo", bytes_image_theater)?;
-    let _button_music =
-        make_image_button(133, 384, 133, 96, "Music", bytes_image_headphone)?;
-    let _button_live_tv =
-        make_image_button(266, 384, 133, 96, "Live TV", bytes_image_television_live)?;
-    let _button_home_video =
-        make_image_button(399, 384, 133, 96, "Home Video", bytes_image_vid_camera)?;
-    let _button_internet =
-        make_image_button(532, 384, 133, 96, "Internet", bytes_image_earth)?;
+    let mut center_col = Flex::default().column();
+    center_col.set_pad(0);
+    let _button_demo = make_image_button("Demo", asset!("theater.png"))?;
+    let mut bottom_row = Flex::default().row();
+    bottom_row.set_pad(0);
+    let _button_music = make_image_button("Music", asset!("headphone.png"))?;
+    let _button_live_tv = make_image_button("Live TV", asset!("television_live.png"))?;
+    let _button_home_video = make_image_button("Home Video", asset!("vid_camera.png"))?;
+    let _button_internet = make_image_button("Internet", asset!("earth.png"))?;
+    bottom_row.end();
+    center_col.fixed(&bottom_row, BOTTOM_ROW_H);
+    center_col.end();
 
-    // right column
-    let _button_music_video =
-        make_image_button(666, 0, 133, 96, "Music Video", bytes_image_music_video)?;
-    let _button_pictures =
-        make_image_button(666, 96, 133, 96, "Pictures", bytes_image_photo)?;
-    let _button_radio =
-        make_image_button(666, 192, 133, 96, "Radio", bytes_image_radio)?;
-    let _button_books =
-        make_image_button(666, 288, 133, 96, "Books", bytes_image_books)?;
-    let mut button_settings =
-        make_image_button(666, 384, 133, 96, "Settings", bytes_image_settings)?;
+    let mut right_col = Flex::default().column();
+    right_col.set_pad(0);
+    let _button_music_video = make_image_button(
+        "Music Video",
+        asset!("listening-music-video-clip-with-auricular.png"),
+    )?;
+    let _button_pictures = make_image_button("Pictures", asset!("photo.png"))?;
+    let _button_radio = make_image_button("Radio", asset!("radio.png"))?;
+    let _button_books = make_image_button("Books", asset!("books.png"))?;
+    let mut button_settings = make_image_button("Settings", asset!("settings.png"))?;
+    right_col.end();
+
+    outer.fixed(&left_col, SIDE_COL_W);
+    outer.fixed(&right_col, SIDE_COL_W);
+    outer.end();
 
     window_menu.end();
     window_menu.make_resizable(true);
     window_menu.fullscreen(true);
 
-    // settings window
-    let mut window_settings = Window::default().with_size(800, 480);
-    let mut button_settings_back =
-        make_image_button(666, 384, 133, 96, "Back", bytes_image_return)?;
+    let mut window_settings = Window::default()
+        .with_size(WINDOW_W, WINDOW_H)
+        .with_label("MediaKraken Theater - Settings");
+    let mut settings_flex = Flex::default_fill().column();
+    settings_flex.set_margin(0);
+    settings_flex.set_pad(0);
+    let settings_body = Flex::default().row();
+    settings_body.end();
+    let mut settings_footer = Flex::default().row();
+    settings_footer.set_pad(0);
+    let footer_spacer = Flex::default().row();
+    footer_spacer.end();
+    let mut button_settings_back = make_image_button("Back", asset!("navigation/return.png"))?;
+    settings_footer.fixed(&button_settings_back, SIDE_COL_W);
+    settings_footer.end();
+    settings_flex.fixed(&settings_footer, BOTTOM_ROW_H);
+    settings_flex.end();
     window_settings.end();
     window_settings.make_resizable(true);
     window_settings.fullscreen(true);
     window_settings.hide();
 
-    // callbacks
     {
         let mut menu = window_menu.clone();
         let mut settings = window_settings.clone();
@@ -143,9 +141,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         });
     }
 
-    // show the real UI window
     window_menu.show();
 
     app.run()?;
     Ok(())
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("theater_full fatal error: {error}");
+        dialog::alert_default(&format!("Fatal error: {error}"));
+        std::process::exit(1);
+    }
 }


### PR DESCRIPTION
## Summary
Refactored the theater_full application to use FLTK's Flex layout system instead of absolute positioning, improving maintainability and responsiveness. Also added async network initialization and improved error handling.

## Key Changes
- **Layout System**: Replaced hardcoded x/y coordinates with Flex containers (row/column layouts) for the main menu and settings windows
- **Constants**: Introduced window dimension constants (`WINDOW_W`, `WINDOW_H`, `SIDE_COL_W`, `BOTTOM_ROW_H`) for consistent sizing
- **Asset Macro**: Created `asset!()` macro to simplify embedded image file paths and reduce boilerplate
- **Function Simplification**: Refactored `make_image_button()` to remove position parameters, relying on Flex layout instead
- **Async Support**: Added tokio runtime initialization for network operations in a new `run()` function
- **Error Handling**: Wrapped main logic in `run()` function with proper error propagation and user-facing error dialogs
- **Window Titles**: Added descriptive labels to windows ("MediaKraken Theater", "MediaKraken Theater - Settings")
- **Dependencies**: Replaced unused dependencies (reqwest, serde, stdext, tokio-test) with tokio runtime feature

## Implementation Details
- The main menu uses a 3-column layout: left sidebar (5 buttons), center area (demo + 4 bottom buttons), right sidebar (5 buttons)
- Settings window uses a flexible layout with a footer containing the back button
- All buttons now use consistent sizing based on window dimensions
- Network server discovery is now initialized asynchronously at startup
- Fatal errors are displayed to users via dialog before exit

https://claude.ai/code/session_01995R3rNEHxdHwNt6cBCebY