### PR TITLE
Add S3 object storage admin interface

### DIFF
--- a/docker/core/mkwebaxum/Cargo.toml
+++ b/docker/core/mkwebaxum/Cargo.toml
@@ -27,6 +27,8 @@ mk_lib_rabbitmq = { version = "0.0.210", registry = "kellnr" }
 askama = "0.15.4"
 askama_axum = "0.4.0"
 async-trait = "0.1.89"
+aws-config = "1.8.12"
+aws-sdk-s3 = "1.119.0"
 axum = { version = "0.8.8", features = ["form", "http2", "json", "multipart", "ws", "macros"] }
 axum-client-ip = "1.3.1"
 axum_csrf = "0.11.0"

--- a/docker/core/mkwebaxum/src/admin/bp_s3.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_s3.rs
@@ -1,0 +1,375 @@
+use crate::axum_custom_filters::filters;
+use crate::mk_lib_database;
+use askama::Template;
+use aws_config::BehaviorVersion;
+use aws_sdk_s3::{Client as S3Client, config::Builder as S3ConfigBuilder};
+use axum::extract::Query;
+use axum::{
+    http::{Method, StatusCode},
+    response::{Html, IntoResponse},
+};
+use axum_session_auth::*;
+use axum_session_sqlx::SessionPgPool;
+use serde::Deserialize;
+use sqlx::postgres::PgPool;
+
+#[derive(Template)]
+#[template(path = "bss_error/bss_error_403.html")]
+struct TemplateError403Context {}
+
+pub struct BucketSummary {
+    pub name: String,
+    pub object_count: u64,
+    pub total_size: u64,
+}
+
+pub struct BrowserFolder {
+    pub name: String,
+    pub prefix: String,
+}
+
+pub struct BrowserObject {
+    pub name: String,
+    pub key: String,
+    pub size: u64,
+    pub last_modified: String,
+}
+
+pub struct Breadcrumb {
+    pub label: String,
+    pub prefix: String,
+}
+
+#[derive(Template)]
+#[template(path = "bss_admin/bss_admin_s3.html")]
+struct AdminS3Template<'a> {
+    template_endpoint: &'a String,
+    template_region: &'a String,
+    template_error: &'a Option<String>,
+    template_bucket_count: &'a u64,
+    template_object_count: &'a u64,
+    template_total_size: &'a u64,
+    template_data_path: &'a Option<String>,
+    template_disk_total: &'a Option<u64>,
+    template_disk_free: &'a Option<u64>,
+    template_buckets: &'a Vec<BucketSummary>,
+    template_browse_active: &'a bool,
+    template_selected_bucket: &'a String,
+    template_breadcrumbs: &'a Vec<Breadcrumb>,
+    template_folders: &'a Vec<BrowserFolder>,
+    template_objects: &'a Vec<BrowserObject>,
+    template_truncated: &'a bool,
+    page_title: Option<String>,
+}
+
+#[derive(Deserialize, Default, Debug)]
+pub struct S3QueryParams {
+    pub bucket: Option<String>,
+    pub prefix: Option<String>,
+}
+
+fn build_s3_client_config() -> Option<(String, String)> {
+    let endpoint = std::env::var("MK_GARAGE_S3_ENDPOINT")
+        .or_else(|_| std::env::var("AWS_ENDPOINT_URL"))
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())?;
+    let region = std::env::var("AWS_REGION")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "garage".to_string());
+    Some((endpoint, region))
+}
+
+async fn build_s3_client(endpoint: &str) -> S3Client {
+    let shared = aws_config::load_defaults(BehaviorVersion::latest()).await;
+    let s3_config = S3ConfigBuilder::from(&shared)
+        .endpoint_url(endpoint.to_string())
+        .force_path_style(true)
+        .build();
+    S3Client::from_conf(s3_config)
+}
+
+async fn gather_bucket_summaries(client: &S3Client) -> Result<Vec<BucketSummary>, String> {
+    let buckets_response = client
+        .list_buckets()
+        .send()
+        .await
+        .map_err(|err| format!("list_buckets failed: {err}"))?;
+    let bucket_list = buckets_response.buckets();
+    let mut summaries: Vec<BucketSummary> = Vec::with_capacity(bucket_list.len());
+    for bucket in bucket_list {
+        let Some(name) = bucket.name() else {
+            continue;
+        };
+        let mut object_count: u64 = 0;
+        let mut total_size: u64 = 0;
+        let mut continuation_token: Option<String> = None;
+        loop {
+            let mut req = client.list_objects_v2().bucket(name);
+            if let Some(token) = continuation_token.as_deref() {
+                req = req.continuation_token(token);
+            }
+            let page = match req.send().await {
+                Ok(page) => page,
+                Err(err) => {
+                    tracing::warn!(bucket = %name, error = %err, "list_objects_v2 failed");
+                    break;
+                }
+            };
+            for object in page.contents() {
+                object_count += 1;
+                if let Some(size) = object.size() {
+                    total_size = total_size.saturating_add(u64::try_from(size).unwrap_or(0));
+                }
+            }
+            if page.is_truncated().unwrap_or(false) {
+                continuation_token = page.next_continuation_token().map(|s| s.to_string());
+                if continuation_token.is_none() {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+        summaries.push(BucketSummary {
+            name: name.to_string(),
+            object_count,
+            total_size,
+        });
+    }
+    summaries.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(summaries)
+}
+
+async fn browse_bucket(
+    client: &S3Client,
+    bucket: &str,
+    prefix: &str,
+) -> Result<(Vec<BrowserFolder>, Vec<BrowserObject>, bool), String> {
+    let mut request = client
+        .list_objects_v2()
+        .bucket(bucket)
+        .delimiter("/")
+        .max_keys(1000);
+    if !prefix.is_empty() {
+        request = request.prefix(prefix);
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|err| format!("list_objects_v2 failed: {err}"))?;
+
+    let mut folders: Vec<BrowserFolder> = Vec::new();
+    for cp in response.common_prefixes() {
+        if let Some(folder_prefix) = cp.prefix() {
+            let trimmed = folder_prefix.strip_suffix('/').unwrap_or(folder_prefix);
+            let display = trimmed.rsplit('/').next().unwrap_or(trimmed).to_string();
+            folders.push(BrowserFolder {
+                name: display,
+                prefix: folder_prefix.to_string(),
+            });
+        }
+    }
+
+    let mut objects: Vec<BrowserObject> = Vec::new();
+    for obj in response.contents() {
+        let Some(key) = obj.key() else {
+            continue;
+        };
+        if key == prefix {
+            continue;
+        }
+        let display = key
+            .strip_prefix(prefix)
+            .unwrap_or(key)
+            .trim_start_matches('/')
+            .to_string();
+        if display.is_empty() {
+            continue;
+        }
+        let size = obj.size().and_then(|s| u64::try_from(s).ok()).unwrap_or(0);
+        let last_modified = obj
+            .last_modified()
+            .and_then(|ts| chrono::DateTime::<chrono::Utc>::from_timestamp(ts.secs(), 0))
+            .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+            .unwrap_or_default();
+        objects.push(BrowserObject {
+            name: display,
+            key: key.to_string(),
+            size,
+            last_modified,
+        });
+    }
+
+    let truncated = response.is_truncated().unwrap_or(false);
+    Ok((folders, objects, truncated))
+}
+
+fn build_breadcrumbs(prefix: &str) -> Vec<Breadcrumb> {
+    let mut crumbs = Vec::new();
+    if prefix.is_empty() {
+        return crumbs;
+    }
+    let mut accumulator = String::new();
+    for segment in prefix.trim_end_matches('/').split('/') {
+        if segment.is_empty() {
+            continue;
+        }
+        accumulator.push_str(segment);
+        accumulator.push('/');
+        crumbs.push(Breadcrumb {
+            label: segment.to_string(),
+            prefix: accumulator.clone(),
+        });
+    }
+    crumbs
+}
+
+fn read_disk_stats(path: &str) -> Option<(u64, u64)> {
+    let cpath = std::ffi::CString::new(path).ok()?;
+    let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
+    let ret = unsafe { libc::statvfs(cpath.as_ptr(), &mut stat) };
+    if ret != 0 {
+        return None;
+    }
+    let frsize = u64::try_from(stat.f_frsize).unwrap_or(0);
+    let blocks = u64::try_from(stat.f_blocks).unwrap_or(0);
+    let avail = u64::try_from(stat.f_bavail).unwrap_or(0);
+    Some((blocks.saturating_mul(frsize), avail.saturating_mul(frsize)))
+}
+
+fn sanitize_bucket_name(name: &str) -> Option<String> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() || trimmed.len() > 63 {
+        return None;
+    }
+    if !trimmed
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == '_')
+    {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+fn sanitize_prefix(prefix: &str) -> String {
+    let mut cleaned = prefix.trim_start_matches('/').to_string();
+    if cleaned.contains("..") {
+        cleaned.clear();
+    }
+    if cleaned.len() > 1024 {
+        cleaned.truncate(1024);
+    }
+    cleaned
+}
+
+pub async fn admin_s3(
+    method: Method,
+    auth: AuthSession<mk_lib_database::mk_lib_database_user::User, i64, SessionPgPool, PgPool>,
+    Query(params): Query<S3QueryParams>,
+) -> impl IntoResponse {
+    let current_user = auth.current_user.clone().unwrap_or_default();
+    if !Auth::<mk_lib_database::mk_lib_database_user::User, i64, PgPool>::build(
+        [Method::GET],
+        false,
+    )
+    .requires(Rights::any([Rights::permission("Admin::View")]))
+    .validate(&current_user, &method, None)
+    .await
+    {
+        let template = TemplateError403Context {};
+        let reply_html = template.render().unwrap_or_default();
+        return (StatusCode::UNAUTHORIZED, Html(reply_html).into_response());
+    }
+
+    let selected_bucket = params.bucket.as_deref().and_then(sanitize_bucket_name);
+    let current_prefix = sanitize_prefix(params.prefix.as_deref().unwrap_or(""));
+
+    let mut error_message: Option<String> = None;
+    let mut bucket_summaries: Vec<BucketSummary> = Vec::new();
+    let mut folders: Vec<BrowserFolder> = Vec::new();
+    let mut objects: Vec<BrowserObject> = Vec::new();
+    let mut truncated = false;
+
+    let (endpoint, region) = match build_s3_client_config() {
+        Some(values) => values,
+        None => {
+            error_message = Some(
+                "S3 endpoint is not configured (set MK_GARAGE_S3_ENDPOINT or AWS_ENDPOINT_URL)."
+                    .to_string(),
+            );
+            (String::new(), String::new())
+        }
+    };
+
+    if error_message.is_none() {
+        let client = build_s3_client(&endpoint).await;
+        match gather_bucket_summaries(&client).await {
+            Ok(summaries) => bucket_summaries = summaries,
+            Err(err) => {
+                tracing::warn!(error = %err, "failed to gather S3 bucket summaries");
+                error_message = Some(format!("Unable to query S3 backend: {err}"));
+            }
+        }
+        if let Some(bucket_name) = selected_bucket.as_deref() {
+            match browse_bucket(&client, bucket_name, &current_prefix).await {
+                Ok((listed_folders, listed_objects, is_truncated)) => {
+                    folders = listed_folders;
+                    objects = listed_objects;
+                    truncated = is_truncated;
+                }
+                Err(err) => {
+                    tracing::warn!(bucket = %bucket_name, error = %err, "failed to list bucket");
+                    error_message = Some(match error_message.take() {
+                        Some(existing) => format!("{existing}; bucket browse failed: {err}"),
+                        None => format!("Unable to browse bucket: {err}"),
+                    });
+                }
+            }
+        }
+    }
+
+    let bucket_count: u64 = u64::try_from(bucket_summaries.len()).unwrap_or(0);
+    let object_count: u64 = bucket_summaries.iter().map(|b| b.object_count).sum();
+    let total_size: u64 = bucket_summaries.iter().map(|b| b.total_size).sum();
+
+    let data_path = std::env::var("MK_GARAGE_DATA_PATH")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    let (disk_total, disk_free) = match data_path.as_deref() {
+        Some(path) => match read_disk_stats(path) {
+            Some((total, free)) => (Some(total), Some(free)),
+            None => (None, None),
+        },
+        None => (None, None),
+    };
+
+    let breadcrumbs = build_breadcrumbs(&current_prefix);
+    let browse_active = selected_bucket.is_some();
+    let selected_bucket_string = selected_bucket.clone().unwrap_or_default();
+
+    let template = AdminS3Template {
+        template_endpoint: &endpoint,
+        template_region: &region,
+        template_error: &error_message,
+        template_bucket_count: &bucket_count,
+        template_object_count: &object_count,
+        template_total_size: &total_size,
+        template_data_path: &data_path,
+        template_disk_total: &disk_total,
+        template_disk_free: &disk_free,
+        template_buckets: &bucket_summaries,
+        template_browse_active: &browse_active,
+        template_selected_bucket: &selected_bucket_string,
+        template_breadcrumbs: &breadcrumbs,
+        template_folders: &folders,
+        template_objects: &objects,
+        template_truncated: &truncated,
+        page_title: Some("MediaKraken Admin S3".to_string()),
+    };
+    let reply_html = template.render().unwrap_or_default();
+    (StatusCode::OK, Html(reply_html).into_response())
+}

--- a/docker/core/mkwebaxum/src/admin/bp_s3.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_s3.rs
@@ -82,10 +82,11 @@ fn build_s3_client_config() -> Option<(String, String)> {
     Some((endpoint, region))
 }
 
-async fn build_s3_client(endpoint: &str) -> S3Client {
+async fn build_s3_client(endpoint: &str, region: &str) -> S3Client {
     let shared = aws_config::load_defaults(BehaviorVersion::latest()).await;
     let s3_config = S3ConfigBuilder::from(&shared)
         .endpoint_url(endpoint.to_string())
+        .region(aws_sdk_s3::config::Region::new(region.to_string()))
         .force_path_style(true)
         .build();
     S3Client::from_conf(s3_config)
@@ -305,7 +306,7 @@ pub async fn admin_s3(
     };
 
     if error_message.is_none() {
-        let client = build_s3_client(&endpoint).await;
+        let client = build_s3_client(&endpoint, &region).await;
         match gather_bucket_summaries(&client).await {
             Ok(summaries) => bucket_summaries = summaries,
             Err(err) => {

--- a/docker/core/mkwebaxum/src/axum_custom_filters.rs
+++ b/docker/core/mkwebaxum/src/axum_custom_filters.rs
@@ -31,6 +31,14 @@ pub mod filters {
     }
 
     #[askama::filter_fn]
+    pub fn url_encode<T: std::fmt::Display>(
+        s: T,
+        _env: &dyn askama::Values,
+    ) -> askama::Result<String> {
+        Ok(urlencoding::encode(&s.to_string()).into_owned())
+    }
+
+    #[askama::filter_fn]
     pub fn slash_to_asterik<T: std::fmt::Display>(
         s: T,
         _env: &dyn askama::Values,

--- a/docker/core/mkwebaxum/src/main.rs
+++ b/docker/core/mkwebaxum/src/main.rs
@@ -43,6 +43,7 @@ pub mod admin {
     pub mod bp_library;
     pub mod bp_logging;
     pub mod bp_reports;
+    pub mod bp_s3;
     pub mod bp_server_links;
     pub mod bp_settings;
     pub mod bp_torrent;
@@ -312,6 +313,7 @@ async fn main() {
             get(admin::bp_server_links::admin_server_links)
                 .post(admin::bp_server_links::admin_server_links_post),
         )
+        .route_with_tsr("/admin/s3", get(admin::bp_s3::admin_s3))
         .route_with_tsr("/admin/settings", get(admin::bp_settings::admin_settings))
         .route_with_tsr(
             "/admin/report_known_media/{page}",

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_include_menu.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_include_menu.html
@@ -45,6 +45,9 @@
         </a> <a class="relative flex items-center w-full h-12 px-3 mt-2 rounded hover:bg-gray-300 dark:hover:bg-zinc-800" :class="{ 'bg-gray-300 dark:bg-zinc-800': activePath === '/admin/server_links' }" :aria-current="activePath === '/admin/server_links' ? 'page' : null" href="/admin/server_links">
           {% include "icons/link.svg" %}
           <span class="ml-2 text-sm font-medium">Server Links</span>
+        </a> <a class="relative flex items-center w-full h-12 px-3 mt-2 rounded hover:bg-gray-300 dark:hover:bg-zinc-800" :class="{ 'bg-gray-300 dark:bg-zinc-800': activePath.startsWith('/admin/s3') }" :aria-current="activePath.startsWith('/admin/s3') ? 'page' : null" href="/admin/s3">
+          {% include "icons/server.svg" %}
+          <span class="ml-2 text-sm font-medium">S3 Storage</span>
         </a> <a class="relative flex items-center w-full h-12 px-3 mt-2 rounded hover:bg-gray-300 dark:hover:bg-zinc-800" :class="{ 'bg-gray-300 dark:bg-zinc-800': activePath === '/admin/torrent' }" :aria-current="activePath === '/admin/torrent' ? 'page' : null" href="/admin/torrent">
           {% include "icons/bolt.svg" %}
           <span class="ml-2 text-sm font-medium">Torrent Management</span>

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_s3.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_s3.html
@@ -107,7 +107,7 @@
                 <td class="px-3 py-2 text-right">{{ bucket.object_count }}</td>
                 <td class="px-3 py-2 text-right">{{ bucket.total_size|byte_format }}</td>
                 <td class="px-3 py-2 text-center">
-                  <a href="/admin/s3?bucket={{ bucket.name|space_to_html }}"
+                  <a href="/admin/s3?bucket={{ bucket.name|url_encode }}"
                      class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300"
                      aria-label="Browse bucket {{ bucket.name }}">
                     Browse
@@ -136,13 +136,13 @@
 
         <!-- Breadcrumbs -->
         <nav class="text-sm mb-3 flex flex-wrap items-center gap-1 text-zinc-600 dark:text-zinc-400">
-          <a href="/admin/s3?bucket={{ template_selected_bucket|space_to_html }}"
+          <a href="/admin/s3?bucket={{ template_selected_bucket|url_encode }}"
              class="hover:text-indigo-600 dark:hover:text-indigo-400">
             (root)
           </a>
           {% for crumb in template_breadcrumbs %}
           <span class="text-zinc-400">/</span>
-          <a href="/admin/s3?bucket={{ template_selected_bucket|space_to_html }}&prefix={{ crumb.prefix|space_to_html }}"
+          <a href="/admin/s3?bucket={{ template_selected_bucket|url_encode }}&prefix={{ crumb.prefix|url_encode }}"
              class="hover:text-indigo-600 dark:hover:text-indigo-400">
             {{ crumb.label }}
           </a>
@@ -162,7 +162,7 @@
               {% for folder in template_folders %}
               <tr class="hover:bg-zinc-50 dark:hover:bg-zinc-800">
                 <td class="px-3 py-2">
-                  <a href="/admin/s3?bucket={{ template_selected_bucket|space_to_html }}&prefix={{ folder.prefix|space_to_html }}"
+                  <a href="/admin/s3?bucket={{ template_selected_bucket|url_encode }}&prefix={{ folder.prefix|url_encode }}"
                      class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300">
                     <span class="mr-1">&#128193;</span>{{ folder.name }}/
                   </a>

--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_s3.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_s3.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html lang="en">
+{% include "bss_include_header.html" %}
+
+<body class="bg-gray-100 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100 transition-colors duration-300">
+
+<div class="flex min-h-screen flex-col">
+  {% include "bss_user/bss_user_include_menu.html" %}
+
+  <div class="flex flex-1">
+    {% include "bss_admin/bss_admin_include_menu.html" %}
+
+  <main class="flex-1 p-6">
+
+    <section class="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded shadow">
+
+      <!-- Header -->
+      <div class="border-b border-zinc-200 dark:border-zinc-800 p-4 space-y-1">
+        <h1 class="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+          S3 Object Storage
+        </h1>
+        <p class="text-sm text-zinc-600 dark:text-zinc-400">
+          Endpoint:
+          <span class="text-zinc-900 dark:text-zinc-100">
+            {% if template_endpoint.is_empty() %}<em>not configured</em>{% else %}{{ template_endpoint }}{% endif %}
+          </span>
+        </p>
+        <p class="text-sm text-zinc-600 dark:text-zinc-400">
+          Region:
+          <span class="text-zinc-900 dark:text-zinc-100">
+            {% if template_region.is_empty() %}<em>n/a</em>{% else %}{{ template_region }}{% endif %}
+          </span>
+        </p>
+        {% if let Some(error) = template_error %}
+        <p class="text-sm text-red-600 dark:text-red-400">
+          <span class="mr-1 inline-flex align-middle">{% include "icons/alert_triangle.svg" %}</span>
+          {{ error }}
+        </p>
+        {% endif %}
+      </div>
+
+      <!-- Stats grid -->
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 p-6">
+        <div class="border border-zinc-200 dark:border-zinc-800 rounded p-4 bg-zinc-50 dark:bg-zinc-800">
+          <p class="text-xs uppercase text-zinc-500 dark:text-zinc-400">Buckets</p>
+          <p class="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">
+            {{ template_bucket_count }}
+          </p>
+        </div>
+        <div class="border border-zinc-200 dark:border-zinc-800 rounded p-4 bg-zinc-50 dark:bg-zinc-800">
+          <p class="text-xs uppercase text-zinc-500 dark:text-zinc-400">Total Files</p>
+          <p class="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">
+            {{ template_object_count }}
+          </p>
+        </div>
+        <div class="border border-zinc-200 dark:border-zinc-800 rounded p-4 bg-zinc-50 dark:bg-zinc-800">
+          <p class="text-xs uppercase text-zinc-500 dark:text-zinc-400">Total Size</p>
+          <p class="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">
+            {{ template_total_size|byte_format }}
+          </p>
+        </div>
+        <div class="border border-zinc-200 dark:border-zinc-800 rounded p-4 bg-zinc-50 dark:bg-zinc-800">
+          <p class="text-xs uppercase text-zinc-500 dark:text-zinc-400">Free Space</p>
+          {% if let Some(free) = template_disk_free %}
+          <p class="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">
+            {{ free|byte_format }}
+          </p>
+          {% if let Some(total) = template_disk_total %}
+          <p class="text-xs text-zinc-500 dark:text-zinc-400">
+            of {{ total|byte_format }} total
+          </p>
+          {% endif %}
+          {% if let Some(path) = template_data_path %}
+          <p class="text-xs text-zinc-500 dark:text-zinc-400 truncate" title="{{ path }}">
+            {{ path }}
+          </p>
+          {% endif %}
+          {% else %}
+          <p class="text-2xl font-semibold text-zinc-500 dark:text-zinc-400">N/A</p>
+          <p class="text-xs text-zinc-500 dark:text-zinc-400">
+            Set MK_GARAGE_DATA_PATH to enable
+          </p>
+          {% endif %}
+        </div>
+      </div>
+
+      <!-- Bucket summary -->
+      <div class="border-t border-zinc-200 dark:border-zinc-800 p-6">
+        <h2 class="text-lg font-semibold mb-3 text-zinc-900 dark:text-zinc-100">
+          Buckets
+        </h2>
+
+        <div class="overflow-x-auto">
+          <table class="min-w-full border border-zinc-200 dark:border-zinc-800 text-sm text-zinc-700 dark:text-zinc-300">
+            <thead class="bg-zinc-50 dark:bg-zinc-800">
+              <tr class="text-left font-semibold text-zinc-700 dark:text-zinc-200">
+                <th class="px-3 py-2">Name</th>
+                <th class="px-3 py-2 text-right">Objects</th>
+                <th class="px-3 py-2 text-right">Size</th>
+                <th class="px-3 py-2 text-center">Browse</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-zinc-200 dark:divide-zinc-800">
+              {% for bucket in template_buckets %}
+              <tr class="hover:bg-zinc-50 dark:hover:bg-zinc-800{% if template_browse_active && bucket.name.as_str() == template_selected_bucket.as_str() %} bg-indigo-50 dark:bg-indigo-900/30{% endif %}">
+                <td class="px-3 py-2 font-medium text-zinc-900 dark:text-zinc-100">{{ bucket.name }}</td>
+                <td class="px-3 py-2 text-right">{{ bucket.object_count }}</td>
+                <td class="px-3 py-2 text-right">{{ bucket.total_size|byte_format }}</td>
+                <td class="px-3 py-2 text-center">
+                  <a href="/admin/s3?bucket={{ bucket.name|space_to_html }}"
+                     class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300"
+                     aria-label="Browse bucket {{ bucket.name }}">
+                    Browse
+                  </a>
+                </td>
+              </tr>
+              {% endfor %}
+              {% if template_buckets.is_empty() %}
+              <tr>
+                <td colspan="4" class="px-3 py-4 text-center text-zinc-500 dark:text-zinc-400">
+                  No buckets found.
+                </td>
+              </tr>
+              {% endif %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Browser -->
+      {% if template_browse_active %}
+      <div class="border-t border-zinc-200 dark:border-zinc-800 p-6">
+        <h2 class="text-lg font-semibold mb-3 text-zinc-900 dark:text-zinc-100">
+          Browsing: {{ template_selected_bucket }}
+        </h2>
+
+        <!-- Breadcrumbs -->
+        <nav class="text-sm mb-3 flex flex-wrap items-center gap-1 text-zinc-600 dark:text-zinc-400">
+          <a href="/admin/s3?bucket={{ template_selected_bucket|space_to_html }}"
+             class="hover:text-indigo-600 dark:hover:text-indigo-400">
+            (root)
+          </a>
+          {% for crumb in template_breadcrumbs %}
+          <span class="text-zinc-400">/</span>
+          <a href="/admin/s3?bucket={{ template_selected_bucket|space_to_html }}&prefix={{ crumb.prefix|space_to_html }}"
+             class="hover:text-indigo-600 dark:hover:text-indigo-400">
+            {{ crumb.label }}
+          </a>
+          {% endfor %}
+        </nav>
+
+        <div class="overflow-x-auto">
+          <table class="min-w-full border border-zinc-200 dark:border-zinc-800 text-sm text-zinc-700 dark:text-zinc-300">
+            <thead class="bg-zinc-50 dark:bg-zinc-800">
+              <tr class="text-left font-semibold text-zinc-700 dark:text-zinc-200">
+                <th class="px-3 py-2">Name</th>
+                <th class="px-3 py-2 text-right">Size</th>
+                <th class="px-3 py-2">Last Modified</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-zinc-200 dark:divide-zinc-800">
+              {% for folder in template_folders %}
+              <tr class="hover:bg-zinc-50 dark:hover:bg-zinc-800">
+                <td class="px-3 py-2">
+                  <a href="/admin/s3?bucket={{ template_selected_bucket|space_to_html }}&prefix={{ folder.prefix|space_to_html }}"
+                     class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300">
+                    <span class="mr-1">&#128193;</span>{{ folder.name }}/
+                  </a>
+                </td>
+                <td class="px-3 py-2 text-right text-zinc-400">&mdash;</td>
+                <td class="px-3 py-2 text-zinc-400">&mdash;</td>
+              </tr>
+              {% endfor %}
+              {% for object in template_objects %}
+              <tr class="hover:bg-zinc-50 dark:hover:bg-zinc-800">
+                <td class="px-3 py-2">
+                  <span class="mr-1">&#128196;</span>{{ object.name }}
+                </td>
+                <td class="px-3 py-2 text-right">{{ object.size|byte_format }}</td>
+                <td class="px-3 py-2">{{ object.last_modified }}</td>
+              </tr>
+              {% endfor %}
+              {% if template_folders.is_empty() && template_objects.is_empty() %}
+              <tr>
+                <td colspan="3" class="px-3 py-4 text-center text-zinc-500 dark:text-zinc-400">
+                  No objects under this prefix.
+                </td>
+              </tr>
+              {% endif %}
+            </tbody>
+          </table>
+        </div>
+
+        {% if template_truncated %}
+        <p class="mt-2 text-xs text-zinc-500 dark:text-zinc-400">
+          Listing truncated at 1000 entries; refine the prefix to drill in further.
+        </p>
+        {% endif %}
+      </div>
+      {% endif %}
+
+    </section>
+
+  </main>
+  </div>
+</div>
+
+{% include "bss_public/bss_public_footer.html" %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
This PR adds a new S3 object storage administration interface to the MediaKraken admin panel, allowing administrators to view and browse S3 buckets and objects stored in a Garage or AWS-compatible S3 backend.

## Key Changes
- **New S3 Admin Module** (`bp_s3.rs`): Implements the S3 admin interface with the following features:
  - Gathers bucket summaries including object counts and total storage size
  - Browses bucket contents with folder/object listing
  - Supports prefix-based navigation with breadcrumb trails
  - Reads disk statistics from the configured data path
  - Includes input sanitization for bucket names and prefixes to prevent path traversal attacks
  - Requires `Admin::View` permission for access

- **S3 Client Configuration**: 
  - Reads S3 endpoint from `MK_GARAGE_S3_ENDPOINT` or `AWS_ENDPOINT_URL` environment variables
  - Reads region from `AWS_REGION` (defaults to "garage")
  - Supports force path-style URLs for Garage compatibility

- **New Admin Template** (`bss_admin_s3.html`): 
  - Displays S3 endpoint and region information
  - Shows statistics grid with bucket count, total files, total size, and free disk space
  - Renders bucket summary table with browse links
  - Implements bucket browser with folder/file listing and breadcrumb navigation
  - Handles truncated listings (1000 entry limit) with user notification

- **Admin Menu Integration**: Added S3 link to the admin menu sidebar

- **Dependencies**: Added AWS SDK dependencies (`aws-config` and `aws-sdk-s3`)

## Implementation Details
- Uses AWS SDK for Rust with async/await for S3 operations
- Implements pagination for large bucket listings
- Sanitizes user inputs to prevent injection attacks and path traversal
- Gracefully handles S3 connection errors with user-friendly error messages
- Uses `libc::statvfs` for accurate disk space reporting
- Formats file sizes and timestamps for human-readable display

https://claude.ai/code/session_01WAHHdxF9fL52qugptEobRC