### PR TITLE
Refactor S3 upload to use shared mk_lib_file utility

### DIFF
--- a/docker/core/mkopenlibrarynetfetchbulk/Cargo.toml
+++ b/docker/core/mkopenlibrarynetfetchbulk/Cargo.toml
@@ -18,6 +18,7 @@ codegen-units = 1
 [dependencies]
 mk_lib_compression = { version = "0.0.207", registry = "kellnr" }
 mk_lib_database = { version = "0.0.240", registry = "kellnr" }
+mk_lib_file = { version = "0.0.217", registry = "kellnr", features = ["s3"] }
 mk_lib_logging = { version = "0.0.209", registry = "kellnr" }
 mk_lib_network = { version = "0.0.210", registry = "kellnr" }
 mk_lib_rabbitmq = { version = "0.0.212", registry = "kellnr" }
@@ -26,7 +27,6 @@ anyhow = "1.0.102"
 async-compression = { version = "0.4.40", features = ["tokio", "gzip"] }
 aws-config = "1.8.8"
 aws-sdk-s3 = "1.119.0"
-bytes = "1.10.1"
 chrono = { version = "0.4.43", features = ["serde"] }
 flate2 = "1.1.9"
 futures = "0.3.32"

--- a/docker/core/mkopenlibrarynetfetchbulk/src/main.rs
+++ b/docker/core/mkopenlibrarynetfetchbulk/src/main.rs
@@ -1,8 +1,8 @@
 use async_compression::tokio::bufread::GzipDecoder;
 use aws_config::BehaviorVersion;
-use aws_sdk_s3::{Client as S3Client, config::Builder as S3ConfigBuilder, primitives::ByteStream};
-use bytes::Bytes;
+use aws_sdk_s3::{Client as S3Client, config::Builder as S3ConfigBuilder};
 use futures::StreamExt;
+use mk_lib_file::mk_lib_file_s3_garage::mk_lib_file_s3_garage_add;
 use serde::Deserialize;
 use serde_json::{Value, json};
 use sqlx::{Pool, Postgres};
@@ -174,13 +174,13 @@ async fn run_bulk_cover_archive_upload(options: BulkImageCoverLoadOptions) -> an
             let payload_len = payload.len();
             let object_key = format!("{}/{}", upload_s3_prefix, file_name);
 
-            rt.block_on(upload_s3_object(
-                s3_client.clone(),
+            rt.block_on(mk_lib_file_s3_garage_add(
+                &s3_client,
                 &upload_bucket,
                 &object_key,
                 payload,
-                content_type,
-            ))?;
+            ))
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
             uploaded_count += 1;
 
             if add_json {
@@ -192,13 +192,13 @@ async fn run_bulk_cover_archive_upload(options: BulkImageCoverLoadOptions) -> an
                     "size_bytes": payload_len,
                     "content_type": content_type
                 });
-                rt.block_on(upload_s3_object(
-                    s3_client.clone(),
+                rt.block_on(mk_lib_file_s3_garage_add(
+                    &s3_client,
                     &upload_bucket,
                     &json_key,
                     serde_json::to_vec(&metadata)?,
-                    "application/json",
-                ))?;
+                ))
+                .map_err(|e| anyhow::anyhow!(e.to_string()))?;
             }
         }
         Ok(uploaded_count)
@@ -209,24 +209,6 @@ async fn run_bulk_cover_archive_upload(options: BulkImageCoverLoadOptions) -> an
         "✅ Uploaded {} cover images to s3://{}/{}",
         uploaded, bucket, s3_prefix
     );
-    Ok(())
-}
-
-async fn upload_s3_object(
-    client: S3Client,
-    bucket: &str,
-    key: &str,
-    payload: Vec<u8>,
-    content_type: &str,
-) -> anyhow::Result<()> {
-    client
-        .put_object()
-        .bucket(bucket)
-        .key(key)
-        .content_type(content_type)
-        .body(ByteStream::from(Bytes::from(payload)))
-        .send()
-        .await?;
     Ok(())
 }
 

--- a/docker/core/mkopenlibrarynetfetchbulk/src/main.rs
+++ b/docker/core/mkopenlibrarynetfetchbulk/src/main.rs
@@ -179,6 +179,7 @@ async fn run_bulk_cover_archive_upload(options: BulkImageCoverLoadOptions) -> an
                 &upload_bucket,
                 &object_key,
                 payload,
+                Some(content_type),
             ))
             .map_err(|e| anyhow::anyhow!(e.to_string()))?;
             uploaded_count += 1;
@@ -197,6 +198,7 @@ async fn run_bulk_cover_archive_upload(options: BulkImageCoverLoadOptions) -> an
                     &upload_bucket,
                     &json_key,
                     serde_json::to_vec(&metadata)?,
+                    Some("application/json"),
                 ))
                 .map_err(|e| anyhow::anyhow!(e.to_string()))?;
             }

--- a/src/mk_lib_file/src/mk_lib_file_s3_garage.rs
+++ b/src/mk_lib_file/src/mk_lib_file_s3_garage.rs
@@ -33,19 +33,20 @@ pub async fn mk_lib_file_s3_garage_client(
 }
 
 /// Add a new object to the bucket.
+///
+/// `content_type` is forwarded as the object's MIME type when `Some`.
 pub async fn mk_lib_file_s3_garage_add(
     client: &S3Client,
     bucket: &str,
     key: &str,
     body: Vec<u8>,
+    content_type: Option<&str>,
 ) -> Result<(), Box<dyn Error>> {
-    client
-        .put_object()
-        .bucket(bucket)
-        .key(key)
-        .body(ByteStream::from(body))
-        .send()
-        .await?;
+    let mut request = client.put_object().bucket(bucket).key(key);
+    if let Some(ct) = content_type {
+        request = request.content_type(ct);
+    }
+    request.body(ByteStream::from(body)).send().await?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
Consolidate S3 object upload logic by replacing the local `upload_s3_object` function with the shared `mk_lib_file_s3_garage_add` utility function from the `mk_lib_file` library.

## Key Changes
- Removed the local `upload_s3_object` async function from `mkopenlibrarynetfetchbulk/src/main.rs`
- Updated all S3 upload calls to use `mk_lib_file_s3_garage_add` instead
- Modified `mk_lib_file_s3_garage_add` to accept an optional `content_type` parameter, allowing callers to specify MIME types when needed
- Updated function calls to pass `Some(content_type)` for content type specification
- Added `mk_lib_file` dependency with the `s3` feature to `mkopenlibrarynetfetchbulk/Cargo.toml`
- Removed unused `bytes` and `ByteStream` imports from `mkopenlibrarynetfetchbulk`

## Implementation Details
- The `mk_lib_file_s3_garage_add` function now conditionally sets the content type on the S3 request only when provided
- Error handling updated to use `.map_err()` to convert the boxed error to an `anyhow::anyhow!` error
- S3 client is now passed by reference (`&s3_client`) instead of being cloned, improving efficiency

https://claude.ai/code/session_01EJZkEmQzHrhkmqnKysBbxK