### PR TITLE
Fix admin library Browse button to reliably trigger share directory fetch

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
@@ -87,7 +87,7 @@
                   </select>
                   <button
                     type="button"
-                    @click="openDirectoryPicker($event, '{{ row_data.mm_network_share_guid }}')"
+                    @click.prevent.stop="openDirectoryPicker($el.form, '{{ row_data.mm_network_share_guid }}')"
                     aria-label="Browse share directory"
                     class="bg-zinc-700 text-white px-3 py-1 rounded hover:bg-zinc-800 dark:bg-zinc-700 dark:hover:bg-zinc-600 whitespace-nowrap shrink-0 font-medium">
                     Browse
@@ -279,8 +279,7 @@ function libraryPage() {
       this.showDelete = true
     },
 
-    openDirectoryPicker(event, shareGuid) {
-      const form = event.currentTarget.closest('form')
+    openDirectoryPicker(form, shareGuid) {
       this.activeSubdirectoryInput = form?.querySelector('input[name=\"subdirectory\"]') ?? null
       this.browserShareGuid = shareGuid
       this.showShareBrowser = true


### PR DESCRIPTION
### Motivation
- Clicking the Browse button sometimes failed to open the share directory browser because the handler relied on the click `event` and form submission behavior could interfere with resolving the target form and subdirectory input.

### Description
- Change the Browse button binding to use Alpine’s `.prevent.stop` and pass the owning form via `$el.form` in the template `docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html` so the action is isolated from form submission behavior.
- Update the `openDirectoryPicker` handler to accept a `form` argument instead of an `event`, and resolve the `subdirectory` input from that `form` for deterministic behavior.

### Testing
- Ran `cd docker/core/mkwebaxum && cargo check`, which could not complete in this environment due to an external crate registry returning HTTP 403 and not due to the template change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d1095d6c832187bfc661053dae08)