### PR TITLE
Remove guest user check in SMB share authentication

### DIFF
--- a/docker/core/mkwebaxum/src/admin/bp_library.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_library.rs
@@ -440,9 +440,7 @@ pub async fn admin_library_share_directories(
             smb_command.arg("-W").arg(workgroup);
         }
     }
-    if let Some(user) = share_info.mm_share_auth_user.as_deref()
-        && user != "guest"
-    {
+    if let Some(user) = share_info.mm_share_auth_user.as_deref() {
         let pass = share_info
             .mm_share_auth_password
             .as_deref()


### PR DESCRIPTION
## Summary
Simplified the SMB share authentication logic by removing an unnecessary guest user check that was preventing authentication credentials from being applied.

## Changes
- Removed the `&& user != "guest"` condition from the authentication user check in `admin_library_share_directories`
- This allows authentication credentials to be processed for all non-null users, including the "guest" user if explicitly configured

## Details
The previous logic would skip password authentication when the configured user was "guest". This change removes that special case, allowing the authentication flow to proceed uniformly for all configured users. This is likely a bug fix that enables proper credential handling in scenarios where "guest" authentication is explicitly configured.

https://claude.ai/code/session_019tkYQTWCFitfPzV7HJBctt