### PR TITLE
Add TMDB collection metadata fetching and processing

### DIFF
--- a/docker/core/mktmdbnetfetchbulk/src/main.rs
+++ b/docker/core/mktmdbnetfetchbulk/src/main.rs
@@ -34,6 +34,12 @@ struct MetadataPerson {
     popularity: f32,
 }
 
+#[derive(Serialize, Deserialize)]
+struct MetadataCollection {
+    id: Option<i32>,
+    name: String,
+}
+
 #[derive(Deserialize)]
 struct ResponseMetadata {
     results: Vec<MetadataGeneral>,
@@ -279,6 +285,69 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             }
                         }
                     }
+
+                    let date_to_use = find_date_to_use(
+                        "http://files.tmdb.org/p/exports/collection_ids_{}.json.gz",
+                    )
+                    .await
+                    .unwrap();
+                    // grab the Collection id's
+                    let fetch_result_collection =
+                        mk_lib_network::mk_lib_network::mk_network_download_file_to_vec(
+                            format!(
+                                "http://files.tmdb.org/p/exports/collection_ids_{}.json.gz",
+                                date_to_use
+                            )
+                            .replace("\"", ""),
+                        )
+                        .await
+                        .unwrap();
+                    let json_result =
+                        mk_lib_compression::mk_lib_compression::mk_decompress_gz_bytes(
+                            fetch_result_collection,
+                        )
+                        .await
+                        .unwrap();
+                    let mut record_count = 0;
+                    let mut skipped_rows = 0usize;
+                    for json_item in json_result.lines() {
+                        if !json_item.trim().is_empty() {
+                            if skipped_rows < skip_rows {
+                                skipped_rows += 1;
+                                continue;
+                            }
+                            let metadata_struct: MetadataCollection =
+                                serde_json::from_str(json_item.trim()).unwrap();
+                            let Some(metadata_id) = metadata_struct.id else {
+                                continue;
+                            };
+                            let result =
+                                mk_lib_database::database_metadata::mk_lib_database_metadata_collection::mk_lib_database_metadata_exists_collection(
+                                    &sqlx_pool_rw,
+                                    metadata_id,
+                                )
+                                .await
+                                .unwrap();
+                            if result == false {
+                                let download_result = mk_lib_database::database_metadata::mk_lib_database_metadata_download_queue::mk_lib_database_metadata_download_queue_exists(&sqlx_pool_rw,
+                                                                                                                              "themoviedb".to_string(),
+                                                                                                                              mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::COLLECTION,
+                                                                                                                              metadata_id).await.unwrap();
+                                if download_result == false {
+                                    record_count += 1;
+                                    if record_count > record_limit {
+                                        break;
+                                    }
+                                    let _result = mk_lib_database::database_metadata::mk_lib_database_metadata_download_queue::mk_lib_database_metadata_download_queue_insert(&sqlx_pool_rw,
+                                                                                                            "themoviedb".to_string(),
+                                                                                                            mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::COLLECTION,
+                                                                                                            uuid::Uuid::now_v7(),
+                                                                                                            Some(metadata_id),
+                                                                                                            "Fetch".to_string(), None).await.unwrap();
+                                }
+                            }
+                        }
+                    }
                 } else {
                     let option_config_json: serde_json::Value =
                     mk_lib_database::mk_lib_database_option_status::mk_lib_database_option_read(&sqlx_pool_ro)
@@ -413,6 +482,51 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 let _result = mk_lib_database::database_metadata::mk_lib_database_metadata_download_queue::mk_lib_database_metadata_download_queue_insert(&sqlx_pool_rw,
                                                                                                                         "themoviedb".to_string(),
                                                                                                                         mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::PERSON,
+                                                                                                                        uuid::Uuid::now_v7(),
+                                                                                                                        Some(json_item.id),
+                                                                                                                        "Update".to_string(), None).await;
+                            }
+                        }
+                    }
+
+                    // process collection changes
+                    let url_result = mk_lib_network::mk_lib_network::mk_data_from_url(
+                        format!(
+                            "https://api.themoviedb.org/3/collection/changes?api_key={}",
+                            option_config_json["API"]["themoviedb"]
+                        )
+                        .replace("\"", ""),
+                    )
+                    .await
+                    .unwrap();
+                    let resp: ResponseMetadata = serde_json::from_str(&url_result.trim()).unwrap();
+                    for json_item in resp.results {
+                        println!("collection item {}", json_item.id);
+                        // verify it's not already in the database
+                        let result =
+                            mk_lib_database::database_metadata::mk_lib_database_metadata_collection::mk_lib_database_metadata_exists_collection(
+                                &sqlx_pool_rw,
+                                json_item.id,
+                            )
+                            .await
+                            .unwrap();
+                        if result == false {
+                            let download_result = mk_lib_database::database_metadata::mk_lib_database_metadata_download_queue::mk_lib_database_metadata_download_queue_exists(&sqlx_pool_rw,
+                                                                                                                                          "themoviedb".to_string(),
+                                                                                                                                          mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::COLLECTION,
+                                                                                                                                          json_item.id).await.unwrap();
+                            if download_result == false {
+                                let _result = mk_lib_database::database_metadata::mk_lib_database_metadata_download_queue::mk_lib_database_metadata_download_queue_insert(&sqlx_pool_rw,
+                                                                                                                        "themoviedb".to_string(),
+                                                                                                                        mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::COLLECTION,
+                                                                                                                        uuid::Uuid::now_v7(),
+                                                                                                                        Some(json_item.id),
+                                                                                                                        "Fetch".to_string(), None).await;
+                            } else {
+                                // it's on the database, so must update the record with latest information
+                                let _result = mk_lib_database::database_metadata::mk_lib_database_metadata_download_queue::mk_lib_database_metadata_download_queue_insert(&sqlx_pool_rw,
+                                                                                                                        "themoviedb".to_string(),
+                                                                                                                        mk_lib_common::mk_lib_common_enum_media_type::DLMediaType::COLLECTION,
                                                                                                                         uuid::Uuid::now_v7(),
                                                                                                                         Some(json_item.id),
                                                                                                                         "Update".to_string(), None).await;

--- a/src/mk_lib_common/src/mk_lib_common_enum_media_type.rs
+++ b/src/mk_lib_common/src/mk_lib_common_enum_media_type.rs
@@ -21,6 +21,7 @@ impl DLMediaType {
     pub const ANIME: i16 = 8;
     pub const MUSIC: i16 = 9;
     pub const ADULT: i16 = 10;
+    pub const COLLECTION: i16 = 11;
 
     pub const ADULT_IMAGE: i16 = 1000;
     pub const ADULT_SCENE: i16 = 1001;

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_collection.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_collection.rs
@@ -3,6 +3,23 @@ use sqlx::FromRow;
 use sqlx::postgres::PgRow;
 use sqlx::types::Uuid;
 
+pub async fn mk_lib_database_metadata_exists_collection(
+    sqlx_pool: &sqlx::PgPool,
+    metadata_id: i32,
+) -> Result<bool, sqlx::Error> {
+    let row: (bool,) = sqlx::query_as(
+        r#"select exists(
+            select 1 from mm_metadata_collection
+            where (mm_metadata_collection_json->>'id')::int = $1
+            limit 1
+        ) as found_record limit 1"#,
+    )
+    .bind(metadata_id)
+    .fetch_one(sqlx_pool)
+    .await?;
+    Ok(row.0)
+}
+
 pub async fn mk_lib_database_metadata_collection_count(
     sqlx_pool: &sqlx::PgPool,
     search_value: String,


### PR DESCRIPTION
## Summary
This PR adds support for fetching and processing The Movie Database (TMDB) collection metadata. Collections are now treated as a first-class media type in the system, with dedicated bulk import and change detection capabilities.

## Key Changes
- **New `MetadataCollection` struct**: Added serializable/deserializable struct to represent collection metadata with `id` and `name` fields
- **Bulk collection import**: Implemented fetching of collection IDs from TMDB's bulk export files (similar to existing person/movie/TV show imports), with support for row skipping and record limits
- **Collection change detection**: Added processing of TMDB's collection changes API endpoint to identify new and updated collections
- **Database operations**: Implemented `mk_lib_database_metadata_exists_collection()` function to check if a collection already exists in the database
- **Media type enum**: Added `COLLECTION` (value 11) to the `DLMediaType` enum to support collection as a downloadable media type
- **Download queue management**: Collections are automatically added to the download queue with either "Fetch" (for new collections) or "Update" (for existing collections) operations

## Implementation Details
- Collection fetching follows the same pattern as existing metadata types (persons, movies, TV shows)
- The bulk import processes gzipped JSON files from TMDB's export service
- Change detection integrates with the existing TMDB API polling mechanism
- Database existence checks prevent duplicate entries and unnecessary queue operations

https://claude.ai/code/session_01PBBuNefYrX9ASbTb8e9w3m