### PR TITLE
Refactor UPC scanning logic and simplify database operations

### DIFF
--- a/src_app/pi_upc/Cargo.toml
+++ b/src_app/pi_upc/Cargo.toml
@@ -12,6 +12,3 @@ codegen-units = 1
 [dependencies]
 fltk = { version = "1.5.22", features = ["fltk-bundled"] }
 sqlite = "0.37.0"
-
-[dev-dependencies]
-tokio-test = "*"

--- a/src_app/pi_upc/src/choice.rs
+++ b/src_app/pi_upc/src/choice.rs
@@ -154,12 +154,12 @@ impl MyChoice {
         self.frame.label()
     }
 
-    pub fn value(&self) -> i32 {
+    pub fn value(&self) -> Option<i32> {
         let choice = self.choice();
-        if let Some(val) = self.choices.borrow().iter().position(|x| x == &choice) {
-            val as _
-        } else {
-            -1
-        }
+        self.choices
+            .borrow()
+            .iter()
+            .position(|x| x == &choice)
+            .map(|v| v as i32)
     }
 }

--- a/src_app/pi_upc/src/database.rs
+++ b/src_app/pi_upc/src/database.rs
@@ -3,33 +3,32 @@ use std::error::Error;
 
 pub fn database_open() -> Result<sqlite::Connection, Box<dyn Error>> {
     let db = sqlite::open("upc_scan.db")?;
-    let query = "CREATE TABLE IF NOT EXISTS upc_codes \
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS upc_codes \
             (upc_code INTEGER NOT NULL, \
             upc_code_type INTEGER NOT NULL, \
-            added_timestamp DATETIME NOT NULL);";
-    db.execute(query)?;
-
-    let query = "CREATE INDEX IF NOT EXISTS upc_code_ndx on upc_codes \
-            (upc_code, upc_code_type);";
-    db.execute(query)?;
-
-    let query = "CREATE TABLE IF NOT EXISTS logs \
+            added_timestamp DATETIME NOT NULL);",
+    )?;
+    db.execute("DROP INDEX IF EXISTS upc_code_ndx;")?;
+    db.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS upc_code_unique_ndx ON upc_codes \
+            (upc_code, upc_code_type);",
+    )?;
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS logs \
             (log_timestamp DATETIME NOT NULL, \
-            log_text TEXT)";
-    db.execute(query)?;
-
-    let query = "CREATE INDEX IF NOT EXISTS log_time_ndx on logs \
-            (log_timestamp);";
-    db.execute(query)?;
-
+            log_text TEXT);",
+    )?;
+    db.execute(
+        "CREATE INDEX IF NOT EXISTS log_time_ndx ON logs \
+            (log_timestamp);",
+    )?;
     Ok(db)
 }
 
-//pub fn database_close() -> Result<sqlx::Pool<Sqlite>, Box<dyn Error>> {}
-
 pub fn database_insert_logs(db: &sqlite::Connection, log_text: &str) -> Result<(), Box<dyn Error>> {
-    let query = "insert into logs (log_timestamp, log_text) values (CURRENT_TIMESTAMP, ?);";
-    let mut statement = db.prepare(query)?;
+    let mut statement =
+        db.prepare("INSERT INTO logs (log_timestamp, log_text) VALUES (CURRENT_TIMESTAMP, ?);")?;
     statement.bind((1, log_text))?;
     statement.next()?;
     Ok(())
@@ -39,36 +38,20 @@ pub fn database_upc_insert(
     db: &sqlite::Connection,
     upc_code: i64,
     upc_type: i32,
-) -> Result<(), Box<dyn Error>> {
-    let query =
-        "insert into upc_codes (upc_code, upc_code_type, added_timestamp) values (?, ?, CURRENT_TIMESTAMP);";
-    let mut statement = db.prepare(query)?;
+) -> Result<bool, Box<dyn Error>> {
+    let mut statement = db.prepare(
+        "INSERT OR IGNORE INTO upc_codes (upc_code, upc_code_type, added_timestamp) \
+            VALUES (?, ?, CURRENT_TIMESTAMP);",
+    )?;
     statement.bind((1, upc_code))?;
     statement.bind((2, upc_type))?;
     statement.next()?;
-    Ok(())
-}
-
-pub fn database_upc_owned(
-    db: &sqlite::Connection,
-    upc_code: i64,
-    upc_type: i32,
-) -> Result<i64, Box<dyn Error>> {
-    let query =
-        "SELECT count(*) as total_found FROM upc_codes WHERE upc_code = ? and upc_code_type = ?";
-    let mut statement = db.prepare(query)?;
-    statement.bind((1, upc_code))?;
-    statement.bind((2, upc_type))?;
-    while let Ok(State::Row) = statement.next() {
-        return Ok(statement.read::<i64, _>("total_found")?);
-    }
-    Ok(0)
+    Ok(db.change_count() > 0)
 }
 
 pub fn database_upc_known_count(db: &sqlite::Connection) -> Result<i64, Box<dyn Error>> {
-    let query = "SELECT count(*) as total_found FROM upc_codes";
-    let mut statement = db.prepare(query)?;
-    while let Ok(State::Row) = statement.next() {
+    let mut statement = db.prepare("SELECT count(*) AS total_found FROM upc_codes;")?;
+    if statement.next()? == State::Row {
         return Ok(statement.read::<i64, _>("total_found")?);
     }
     Ok(0)

--- a/src_app/pi_upc/src/main.rs
+++ b/src_app/pi_upc/src/main.rs
@@ -1,6 +1,5 @@
 use fltk::{
-    app, app::*, button::*, enums::*, frame::*, group::*, input::*, output::Output, prelude::*,
-    window::*,
+    app, app::*, enums::*, frame::*, group::*, input::*, output::Output, prelude::*, window::*,
 };
 mod choice;
 mod database;
@@ -8,7 +7,6 @@ use std::error::Error;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Message {
-    Increment,
     Scanned,
 }
 
@@ -17,8 +15,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut total_codes: i64 = database::database_upc_known_count(&db_instance)?;
     let app = app::App::default().with_scheme(app::Scheme::Gleam);
     let mut window_main = Window::default().with_size(800, 480); // pi 7" screen default
-
-    let mut button_sync = Button::new(666, 384, 133, 96, "Sync");
 
     let mut choice_media_type = choice::MyChoice::new(20, 20, 90, 30, None);
     choice_media_type.add_choices(&["Media", "CD", "Book", "Misc"]);
@@ -41,14 +37,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     container_upc_codes.set_color(Color::Black);
     container_upc_codes.set_type(PackType::Vertical);
 
-    // setup the event
     let (s, r) = app::channel::<Message>();
     let mut upc_input = IntInput::new(100, 100, 400, 120, "UPC");
     upc_input.set_trigger(CallbackTrigger::EnterKey);
-    upc_input.set_callback({
-        move |_| {
-            s.send(Message::Scanned);
-        }
+    upc_input.set_callback(move |_| {
+        s.send(Message::Scanned);
     });
 
     window_main.end();
@@ -59,64 +52,64 @@ fn main() -> Result<(), Box<dyn Error>> {
     upc_input.set_visible_focus();
 
     while app.wait() {
-        if let Some(msg) = r.recv() {
-            match msg {
-                Message::Increment => {
-                    println!("Increment");
-                }
-                Message::Scanned => {
-                    let scanned_input = upc_input.value();
-                    println!("{}:", scanned_input);
+        if let Some(Message::Scanned) = r.recv() {
+            let scanned_input = upc_input.value();
+            println!("{}:", scanned_input);
 
-                    match scanned_input.parse::<i64>() {
-                        Ok(inp1_val) => {
-                            let media_type = choice_media_type.value();
-                            let mut output_text: String = "No Data".to_string();
+            let output_text = match scanned_input.parse::<i64>() {
+                Ok(upc_value) => match choice_media_type.value() {
+                    Some(media_type) => handle_scan(
+                        &db_instance,
+                        upc_value,
+                        media_type,
+                        &mut total_codes,
+                        &mut frame_upc_known,
+                    ),
+                    None => "Select a media type".to_string(),
+                },
+                Err(_) => "Invalid UPC".to_string(),
+            };
 
-                            let log_text = format!("{} scanned", inp1_val);
-                            let _ = database::database_insert_logs(&db_instance, &log_text);
-
-                            match database::database_upc_owned(&db_instance, inp1_val, media_type) {
-                                Ok(0) => {
-                                    let _ = database::database_upc_insert(
-                                        &db_instance,
-                                        inp1_val,
-                                        media_type,
-                                    );
-                                    output_text = format!("{} - Added", inp1_val);
-                                    let added_log = format!("{} added", inp1_val);
-                                    let _ =
-                                        database::database_insert_logs(&db_instance, &added_log);
-                                    total_codes += 1;
-
-                                    frame_upc_known.set_label(&format!("Known: {}", total_codes));
-                                }
-                                Ok(_) => {
-                                    output_text = format!("{} - DUPLICATE!", inp1_val);
-                                    let duplicate_log = format!("{} duplicate", inp1_val);
-                                    let _ = database::database_insert_logs(
-                                        &db_instance,
-                                        &duplicate_log,
-                                    );
-                                }
-                                Err(_) => {
-                                    output_text = "Database error".to_string();
-                                }
-                            }
-
-                            out.set_value(&output_text);
-                        }
-                        Err(_) => {
-                            out.set_value("Invalid UPC");
-                        }
-                    }
-
-                    upc_input.set_value("");
-                    upc_input.take_focus();
-                    upc_input.set_visible_focus();
-                }
-            }
+            out.set_value(&output_text);
+            upc_input.set_value("");
+            upc_input.take_focus();
+            upc_input.set_visible_focus();
         }
     }
     Ok(())
+}
+
+fn handle_scan(
+    db: &sqlite::Connection,
+    upc_value: i64,
+    media_type: i32,
+    total_codes: &mut i64,
+    frame_upc_known: &mut Frame,
+) -> String {
+    if let Err(err) = database::database_insert_logs(db, &format!("{} scanned", upc_value)) {
+        eprintln!("log insert failed: {}", err);
+    }
+
+    match database::database_upc_insert(db, upc_value, media_type) {
+        Ok(true) => {
+            *total_codes += 1;
+            frame_upc_known.set_label(&format!("Known: {}", total_codes));
+            if let Err(err) = database::database_insert_logs(db, &format!("{} added", upc_value)) {
+                eprintln!("log insert failed: {}", err);
+            }
+            format!("{} - Added", upc_value)
+        }
+        Ok(false) => {
+            if let Err(err) =
+                database::database_insert_logs(db, &format!("{} duplicate", upc_value))
+            {
+                eprintln!("log insert failed: {}", err);
+            }
+            format!("{} - DUPLICATE!", upc_value)
+        }
+        Err(err) => {
+            eprintln!("upc insert failed: {}", err);
+            "Database error".to_string()
+        }
+    }
 }


### PR DESCRIPTION
## Summary
This PR refactors the UPC scanning application to improve code organization, simplify database operations, and enhance error handling. The main changes include extracting the scan handling logic into a separate function, streamlining the message handling system, and optimizing database queries.

## Key Changes

- **Removed unused UI elements**: Deleted the "Sync" button and `Message::Increment` variant that were not being used
- **Extracted scan handling logic**: Created a new `handle_scan()` function to encapsulate UPC scanning and database operations, improving code readability and testability
- **Simplified message handling**: Refactored the event loop to use pattern matching directly on `Message::Scanned` instead of nested match statements
- **Improved database operations**:
  - Changed `database_upc_insert()` to return `bool` indicating success/duplicate instead of `()`, using `INSERT OR IGNORE` with change count detection
  - Removed `database_upc_owned()` function as its logic is now handled by the `INSERT OR IGNORE` approach
  - Consolidated database schema creation statements for better readability
  - Changed non-unique index to a unique index for UPC code lookups
  - Improved error handling with `eprintln!` for database operation failures
- **Enhanced choice widget**: Modified `MyChoice::value()` to return `Option<i32>` instead of `-1` for invalid selections, providing better type safety
- **Code cleanup**:
  - Removed unused imports (`button::*`)
  - Simplified callback closure formatting
  - Removed unused dev dependency (`tokio-test`)
  - Improved SQL query formatting and consistency

## Notable Implementation Details

The refactored `handle_scan()` function now handles all UPC processing logic including logging, insertion, and duplicate detection. The use of `INSERT OR IGNORE` with change count checking eliminates the need for a separate query to check for duplicates, reducing database round trips and improving performance.

https://claude.ai/code/session_01XckvCdQmrdHpLbccchnMs9