### PR TITLE
Refactor radio station list layout for better UX

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_iradio.html
+++ b/docker/core/mkwebaxum/templates/bss_user/media/bss_user_media_iradio.html
@@ -30,25 +30,25 @@
     <div class="mt-4 overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
         <ul role="list" class="divide-y divide-zinc-200 dark:divide-zinc-800">
             {% for station in template_data %}
-            <li class="flex flex-col gap-3 p-4">
-                <div class="flex items-center justify-between gap-3">
-                    <p class="min-w-0 flex-1 truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+            <li class="flex items-center gap-4 p-4">
+                <button
+                    type="button"
+                    class="inline-flex shrink-0 items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                    aria-label="Play station"
+                    @click="currentUrl='{{ station.mm_radio_address }}'; currentName='{% if let Some(station_name) = station.mm_radio_name %}{{ station_name }}{% else %}Unnamed Station{% endif %}'; $refs.player.load(); $refs.player.play().catch(() => {})"
+                >
+                    Play
+                </button>
+                <div class="min-w-0 flex-1">
+                    <p class="truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">
                         {% if let Some(station_name) = station.mm_radio_name %}
                         {{ station_name }}
                         {% else %}
                         Unnamed Station
                         {% endif %}
                     </p>
-                    <button
-                        type="button"
-                        class="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-                        aria-label="Play station"
-                        @click="currentUrl='{{ station.mm_radio_address }}'; currentName='{% if let Some(station_name) = station.mm_radio_name %}{{ station_name }}{% else %}Unnamed Station{% endif %}'; $refs.player.load(); $refs.player.play().catch(() => {})"
-                    >
-                        Play
-                    </button>
+                    <p class="text-xs break-words text-zinc-500 dark:text-zinc-400">{{ station.mm_radio_address }}</p>
                 </div>
-                <p class="text-xs break-words text-zinc-500 dark:text-zinc-400">{{ station.mm_radio_address }}</p>
             </li>
             {% endfor %}
         </ul>


### PR DESCRIPTION
## Summary
Restructured the internet radio station list item layout to improve visual hierarchy and usability by repositioning the play button and reorganizing content flow.

## Key Changes
- **Layout restructure**: Changed from vertical flex layout (`flex-col`) to horizontal layout (`flex items-center`) for the list item
- **Play button repositioning**: Moved the play button from the right side of the station name to the left side of the list item, making it more prominent and easier to access
- **Button styling enhancement**: Added `shrink-0` class to the play button to prevent it from shrinking in the flex layout
- **Content organization**: Grouped station name and URL into a single flex container (`min-w-0 flex-1`) to keep related information together
- **Improved text handling**: Station name now uses `truncate` directly without the parent flex justification, and the URL is displayed below the name in a more compact format

## Implementation Details
The changes create a more intuitive interface where:
- The action button (Play) is positioned first and is immediately visible
- Station information (name and address) is grouped together on the right
- The layout is more compact and follows common UI patterns for list items with actions
- Text truncation and overflow handling is improved with the new structure

https://claude.ai/code/session_016Fssq9nG8bFD8xDV1Zz7mf