### PR TITLE
Upgrade to Dioxus 0.7 with unified platform support

### DIFF
--- a/src_app/mediakraken/Cargo.toml
+++ b/src_app/mediakraken/Cargo.toml
@@ -16,13 +16,9 @@ reqwest = { version = "0.13.2", default-features = false, features = [
     "rustls-tls",
 ] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
-dioxus-mobile = "0.6.2"
+dioxus = { version = "0.7.5", features = ["mobile"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
-dioxus-desktop = { version = "0.7.5", features = ["tokio_runtime"], default-features = false }
-
-[dev-dependencies]
-tokio-test = "*"
+dioxus = { version = "0.7.5", features = ["desktop"] }

--- a/src_app/mediakraken/README.md
+++ b/src_app/mediakraken/README.md
@@ -27,9 +27,10 @@ If your API endpoint differs, update `src/api.rs` and `src/models.rs`.
 
 ## Local desktop preview
 
+From the `src_app/` workspace root:
+
 ```bash
-cd src_app/mediakraken
-cargo run
+cargo run -p mediakraken
 ```
 
 ## Android / iOS

--- a/src_app/mediakraken/src/api.rs
+++ b/src_app/mediakraken/src/api.rs
@@ -1,6 +1,10 @@
+use std::time::Duration;
+
 use reqwest::Client;
 
 use crate::models::LibrarySummary;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Clone, Debug)]
 pub struct ApiClient {
@@ -10,28 +14,79 @@ pub struct ApiClient {
 }
 
 impl ApiClient {
-    pub fn new(base_url: impl Into<String>, bearer_token: impl Into<String>) -> Self {
+    pub fn default_http_client() -> Client {
+        Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .expect("failed to build reqwest client")
+    }
+
+    pub fn from_parts(
+        http_client: Client,
+        base_url: impl Into<String>,
+        bearer_token: impl Into<String>,
+    ) -> Self {
         Self {
             base_url: base_url.into().trim_end_matches('/').to_owned(),
             bearer_token: bearer_token.into(),
-            http_client: Client::new(),
+            http_client,
         }
     }
 
-    pub async fn fetch_library_summary(&self) -> Result<LibrarySummary, reqwest::Error> {
+    pub async fn fetch_library_summary(&self) -> Result<LibrarySummary, String> {
         let mut request = self
             .http_client
             .get(format!("{}/api/v1/library/summary", self.base_url));
 
-        if !self.bearer_token.trim().is_empty() {
-            request = request.bearer_auth(self.bearer_token.trim());
+        let token = self.bearer_token.trim();
+        if !token.is_empty() {
+            request = request.bearer_auth(token);
         }
 
-        request
+        let response = request
             .send()
-            .await?
-            .error_for_status()?
+            .await
+            .map_err(|err| format!("network error: {err}"))?
+            .error_for_status()
+            .map_err(|err| match err.status() {
+                Some(status) => format!("server returned HTTP {status}"),
+                None => format!("server error: {err}"),
+            })?;
+
+        response
             .json::<LibrarySummary>()
             .await
+            .map_err(|err| format!("failed to decode response: {err}"))
+    }
+}
+
+#[cfg(test)]
+impl ApiClient {
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn client(base_url: &str) -> ApiClient {
+        ApiClient::from_parts(ApiClient::default_http_client(), base_url, "")
+    }
+
+    #[test]
+    fn trims_single_trailing_slash() {
+        assert_eq!(client("https://example.com/").base_url(), "https://example.com");
+    }
+
+    #[test]
+    fn trims_multiple_trailing_slashes() {
+        assert_eq!(client("https://example.com///").base_url(), "https://example.com");
+    }
+
+    #[test]
+    fn leaves_clean_url_unchanged() {
+        assert_eq!(client("https://example.com").base_url(), "https://example.com");
     }
 }

--- a/src_app/mediakraken/src/main.rs
+++ b/src_app/mediakraken/src/main.rs
@@ -14,90 +14,76 @@ enum ApiState {
     Error(String),
 }
 
-#[cfg(any(target_os = "android", target_os = "ios"))]
 fn main() {
-    dioxus_mobile::launch(app);
+    dioxus::launch(App);
 }
 
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
-fn main() {
-    dioxus_desktop::launch(app);
-}
+#[component]
+fn App() -> Element {
+    let mut base_url = use_signal(|| "https://mediakraken.example.com".to_string());
+    let mut bearer_token = use_signal(String::new);
+    let mut api_state = use_signal(|| ApiState::Idle);
+    let http_client = use_signal(ApiClient::default_http_client);
 
-fn app(cx: Scope) -> Element {
-    let base_url = use_state(cx, || "https://mediakraken.example.com".to_string());
-    let bearer_token = use_state(cx, String::new);
-    let api_state = use_state(cx, || ApiState::Idle);
+    let load_summary = move |_| {
+        let client = ApiClient::from_parts(http_client(), base_url(), bearer_token());
+        spawn(async move {
+            api_state.set(ApiState::Loading);
+            let next = match client.fetch_library_summary().await {
+                Ok(summary) => ApiState::Loaded(summary),
+                Err(message) => ApiState::Error(message),
+            };
+            api_state.set(next);
+        });
+    };
 
-    cx.render(rsx! {
-        main {
-            class: "app-shell",
+    rsx! {
+        main { class: "app-shell",
             h1 { "MediaKraken mobile starter" }
             p {
                 "Use this Dioxus screen as a starting point for Android/iOS clients that talk to the MediaKraken API."
             }
-            div {
-                class: "form-grid",
-                label {
-                    "API base URL"
+            div { class: "form-grid",
+                label { "API base URL"
                     input {
                         value: "{base_url}",
-                        oninput: move |event| base_url.set(event.value.clone()),
+                        oninput: move |event| base_url.set(event.value()),
                         placeholder: "https://mediakraken.example.com",
+                        autocomplete: "off",
                     }
                 }
-                label {
-                    "Bearer token"
+                label { "Bearer token"
                     input {
                         r#type: "password",
                         value: "{bearer_token}",
-                        oninput: move |event| bearer_token.set(event.value.clone()),
+                        oninput: move |event| bearer_token.set(event.value()),
                         placeholder: "Optional API token",
+                        autocomplete: "off",
                     }
                 }
-                button {
-                    onclick: move |_| {
-                        let base_url_value = base_url.current().clone();
-                        let bearer_token_value = bearer_token.current().clone();
-                        let api_state = api_state.clone();
-
-                        cx.spawn(async move {
-                            api_state.set(ApiState::Loading);
-
-                            let next_state = match ApiClient::new(base_url_value, bearer_token_value)
-                                .fetch_library_summary()
-                                .await
-                            {
-                                Ok(summary) => ApiState::Loaded(summary),
-                                Err(error) => ApiState::Error(error.to_string()),
-                            };
-
-                            api_state.set(next_state);
-                        });
-                    },
-                    "Load library summary"
-                }
+                button { onclick: load_summary, "Load library summary" }
             }
-            {render_api_state(cx, api_state.current())}
+            ApiStateView { state: api_state() }
         }
-    })
+    }
 }
 
-fn render_api_state<'a>(cx: Scope<'a>, api_state: &'a ApiState) -> Element<'a> {
-    match api_state {
-        ApiState::Idle => cx.render(rsx! {
+#[component]
+fn ApiStateView(state: ApiState) -> Element {
+    match state {
+        ApiState::Idle => rsx! {
             section {
                 h2 { "Ready" }
                 p { "Set the API URL above and tap the button to verify connectivity." }
             }
-        }),
-        ApiState::Loading => cx.render(rsx! {
+        },
+        ApiState::Loading => rsx! {
             section {
                 h2 { "Loading" }
                 p { "Requesting MediaKraken library summary..." }
             }
-        }),
-        ApiState::Loaded(summary) => cx.render(rsx! {
+        },
+        ApiState::Loaded(summary) => rsx! {
             section {
                 h2 { "Connected" }
                 ul {
@@ -108,13 +94,13 @@ fn render_api_state<'a>(cx: Scope<'a>, api_state: &'a ApiState) -> Element<'a> {
                     li { "Music albums: {summary.music_album_count}" }
                 }
             }
-        }),
-        ApiState::Error(message) => cx.render(rsx! {
+        },
+        ApiState::Error(message) => rsx! {
             section {
                 h2 { "Request failed" }
                 p { "{message}" }
                 p { "Confirm the base URL, authentication token, and route path match your server." }
             }
-        }),
+        },
     }
 }

--- a/src_app/mediakraken/src/models.rs
+++ b/src_app/mediakraken/src/models.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct LibrarySummary {
     pub server_name: String,
     pub version: String,


### PR DESCRIPTION
## Summary
Upgrade the MediaKraken mobile app from Dioxus 0.6 to 0.7, consolidating platform-specific dependencies into a single unified `dioxus` crate with feature flags. This modernizes the codebase to use the latest Dioxus patterns and APIs.

## Key Changes

- **Unified Dioxus dependency**: Replaced separate `dioxus-mobile` and `dioxus-desktop` crates with a single `dioxus` 0.7.5 dependency using platform-specific feature flags (`mobile` and `desktop`)
- **Updated to new Dioxus 0.7 API**: 
  - Converted from `Scope`-based to `#[component]` macro pattern
  - Replaced `use_state` with `use_signal` for state management
  - Changed from `cx.render(rsx! { ... })` to direct `rsx! { ... }` returns
  - Updated event handlers to use new closure patterns (e.g., `event.value()` instead of `event.value.clone()`)
- **Improved API client**:
  - Refactored `ApiClient::new()` to `ApiClient::from_parts()` for better testability
  - Added `default_http_client()` factory method with configurable 15-second timeout
  - Enhanced error handling with descriptive `String` error messages instead of raw `reqwest::Error`
  - Added unit tests for URL trimming behavior
- **Code cleanup**:
  - Removed unnecessary `serde_json` dependency
  - Removed `tokio-test` dev dependency
  - Converted `render_api_state()` function to `ApiStateView` component
  - Simplified button click handler logic with extracted `load_summary` closure
  - Added `autocomplete: "off"` to sensitive input fields
- **Documentation**: Updated README with clearer build instructions using workspace-relative paths

## Notable Implementation Details

- The HTTP client is now created once and reused via signals, improving efficiency
- Error messages are now user-friendly strings rather than technical error types
- The component structure is flatter and more idiomatic for Dioxus 0.7
- All platform-specific code paths are now handled through Cargo feature flags rather than conditional compilation attributes

https://claude.ai/code/session_011DHYAKPcThhNXxyEXocGgq