### PR TITLE
Add Helm chart for Garage S3 object storage cluster

### DIFF
--- a/k8s/mkstack-garage/Chart.yaml
+++ b/k8s/mkstack-garage/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: mkstack-garage
+description: Garage S3-compatible object storage cluster (3-node HA) for MediaKraken
+type: application
+version: 0.1.0
+appVersion: "2.1.0"
+keywords:
+  - s3
+  - garage
+  - object-storage
+  - storage
+home: https://garagehq.deuxfleurs.fr/
+sources:
+  - https://git.deuxfleurs.fr/Deuxfleurs/garage

--- a/k8s/mkstack-garage/templates/NOTES.txt
+++ b/k8s/mkstack-garage/templates/NOTES.txt
@@ -1,0 +1,34 @@
+mkstack-garage deployed.
+
+StatefulSet:        {{ include "mkstack-garage.fullname" . }} ({{ .Values.replicaCount }} replicas)
+RPC headless svc:   {{ include "mkstack-garage.rpcServiceName" . }}
+S3 service:         {{ include "mkstack-garage.fullname" . }}-s3:{{ .Values.service.s3.port }}
+Web service:        {{ include "mkstack-garage.fullname" . }}-web:{{ .Values.service.web.port }}
+Admin service:      {{ include "mkstack-garage.fullname" . }}-admin:{{ .Values.service.admin.port }}
+
+1. Watch pods come up:
+   kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }} -w
+
+{{- if .Values.bootstrap.enabled }}
+
+2. Layout bootstrap Job will connect the nodes, assign zones, and commit layout v{{ .Values.bootstrap.layoutVersion }}.
+   Check progress with:
+   kubectl -n {{ .Release.Namespace }} logs job/{{ include "mkstack-garage.fullname" . }}-bootstrap-v{{ .Values.bootstrap.layoutVersion }}
+
+   If you change layout later, bump `bootstrap.layoutVersion` and re-run `helm upgrade`.
+{{- else }}
+
+2. Bootstrap is disabled. Manually run:
+   kubectl -n {{ .Release.Namespace }} exec -it {{ include "mkstack-garage.fullname" . }}-0 -- /garage status
+   kubectl -n {{ .Release.Namespace }} exec -it {{ include "mkstack-garage.fullname" . }}-0 -- /garage layout assign ...
+   kubectl -n {{ .Release.Namespace }} exec -it {{ include "mkstack-garage.fullname" . }}-0 -- /garage layout apply --version 1
+{{- end }}
+
+3. Create an S3 access key:
+   kubectl -n {{ .Release.Namespace }} exec -it {{ include "mkstack-garage.fullname" . }}-0 -- /garage key new --name mediakraken
+   kubectl -n {{ .Release.Namespace }} exec -it {{ include "mkstack-garage.fullname" . }}-0 -- /garage bucket create mediakraken
+   kubectl -n {{ .Release.Namespace }} exec -it {{ include "mkstack-garage.fullname" . }}-0 -- /garage bucket allow --read --write --owner mediakraken --key mediakraken
+
+4. Retrieve secrets (rpc_secret, admin_token, metrics_token):
+   kubectl -n {{ .Release.Namespace }} get secret {{ include "mkstack-garage.rpcSecretName" . }} -o jsonpath='{.data.rpc_secret}' | base64 -d
+   kubectl -n {{ .Release.Namespace }} get secret {{ include "mkstack-garage.adminSecretName" . }} -o jsonpath='{.data.admin_token}' | base64 -d

--- a/k8s/mkstack-garage/templates/_helpers.tpl
+++ b/k8s/mkstack-garage/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mkstack-garage.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "mkstack-garage.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart label.
+*/}}
+{{- define "mkstack-garage.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "mkstack-garage.labels" -}}
+helm.sh/chart: {{ include "mkstack-garage.chart" . }}
+{{ include "mkstack-garage.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "mkstack-garage.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mkstack-garage.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+RPC headless service name.
+*/}}
+{{- define "mkstack-garage.rpcServiceName" -}}
+{{- printf "%s-rpc" (include "mkstack-garage.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Secret name for rpc_secret.
+*/}}
+{{- define "mkstack-garage.rpcSecretName" -}}
+{{- printf "%s-rpc" (include "mkstack-garage.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Secret name for admin/metrics tokens.
+*/}}
+{{- define "mkstack-garage.adminSecretName" -}}
+{{- printf "%s-admin" (include "mkstack-garage.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/k8s/mkstack-garage/templates/bootstrap-job.yaml
+++ b/k8s/mkstack-garage/templates/bootstrap-job.yaml
@@ -1,0 +1,137 @@
+{{- if .Values.bootstrap.enabled }}
+{{- /*
+One-shot job that waits for all Garage pods to be up, discovers their node IDs
+via the RPC headless service, assigns each to the configured zone/capacity,
+and commits a layout version. Idempotent as long as layoutVersion is bumped.
+*/ -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "mkstack-garage.fullname" . }}-bootstrap-v{{ .Values.bootstrap.layoutVersion }}
+  labels:
+    {{- include "mkstack-garage.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        {{- include "mkstack-garage.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: bootstrap
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: bootstrap
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh", "-ec"]
+          args:
+            - |
+              set -eu
+              cat >/etc/garage.toml <<CFG
+              metadata_dir = "/tmp/garage/meta"
+              data_dir = "/tmp/garage/data"
+              db_engine = "sqlite"
+              replication_factor = {{ .Values.garage.replicationFactor }}
+              rpc_bind_addr = "[::]:13901"
+              rpc_public_addr = "127.0.0.1:13901"
+              rpc_secret = "${RPC_SECRET}"
+              [s3_api]
+              s3_region = "{{ .Values.garage.s3Region }}"
+              api_bind_addr = "[::]:13900"
+              [admin]
+              api_bind_addr = "[::]:13903"
+              admin_token = "${ADMIN_TOKEN}"
+              metrics_token = "${METRICS_TOKEN}"
+              CFG
+
+              SVC="{{ include "mkstack-garage.rpcServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+              SS="{{ include "mkstack-garage.fullname" . }}"
+              REPLICAS={{ .Values.replicaCount }}
+
+              echo "Waiting for all ${REPLICAS} garage pods to resolve via ${SVC}..."
+              for i in $(seq 1 60); do
+                COUNT=$(getent hosts "${SVC}" | wc -l || true)
+                if [ "${COUNT}" -ge "${REPLICAS}" ]; then break; fi
+                sleep 5
+              done
+
+              PEERS=""
+              for i in $(seq 0 $((REPLICAS-1))); do
+                HOST="${SS}-${i}.${SVC}"
+                PEERS="${PEERS} -h ${HOST}:3901"
+              done
+
+              echo "Collecting node IDs..."
+              NODE_IDS=""
+              for i in $(seq 0 $((REPLICAS-1))); do
+                HOST="${SS}-${i}.${SVC}"
+                # Wait until this node responds to status.
+                for j in $(seq 1 60); do
+                  ID=$(/garage -c /etc/garage.toml -h "${HOST}:3901" node id -q 2>/dev/null || true)
+                  if [ -n "${ID}" ]; then break; fi
+                  sleep 5
+                done
+                if [ -z "${ID}" ]; then
+                  echo "ERROR: failed to get node id for ${HOST}" >&2
+                  exit 1
+                fi
+                SHORT_ID="${ID%@*}"
+                NODE_IDS="${NODE_IDS} ${SHORT_ID}"
+              done
+
+              echo "Node IDs:${NODE_IDS}"
+
+              echo "Connecting nodes into a cluster..."
+              for i in $(seq 0 $((REPLICAS-1))); do
+                HOST="${SS}-${i}.${SVC}"
+                for ID_FULL in $(
+                  for j in $(seq 0 $((REPLICAS-1))); do
+                    OTHER="${SS}-${j}.${SVC}"
+                    if [ "${OTHER}" != "${HOST}" ]; then
+                      /garage -c /etc/garage.toml -h "${OTHER}:3901" node id 2>/dev/null || true
+                    fi
+                  done
+                ); do
+                  /garage -c /etc/garage.toml -h "${HOST}:3901" node connect "${ID_FULL}" || true
+                done
+              done
+
+              echo "Assigning layout..."
+              FIRST="${SS}-0.${SVC}:3901"
+              IDX=0
+              for SHORT_ID in ${NODE_IDS}; do
+                /garage -c /etc/garage.toml -h "${FIRST}" layout assign \
+                  -z {{ .Values.garage.zone }} \
+                  -c {{ .Values.garage.capacity }} \
+                  -t "${SS}-${IDX}" \
+                  "${SHORT_ID}"
+                IDX=$((IDX+1))
+              done
+
+              echo "Applying layout version {{ .Values.bootstrap.layoutVersion }}..."
+              /garage -c /etc/garage.toml -h "${FIRST}" layout apply --version {{ .Values.bootstrap.layoutVersion }}
+
+              echo "Cluster status:"
+              /garage -c /etc/garage.toml -h "${FIRST}" status
+          env:
+            - name: RPC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mkstack-garage.rpcSecretName" . }}
+                  key: rpc_secret
+            - name: ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mkstack-garage.adminSecretName" . }}
+                  key: admin_token
+            - name: METRICS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mkstack-garage.adminSecretName" . }}
+                  key: metrics_token
+{{- end }}

--- a/k8s/mkstack-garage/templates/ingress.yaml
+++ b/k8s/mkstack-garage/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "mkstack-garage.fullname" . }}
+  labels:
+    {{- include "mkstack-garage.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.s3.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "mkstack-garage.fullname" . }}-s3
+                port:
+                  number: {{ .Values.service.s3.port }}
+    - host: {{ .Values.ingress.web.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "mkstack-garage.fullname" . }}-web
+                port:
+                  number: {{ .Values.service.web.port }}
+{{- end }}

--- a/k8s/mkstack-garage/templates/pdb.yaml
+++ b/k8s/mkstack-garage/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "mkstack-garage.fullname" . }}
+  labels:
+    {{- include "mkstack-garage.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "mkstack-garage.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/k8s/mkstack-garage/templates/secrets.yaml
+++ b/k8s/mkstack-garage/templates/secrets.yaml
@@ -1,0 +1,52 @@
+{{- /*
+rpc_secret must be a 64-char hex string (32 bytes). Preserved across upgrades
+via lookup so an existing secret is not regenerated (which would split-brain the cluster).
+*/ -}}
+{{- $rpcSecretName := include "mkstack-garage.rpcSecretName" . -}}
+{{- $existingRpc := lookup "v1" "Secret" .Release.Namespace $rpcSecretName -}}
+{{- $rpcSecret := "" -}}
+{{- if .Values.secrets.rpcSecret -}}
+{{-   $rpcSecret = .Values.secrets.rpcSecret -}}
+{{- else if and $existingRpc $existingRpc.data (index $existingRpc.data "rpc_secret") -}}
+{{-   $rpcSecret = index $existingRpc.data "rpc_secret" | b64dec -}}
+{{- else -}}
+{{-   $rpcSecret = randAlphaNum 64 | lower -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $rpcSecretName }}
+  labels:
+    {{- include "mkstack-garage.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  rpc_secret: {{ $rpcSecret | quote }}
+---
+{{- $adminSecretName := include "mkstack-garage.adminSecretName" . -}}
+{{- $existingAdmin := lookup "v1" "Secret" .Release.Namespace $adminSecretName -}}
+{{- $adminToken := "" -}}
+{{- $metricsToken := "" -}}
+{{- if .Values.secrets.adminToken -}}
+{{-   $adminToken = .Values.secrets.adminToken -}}
+{{- else if and $existingAdmin $existingAdmin.data (index $existingAdmin.data "admin_token") -}}
+{{-   $adminToken = index $existingAdmin.data "admin_token" | b64dec -}}
+{{- else -}}
+{{-   $adminToken = randAlphaNum 48 -}}
+{{- end -}}
+{{- if .Values.secrets.metricsToken -}}
+{{-   $metricsToken = .Values.secrets.metricsToken -}}
+{{- else if and $existingAdmin $existingAdmin.data (index $existingAdmin.data "metrics_token") -}}
+{{-   $metricsToken = index $existingAdmin.data "metrics_token" | b64dec -}}
+{{- else -}}
+{{-   $metricsToken = randAlphaNum 48 -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $adminSecretName }}
+  labels:
+    {{- include "mkstack-garage.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  admin_token: {{ $adminToken | quote }}
+  metrics_token: {{ $metricsToken | quote }}

--- a/k8s/mkstack-garage/templates/servicemonitor.yaml
+++ b/k8s/mkstack-garage/templates/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "mkstack-garage.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "mkstack-garage.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "mkstack-garage.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: admin
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      bearerTokenSecret:
+        name: {{ include "mkstack-garage.adminSecretName" . }}
+        key: metrics_token
+{{- end }}

--- a/k8s/mkstack-garage/templates/services.yaml
+++ b/k8s/mkstack-garage/templates/services.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mkstack-garage.rpcServiceName" . }}
+  labels:
+    {{- include "mkstack-garage.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    {{- include "mkstack-garage.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: rpc
+      port: 3901
+      targetPort: rpc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mkstack-garage.fullname" . }}-s3
+  labels:
+    {{- include "mkstack-garage.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.s3.type }}
+  selector:
+    {{- include "mkstack-garage.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: s3
+      port: {{ .Values.service.s3.port }}
+      targetPort: s3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mkstack-garage.fullname" . }}-web
+  labels:
+    {{- include "mkstack-garage.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.web.type }}
+  selector:
+    {{- include "mkstack-garage.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: web
+      port: {{ .Values.service.web.port }}
+      targetPort: web
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mkstack-garage.fullname" . }}-admin
+  labels:
+    {{- include "mkstack-garage.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.admin.type }}
+  selector:
+    {{- include "mkstack-garage.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: admin
+      port: {{ .Values.service.admin.port }}
+      targetPort: admin
+{{- if .Values.service.k2v.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mkstack-garage.fullname" . }}-k2v
+  labels:
+    {{- include "mkstack-garage.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.k2v.type }}
+  selector:
+    {{- include "mkstack-garage.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: k2v
+      port: {{ .Values.service.k2v.port }}
+      targetPort: k2v
+{{- end }}

--- a/k8s/mkstack-garage/templates/statefulset.yaml
+++ b/k8s/mkstack-garage/templates/statefulset.yaml
@@ -1,0 +1,144 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "mkstack-garage.fullname" . }}
+  labels:
+    {{- include "mkstack-garage.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "mkstack-garage.rpcServiceName" . }}
+  replicas: {{ .Values.replicaCount }}
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      {{- include "mkstack-garage.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mkstack-garage.selectorLabels" . | nindent 8 }}
+    spec:
+      terminationGracePeriodSeconds: 30
+      {{- if .Values.podAntiAffinity.enabled }}
+      affinity:
+        podAntiAffinity:
+          {{- if eq .Values.podAntiAffinity.mode "hard" }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  {{- include "mkstack-garage.selectorLabels" . | nindent 18 }}
+              topologyKey: {{ .Values.podAntiAffinity.topologyKey }}
+          {{- else }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "mkstack-garage.selectorLabels" . | nindent 20 }}
+                topologyKey: {{ .Values.podAntiAffinity.topologyKey }}
+          {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: garage
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh", "-ec"]
+          args:
+            - |
+              POD_ORDINAL="${HOSTNAME##*-}"
+              NODE_FQDN="${HOSTNAME}.{{ include "mkstack-garage.rpcServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+              cat >/etc/garage.toml <<CFG
+              metadata_dir = "/var/lib/garage/meta"
+              data_dir = "/var/lib/garage/data"
+              db_engine = "{{ .Values.garage.dbEngine }}"
+              replication_factor = {{ .Values.garage.replicationFactor }}
+
+              rpc_bind_addr = "[::]:3901"
+              rpc_public_addr = "${NODE_FQDN}:3901"
+              rpc_secret = "${RPC_SECRET}"
+
+              [s3_api]
+              s3_region = "{{ .Values.garage.s3Region }}"
+              api_bind_addr = "[::]:3900"
+              root_domain = ".{{ .Values.garage.rootDomain }}"
+
+              [s3_web]
+              bind_addr = "[::]:3902"
+              root_domain = ".{{ .Values.garage.rootDomain }}"
+              index = "index.html"
+
+              {{- if .Values.service.k2v.enabled }}
+              [k2v_api]
+              api_bind_addr = "[::]:3904"
+              {{- end }}
+
+              [admin]
+              api_bind_addr = "[::]:3903"
+              admin_token = "${ADMIN_TOKEN}"
+              metrics_token = "${METRICS_TOKEN}"
+              CFG
+              exec /garage -c /etc/garage.toml server
+          env:
+            - name: RPC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mkstack-garage.rpcSecretName" . }}
+                  key: rpc_secret
+            - name: ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mkstack-garage.adminSecretName" . }}
+                  key: admin_token
+            - name: METRICS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mkstack-garage.adminSecretName" . }}
+                  key: metrics_token
+          ports:
+            - name: s3
+              containerPort: 3900
+            - name: rpc
+              containerPort: 3901
+            - name: web
+              containerPort: 3902
+            - name: admin
+              containerPort: 3903
+            {{- if .Values.service.k2v.enabled }}
+            - name: k2v
+              containerPort: 3904
+            {{- end }}
+          readinessProbe:
+            tcpSocket:
+              port: s3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: rpc
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/garage
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          {{- toYaml .Values.persistence.accessModes | nindent 10 }}
+        {{- if .Values.persistence.storageClassName }}
+        storageClassName: {{ .Values.persistence.storageClassName }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+  {{- end }}

--- a/k8s/mkstack-garage/values.yaml
+++ b/k8s/mkstack-garage/values.yaml
@@ -1,0 +1,101 @@
+# Default values for mkstack-garage.
+# Deploys a 3-node Garage S3 cluster as a StatefulSet with one Garage pod per k8s node.
+
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: dxflrs/garage
+  tag: v2.1.0
+  pullPolicy: IfNotPresent
+
+# Number of Garage nodes. The cluster is designed for exactly 3.
+replicaCount: 3
+
+# Garage cluster configuration.
+garage:
+  # replication_factor must be <= replicaCount. Use 3 for HA (any node can fail).
+  replicationFactor: 3
+  # Metadata DB engine: sqlite | lmdb
+  dbEngine: sqlite
+  s3Region: garage
+  # Root domain for virtual-hosted-style S3 and web access (no leading dot).
+  rootDomain: garage.mediakraken.media
+  # Zone used when assigning the cluster layout. Per-node overrides below.
+  zone: dc1
+  # Capacity (bytes) advertised by each node to the layout planner. 1 TiB.
+  capacity: "1000000000000"
+
+# Secrets. Leave blank to let the chart generate random values on first install.
+# Rotating these after install requires manual coordination across all nodes.
+secrets:
+  rpcSecret: ""
+  adminToken: ""
+  metricsToken: ""
+
+service:
+  s3:
+    type: ClusterIP
+    port: 3900
+  web:
+    type: ClusterIP
+    port: 3902
+  admin:
+    type: ClusterIP
+    port: 3903
+  k2v:
+    enabled: false
+    type: ClusterIP
+    port: 3904
+
+persistence:
+  enabled: true
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  size: 500Gi
+
+resources:
+  requests:
+    cpu: "1000m"
+    memory: "2Gi"
+  limits:
+    cpu: "2000m"
+    memory: "4Gi"
+
+# Spread Garage pods across distinct nodes.
+podAntiAffinity:
+  enabled: true
+  # hard | soft
+  mode: hard
+  topologyKey: kubernetes.io/hostname
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2
+
+# Run a one-shot Job after install that assigns the cluster layout and commits it.
+# Disable if you prefer to run `garage layout` manually.
+bootstrap:
+  enabled: true
+  # Layout version to commit. Must be incremented on subsequent re-runs.
+  layoutVersion: 1
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  s3:
+    host: s3.garage.mediakraken.media
+  web:
+    host: web.garage.mediakraken.media
+  tls: []
+
+serviceMonitor:
+  enabled: false
+  namespace: ""
+  interval: 30s
+  labels: {}
+
+nodeSelector: {}
+tolerations: []


### PR DESCRIPTION
## Summary
This PR introduces a complete Helm chart for deploying a 3-node Garage S3-compatible object storage cluster on Kubernetes. The chart provides a production-ready deployment with automatic cluster bootstrapping, persistent storage, and comprehensive configuration options.

## Key Changes
- **StatefulSet deployment** (`statefulset.yaml`): Deploys Garage as a StatefulSet with parallel pod management, pod anti-affinity rules, and health checks (readiness/liveness probes)
- **Cluster bootstrap automation** (`bootstrap-job.yaml`): Post-install/upgrade Job that automatically discovers nodes, assigns layout zones/capacities, and commits the cluster configuration
- **Kubernetes Services** (`services.yaml`): Exposes RPC (headless), S3, Web, Admin, and optional K2V APIs through separate services
- **Secret management** (`secrets.yaml`): Generates and preserves RPC secret and admin/metrics tokens across upgrades using Helm's lookup function
- **Persistent storage**: Configurable PersistentVolumeClaims via volumeClaimTemplates with support for different storage classes
- **Optional features**:
  - Ingress support for S3 and Web APIs
  - ServiceMonitor for Prometheus metrics collection
  - PodDisruptionBudget for high availability
- **Comprehensive values** (`values.yaml`): Sensible defaults for a 3-node HA cluster with 500Gi storage, resource requests/limits, and configurable replication factor
- **Helper templates** (`_helpers.tpl`): Standard Helm template helpers for consistent naming and labeling
- **Documentation** (`NOTES.txt`): Post-deployment instructions for monitoring, bootstrapping, and S3 key creation

## Notable Implementation Details
- The bootstrap Job uses DNS discovery via the RPC headless service to wait for all pods to be ready before configuring the cluster
- Secrets are idempotent: existing secrets are preserved on upgrades to prevent cluster split-brain scenarios
- The StatefulSet uses dynamic configuration generation via shell script to construct `garage.toml` with pod-specific FQDNs
- Layout version is versioned in the bootstrap Job name to allow re-running with `helm upgrade` when topology changes
- Pod anti-affinity is configurable (hard/soft) to spread nodes across distinct Kubernetes nodes for fault tolerance

https://claude.ai/code/session_015E3GHMxF3wpukpRvuknorK