### PR TITLE
Fix admin library Browse button to fire share directory fetch

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
@@ -87,7 +87,8 @@
                   </select>
                   <button
                     type="button"
-                    @click.prevent.stop="openDirectoryPicker('{{ row_data.mm_network_share_guid }}')"
+                    data-share-guid="{{ row_data.mm_network_share_guid }}"
+                    onclick="window.mkOpenShareBrowser(this); return false;"
                     aria-label="Browse share directory"
                     class="bg-zinc-700 text-white px-3 py-1 rounded hover:bg-zinc-800 dark:bg-zinc-700 dark:hover:bg-zinc-600 whitespace-nowrap shrink-0 font-medium">
                     Browse
@@ -251,6 +252,25 @@
 
 {% include "bss_public/bss_public_footer.html" %}
  <script>
+window.mkOpenShareBrowser = function(button) {
+  const shareGuid = button && button.dataset ? button.dataset.shareGuid : ''
+  if (!shareGuid) {
+    console.error('mkOpenShareBrowser: missing share guid on button', button)
+    return
+  }
+  const root = document.querySelector('main[x-data]')
+  if (!root || !window.Alpine || typeof window.Alpine.$data !== 'function') {
+    console.error('mkOpenShareBrowser: Alpine not ready')
+    return
+  }
+  const data = window.Alpine.$data(root)
+  if (!data || typeof data.openDirectoryPicker !== 'function') {
+    console.error('mkOpenShareBrowser: openDirectoryPicker not available on Alpine scope')
+    return
+  }
+  data.openDirectoryPicker(shareGuid)
+}
+
 function libraryPage() {
   return {
     showEdit: false,


### PR DESCRIPTION
## Summary
- The Browse button in the admin library page was not triggering `admin_library_share_directories` even though hitting the route directly via the URL worked.
- Replaced the Alpine `@click` directive with a vanilla `onclick` bridge that reads the share guid from a `data-share-guid` attribute and dispatches into the Alpine scope via `Alpine.$data`, decoupling the click trigger from Alpine directive evaluation.
- Dropped the `$el.form` form-passing indirection; on directory selection the target form is now located by querying the hidden `share_guid` input.
- Added explicit `console.error` diagnostics for the three failure modes (missing guid, Alpine not ready, missing scope method) so future regressions are easy to spot in devtools.

## Test plan
- [ ] Load `/admin/library` as an admin with at least one configured share.
- [ ] Click Browse on a share row and confirm the share directory modal opens.
- [ ] Confirm a `GET /admin/library/share_directories?share_guid=…&path=` request fires and the Loki log entry for `admin_library_share_directories` appears.
- [ ] Navigate into a subdirectory and back via "Up One Level".
- [ ] Click Select on a directory and confirm the correct row's `subdirectory` input is populated.
- [ ] Submit the form (Add) and confirm the library entry is created with the chosen path.

https://claude.ai/code/session_01PfjQnRzKhJCmGLhGUAAkb7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfjQnRzKhJCmGLhGUAAkb7)_