### PR TITLE
Fix smbclient share URI for forward-slash UNC paths in browse handler

### DIFF
--- a/docker/core/mkwebaxum/src/admin/bp_library.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_library.rs
@@ -394,11 +394,17 @@ pub async fn admin_library_share_directories(
         );
     }
 
-    let trimmed_share_path = share_info.mm_network_share_path.trim_matches('/');
-    let share_name = trimmed_share_path
-        .rsplit_once('\\')
-        .map(|(_, name)| name)
-        .unwrap_or(trimmed_share_path);
+    let share_name = match mk_lib_database::mk_lib_database_network_share::parse_share_name(
+        &share_info.mm_network_share_path,
+    ) {
+        Some(name) => name,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "Share path is not a valid UNC path"})),
+            );
+        }
+    };
     let share_uri = format!("//{}/{}", share_info.mm_network_share_ip, share_name);
 
     if let Err(error) = mk_lib_logging::mk_lib_logging_loki::mk_logging_loki_push(json!({

--- a/src/mk_lib_database/src/mk_lib_database_network_share.rs
+++ b/src/mk_lib_database/src/mk_lib_database_network_share.rs
@@ -19,7 +19,7 @@ fn share_auth_key() -> String {
 /// `mm_network_share_ip` — and any deeper subpath is dropped, so only the
 /// share name itself is returned. A bare `share` with no UNC prefix is also
 /// accepted and returned unchanged.
-fn parse_share_name(network_share_path: &str) -> Option<String> {
+pub fn parse_share_name(network_share_path: &str) -> Option<String> {
     let normalized = network_share_path.replace('\\', "/");
     let had_unc_prefix = normalized.starts_with("//");
     let mut segments = normalized.split('/').filter(|s| !s.is_empty());


### PR DESCRIPTION
## Summary
- Fixes the empty share directory listing observed after the Browse button started firing in #292.
- The browse handler extracted the share name with `rsplit_once('\\')`, which silently fell through to the trimmed full path when the stored `mm_network_share_path` used forward-slash UNC (e.g. `//host/share`). That produced share URIs like `//host/host/share`, so smbclient connected to a non-existent share and returned an empty listing.
- Reuse the existing `parse_share_name` helper, which already handles both `\\host\share` and `//host/share` formats and is covered by tests. Made it `pub` so the webaxum crate can call it; surfaces a 400 if the stored path isn't a valid UNC path.

## Test plan
- [ ] On a share whose `mm_network_share_path` is stored as `//host/share`, click Browse and confirm directories now populate.
- [ ] On a share stored as `\\host\share`, confirm browse still works (no regression).
- [ ] Confirm a malformed share path returns a 400 with `Share path is not a valid UNC path` instead of silently producing an empty listing.

https://claude.ai/code/session_01PfjQnRzKhJCmGLhGUAAkb7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfjQnRzKhJCmGLhGUAAkb7)_