### PR TITLE
Refactor directory picker to find form context dynamically

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
@@ -87,7 +87,7 @@
                   </select>
                   <button
                     type="button"
-                    @click.prevent.stop="openDirectoryPicker($el.form, '{{ row_data.mm_network_share_guid }}')"
+                    @click.prevent.stop="openDirectoryPicker('{{ row_data.mm_network_share_guid }}')"
                     aria-label="Browse share directory"
                     class="bg-zinc-700 text-white px-3 py-1 rounded hover:bg-zinc-800 dark:bg-zinc-700 dark:hover:bg-zinc-600 whitespace-nowrap shrink-0 font-medium">
                     Browse
@@ -257,7 +257,6 @@ function libraryPage() {
     showDelete: false,
     showShareBrowser: false,
     selectedGuid: null,
-    activeSubdirectoryInput: null,
     browserShareGuid: '',
     browserCurrentPath: '',
     browserParentPath: null,
@@ -279,8 +278,7 @@ function libraryPage() {
       this.showDelete = true
     },
 
-    openDirectoryPicker(form, shareGuid) {
-      this.activeSubdirectoryInput = form?.querySelector('input[name=\"subdirectory\"]') ?? null
+    openDirectoryPicker(shareGuid) {
       this.browserShareGuid = shareGuid
       this.showShareBrowser = true
       this.loadDirectories('')
@@ -326,8 +324,12 @@ function libraryPage() {
       const selectedPath = this.browserCurrentPath
         ? `${this.browserCurrentPath}/${dirName}`
         : dirName
-      if (this.activeSubdirectoryInput) {
-        this.activeSubdirectoryInput.value = selectedPath
+      const hiddenInput = document.querySelector(
+        `input[name="share_guid"][value="${this.browserShareGuid}"]`
+      )
+      const subdirInput = hiddenInput?.closest('form')?.querySelector('input[name="subdirectory"]')
+      if (subdirInput) {
+        subdirInput.value = selectedPath
       }
       this.showShareBrowser = false
     },


### PR DESCRIPTION
## Summary
Refactored the directory picker functionality to eliminate the need for passing form references and instead dynamically locate the target form when a directory is selected.

## Key Changes
- **Simplified `openDirectoryPicker()` method**: Removed the `form` parameter and `activeSubdirectoryInput` instance variable that stored a reference to the form's subdirectory input field
- **Updated button click handler**: Changed from `openDirectoryPicker($el.form, '{{ row_data.mm_network_share_guid }}')` to `openDirectoryPicker('{{ row_data.mm_network_share_guid }}')`
- **Dynamic form lookup in `selectDirectory()`**: Replaced stored form reference with DOM query logic that:
  - Finds the hidden input with the matching `share_guid` value
  - Traverses up to the closest form element
  - Queries for the subdirectory input within that form context

## Implementation Details
This change improves code maintainability by removing implicit dependencies on form structure passed through method parameters. The form context is now determined at the point of selection rather than at picker initialization, making the code more resilient to DOM structure changes and reducing the coupling between the button handler and the picker logic.

https://claude.ai/code/session_01PfjQnRzKhJCmGLhGUAAkb7