### PR TITLE
Add Linux prerequisites and update workspace resolver

### DIFF
--- a/src_app/Cargo.toml
+++ b/src_app/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "3"
 
 members = [
     "brother_print_label",

--- a/src_app/mediakraken/README.md
+++ b/src_app/mediakraken/README.md
@@ -33,6 +33,20 @@ From the `src_app/` workspace root:
 cargo run -p mediakraken
 ```
 
+### Linux prerequisites
+
+The desktop target embeds a WebKit2GTK WebView. If the app aborts at startup
+with an error such as `failed to load GTK` or a missing
+`libwebkit2gtk-4.1.so.0`, install the system libraries before running:
+
+```bash
+sudo apt install libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev
+```
+
+On Debian/Ubuntu releases that only ship the 4.0 packages, substitute
+`libwebkit2gtk-4.0-dev` for the 4.1 package. See
+`docs/dev_notes/MK_Dioxus.txt` for the full development environment notes.
+
 ## Android / iOS
 
 Use the Dioxus mobile tooling that matches the installed SDKs in your environment, then point the app at a reachable MediaKraken API base URL.


### PR DESCRIPTION
## Summary
This PR updates the MediaKraken documentation with Linux system dependencies and updates the workspace configuration to use resolver version 3.

## Key Changes
- **Documentation**: Added a new "Linux prerequisites" section to the README documenting required system libraries for the desktop target's WebKit2GTK WebView integration
  - Lists required packages for standard Debian/Ubuntu releases with libwebkit2gtk-4.1
  - Provides guidance for older releases that only ship 4.0 packages
  - References additional development environment notes in `docs/dev_notes/MK_Dioxus.txt`
- **Workspace Configuration**: Updated `Cargo.toml` to explicitly set `resolver = "3"` for the workspace

## Implementation Details
The Linux prerequisites documentation addresses common startup failures when the WebKit2GTK dependencies are missing, providing clear installation instructions and version compatibility guidance for different Debian/Ubuntu releases.

https://claude.ai/code/session_01YEwiSHjcc4rtjYAHv6e3vh