### PR TITLE
Add favicon to all HTML templates

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_include_header.html
+++ b/docker/core/mkwebaxum/templates/bss_include_header.html
@@ -8,6 +8,7 @@
     MediaKraken
     {% endif %}
   </title>
+<link rel="icon" type="image/png" href="/static/image/K3.png">
 <link rel="stylesheet" href="/static/css/base_webapp_9.css">
   <script src="/static/js/alpinejs_3.15.3.min.js" defer></script>
   <script src="/static/js/base_webapp.js" defer></script>

--- a/docker/core/mkwebaxum/templates/layouts/base_admin.html
+++ b/docker/core/mkwebaxum/templates/layouts/base_admin.html
@@ -11,6 +11,7 @@
         MediaKraken
         {% endif %}
     </title>
+    <link rel="icon" type="image/png" href="/static/image/K3.png">
     <link rel="stylesheet" href="/static/css/base_webapp_9.css">
     <script src="/static/js/alpinejs_3.15.3.min.js" defer></script>
     <style>

--- a/docker/core/mkwebaxum/templates/layouts/base_user.html
+++ b/docker/core/mkwebaxum/templates/layouts/base_user.html
@@ -14,6 +14,7 @@
         {% endif %}
     </title>
     
+    <link rel="icon" type="image/png" href="/static/image/K3.png">
     <link rel="stylesheet" href="/static/css/base_webapp_9.css">
     {% block extra_head %}{% endblock %}
     


### PR DESCRIPTION
## Summary
Added favicon link to all base HTML templates to display the K3 logo in browser tabs and bookmarks.

## Changes
- Added `<link rel="icon" type="image/png" href="/static/image/K3.png">` to three base template files:
  - `bss_include_header.html`
  - `layouts/base_admin.html`
  - `layouts/base_user.html`

## Details
The favicon link is placed in the `<head>` section immediately after the `<title>` tag in each template. This ensures the K3.png image will be displayed as the favicon across all pages that inherit from these base templates, improving brand consistency and visual identification in browser tabs.

https://claude.ai/code/session_01CRYipHNVVneQUDCVkasyu3