### PR TITLE
Replace &String with &str in function parameters

### DIFF
--- a/src/mk_lib_database/src/media/mk_lib_database_media.rs
+++ b/src/mk_lib_database/src/media/mk_lib_database_media.rs
@@ -111,7 +111,7 @@ pub async fn mk_lib_database_media_insert(
     sqlx_pool: &sqlx::PgPool,
     mm_media_guid: Uuid,
     mm_media_class_enum: i16,
-    mm_media_path: &String,
+    mm_media_path: &str,
     mm_media_metadata_guid: Option<Uuid>,
     mm_media_ffprobe_json: serde_json::Value,
     mm_media_json: serde_json::Value,

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_download_queue.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_download_queue.rs
@@ -102,7 +102,7 @@ pub async fn mk_lib_database_metadata_download_queue_insert(
     metadata_new_uuid: Uuid,
     metadata_provider_id: Option<i32>,
     metadata_status: String,
-    metadata_path: Option<&String>,
+    metadata_path: Option<&str>,
 ) -> Result<(), sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     sqlx::query(

--- a/src/mk_lib_database/src/metadata/mk_lib_database_metadata_game_system.rs
+++ b/src/mk_lib_database/src/metadata/mk_lib_database_metadata_game_system.rs
@@ -97,7 +97,7 @@ pub async fn mk_lib_database_metadata_game_system_upsert(
 
 pub async fn mk_lib_database_metadata_game_system_guid_by_short_name(
     sqlx_pool: &sqlx::PgPool,
-    game_system_short_name: &String,
+    game_system_short_name: &str,
 ) -> Result<Uuid, sqlx::Error> {
     let row: (Uuid,) = sqlx::query_as(
         r#"select gs_game_system_id from mm_metadata_game_systems_info where gs_game_system_name = $1"#,
@@ -110,7 +110,7 @@ pub async fn mk_lib_database_metadata_game_system_guid_by_short_name(
 
 pub async fn mk_lib_database_metadata_game_system_game_count_by_short_name(
     sqlx_pool: &sqlx::PgPool,
-    game_system_short_name: &String,
+    game_system_short_name: &str,
 ) -> Result<i64, sqlx::Error> {
     // TODO this query doesn't return game count.......
     let row: (i64,) = sqlx::query_as(

--- a/src/mk_lib_database/src/mk_lib_database_user.rs
+++ b/src/mk_lib_database/src/mk_lib_database_user.rs
@@ -131,7 +131,7 @@ impl SqlUser {
 
 pub async fn mk_lib_database_user_exists(
     sqlx_pool: &sqlx::PgPool,
-    user_name: &String,
+    user_name: &str,
 ) -> Result<bool, sqlx::Error> {
     let row: (bool,) = sqlx::query_as(
         r#"select exists(select 1 from mm_axum_users where username = $1 limit 1) limit 1"#,
@@ -220,8 +220,8 @@ pub async fn mk_lib_database_user_set_admin(
 
 pub async fn mk_lib_database_user_insert(
     sqlx_pool: &sqlx::PgPool,
-    username: &String,
-    password: &String,
+    username: &str,
+    password: &str,
 ) -> Result<i64, sqlx::Error> {
     let mut transaction = sqlx_pool.begin().await?;
     let row: (i64,) = sqlx::query_as(
@@ -237,8 +237,8 @@ pub async fn mk_lib_database_user_insert(
 
 pub async fn mk_lib_database_user_login_verification(
     sqlx_pool: &sqlx::PgPool,
-    username: &String,
-    password: &String,
+    username: &str,
+    password: &str,
 ) -> Result<i64, sqlx::Error> {
     let row: (i64,) = sqlx::query_as(
         r#"select coalesce((select id from mm_axum_users where username = $1 and password = crypt($2, password) limit 1), 0)"#,

--- a/src/mk_lib_metadata/src/provider/tmdb.rs
+++ b/src/mk_lib_metadata/src/provider/tmdb.rs
@@ -196,7 +196,7 @@ pub async fn provider_tmdb_collection_fetch(
 }
 
 pub async fn provider_tmdb_movie_id_max(
-    api_key: &String,
+    api_key: &str,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
     let url_result = tmdb_fetch_json_with_retry(format!(
         "https://api.themoviedb.org/3/movie/latest?api_key={}",
@@ -208,7 +208,7 @@ pub async fn provider_tmdb_movie_id_max(
 }
 
 pub async fn provider_tmdb_person_id_max(
-    api_key: &String,
+    api_key: &str,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
     let url_result = tmdb_fetch_json_with_retry(format!(
         "https://api.themoviedb.org/3/person/latest?api_key={}",
@@ -220,7 +220,7 @@ pub async fn provider_tmdb_person_id_max(
 }
 
 pub async fn provider_tmdb_tv_id_max(
-    api_key: &String,
+    api_key: &str,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
     let url_result = tmdb_fetch_json_with_retry(format!(
         "https://api.themoviedb.org/3/tv/latest?api_key={}",
@@ -374,7 +374,7 @@ pub async fn provider_tmdb_meta_info_build(
     Ok(image_json)
 }
 
-pub async fn provider_tmdb_search(guessit_data: Metadata, media_type: i16, tmdb_api_key: &String) {
+pub async fn provider_tmdb_search(guessit_data: Metadata, media_type: i16, tmdb_api_key: &str) {
     let mut raw_query = guessit_data.title().to_string();
     if let Some(year) = guessit_data.year() {
         raw_query.push(' ');

--- a/src/mk_lib_network/src/mk_lib_network.rs
+++ b/src/mk_lib_network/src/mk_lib_network.rs
@@ -103,7 +103,7 @@ pub async fn mk_network_download_file_to_vec(url: String) -> Result<Vec<u8>, req
 
 pub async fn mk_download_file_from_url(
     url: String,
-    file_name: &String,
+    file_name: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("url: {}", url);
     let response = SHARED_HTTP_CLIENT.get(url).send().await?;


### PR DESCRIPTION
## Summary
This PR refactors function signatures across multiple modules to use `&str` instead of `&String` for string parameters. This is a Rust best practice that improves API ergonomics and reduces unnecessary allocations.

## Key Changes
- **mk_lib_database_user.rs**: Updated 4 functions to accept `&str` instead of `&String`:
  - `mk_lib_database_user_exists()`
  - `mk_lib_database_user_insert()`
  - `mk_lib_database_user_login_verification()`

- **provider/tmdb.rs**: Updated 4 functions to accept `&str` instead of `&String`:
  - `provider_tmdb_movie_id_max()`
  - `provider_tmdb_person_id_max()`
  - `provider_tmdb_tv_id_max()`
  - `provider_tmdb_search()`

- **mk_lib_database_metadata_game_system.rs**: Updated 2 functions to accept `&str` instead of `&String`:
  - `mk_lib_database_metadata_game_system_guid_by_short_name()`
  - `mk_lib_database_metadata_game_system_game_count_by_short_name()`

- **mk_lib_database_media.rs**: Updated `mk_lib_database_media_insert()` to accept `&str` for the `mm_media_path` parameter

- **mk_lib_database_metadata_download_queue.rs**: Updated `mk_lib_database_metadata_download_queue_insert()` to accept `Option<&str>` instead of `Option<&String>` for the `metadata_path` parameter

- **mk_lib_network.rs**: Updated `mk_download_file_from_url()` to accept `&str` instead of `&String` for the `file_name` parameter

## Implementation Details
Using `&str` instead of `&String` is idiomatic Rust and provides better API design:
- Callers can pass string slices, string literals, or owned Strings without conversion
- Reduces unnecessary allocations and clones
- Improves code flexibility and composability
- No functional changes to the implementation logic

https://claude.ai/code/session_01GVLiKe6JaTLu3joFu1LEvQ