### PR TITLE
Replace tar-based metadata initialization with S3 bucket setup

### DIFF
--- a/docker/core/mkinit/Cargo.toml
+++ b/docker/core/mkinit/Cargo.toml
@@ -19,6 +19,8 @@ codegen-units = 1
 mk_lib_database = { version = "0.0.238", registry = "kellnr" }
 mk_lib_logging = { version = "0.0.207", registry = "kellnr" }
 
+aws-config = "1.8.12"
+aws-sdk-s3 = "1.119.0"
 tokio = { version = "1.49.0", features = ["full"] }
 
 [dev-dependencies]

--- a/docker/core/mkinit/src/main.rs
+++ b/docker/core/mkinit/src/main.rs
@@ -1,34 +1,46 @@
+use aws_config::BehaviorVersion;
+use aws_sdk_s3::{Client as S3Client, config::Builder as S3ConfigBuilder};
 use std::env;
 use std::error::Error;
-use std::fs;
-use std::fs::File;
-use std::io::Write;
-use std::path::Path;
 use std::process::{Command, Stdio};
+
+const POSTER_BUCKETS: &[&str] = &[
+    "movie_poster",
+    "tv_poster",
+    "person_poster",
+    "crew_poster",
+    "cast_poster",
+    "book_cover",
+];
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // create metadata paths, as before the db update will let it finish before
-    // other containers can use them
-    if Path::new(&"/tmp/meta.tar.gz").exists() {
-        println!("Meta file exists")
-    }
-    if Path::new(&"/mediakraken/metadata").exists() {
-        println!("Meta directory exists")
-    }
-    if !Path::new(&"/mediakraken/metadata/backdrop/aa").exists() {
-        println!("Creating directories");
-        // untar the tarball to /mediakraken/metadata
-        let output = Command::new("tar")
-            .args(["-xzf", "/tmp/meta.tar.gz", "-C", "/mediakraken/metadata"])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .unwrap();
-        let stdout: String = String::from_utf8(output.stdout).unwrap();
-        let stderr: String = String::from_utf8(output.stderr).unwrap();
-        println!("tar output: {}", stdout);
-        println!("tar erroutput: {}", stderr);
+    // Connect to local garage s3 and ensure required buckets exist before
+    // other containers try to use them.
+    let endpoint = env::var("MK_GARAGE_S3_ENDPOINT")
+        .or_else(|_| env::var("AWS_ENDPOINT_URL"))
+        .unwrap();
+    let shared = aws_config::load_defaults(BehaviorVersion::latest()).await;
+    let s3_config = S3ConfigBuilder::from(&shared)
+        .endpoint_url(endpoint)
+        .force_path_style(true)
+        .build();
+    let s3_client = S3Client::from_conf(s3_config);
+
+    for bucket in POSTER_BUCKETS {
+        match s3_client.create_bucket().bucket(*bucket).send().await {
+            Ok(_) => println!("Created bucket: {}", bucket),
+            Err(err) => {
+                let service_err = err.into_service_error();
+                if service_err.is_bucket_already_owned_by_you()
+                    || service_err.is_bucket_already_exists()
+                {
+                    println!("Bucket already exists: {}", bucket);
+                } else {
+                    return Err(Box::new(service_err));
+                }
+            }
+        }
     }
 
     // connect to db and do a version check and upgrade if needed

--- a/k8s/mkstack-mediakraken/templates/mkstack-init.yaml
+++ b/k8s/mkstack-mediakraken/templates/mkstack-init.yaml
@@ -47,6 +47,26 @@ spec:
                 secretKeyRef:
                   name: run-env-type
                   key: debug
+            - name: MK_GARAGE_S3_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: garage-s3-credentials
+                  key: endpoint
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: garage-s3-credentials
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: garage-s3-credentials
+                  key: secret_access_key
+            - name: AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: garage-s3-credentials
+                  key: region
           image: mediakraken/mkinit:dev
           imagePullPolicy: Always
           name: mkstack-init


### PR DESCRIPTION
## Summary
Refactored the mkinit container initialization logic to replace local tar file extraction with AWS S3 bucket creation and validation. The service now connects to a Garage S3 endpoint to ensure required poster and cover buckets exist before other containers attempt to use them.

## Key Changes
- **Removed local file operations**: Eliminated tar extraction logic that previously unpacked metadata from `/tmp/meta.tar.gz` to `/mediakraken/metadata`
- **Added S3 bucket initialization**: Implemented AWS SDK integration to create and validate existence of S3 buckets for storing media assets (movie posters, TV posters, person posters, crew posters, cast posters, and book covers)
- **Environment configuration**: Added support for S3 endpoint configuration via `MK_GARAGE_S3_ENDPOINT` environment variable with fallback to `AWS_ENDPOINT_URL`
- **Error handling**: Gracefully handles bucket creation with proper error differentiation between "bucket already exists" scenarios and actual failures
- **Kubernetes secrets integration**: Updated deployment manifest to inject S3 credentials (`access_key_id`, `secret_access_key`, `region`, `endpoint`) from the `garage-s3-credentials` secret

## Implementation Details
- Uses AWS SDK for Rust with `force_path_style(true)` to support S3-compatible services like Garage
- Defines a constant list of required buckets (`POSTER_BUCKETS`) for centralized management
- Converts the main function to async using `#[tokio::main]` to support async S3 operations
- Maintains the existing pattern of blocking initialization before other containers proceed

https://claude.ai/code/session_01DbtXb6nQbWAPa5TQuRRrnv