### PR TITLE
Fix admin share browse for anonymous/guest shares

### DIFF
--- a/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
+++ b/docker/core/mkwebaxum/templates/bss_admin/bss_admin_library.html
@@ -55,6 +55,11 @@
               <td class="px-3 py-2">
                 <select class="border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 rounded px-2 py-1 w-full">
                   <optgroup label="Auth user group">
+                    <option
+                      value=""
+                      {% if row_data.mm_share_auth_user.is_none() %}selected{% endif %}>
+                      Anonymous
+                    </option>
                     {% for auth_row in template_data_share_user %}
                       <option
                         value="{{ auth_row.mm_share_auth_guid }}"


### PR DESCRIPTION
## Summary
- Drop the `user != "guest"` exception in `admin_library_share_directories` so a stored guest user is passed via `-U guest%pass` instead of falling through to `-N`. Many Samba servers refuse to disclose share names to anonymous clients and reject the tree-connect with `NT_STATUS_BAD_NETWORK_NAME`, which the classifier surfaced as "Share path was not found".
- Add an explicit "Anonymous" option (empty value) at the top of the share auth user `<select>` on the admin library page, selected when `mm_share_auth_user` is `None`. The display now matches the handler's actual behavior (`-N` when no auth user is assigned).

## Test plan
- [ ] Browse a share whose `mm_share_auth` row has user `guest` (any password) — directory listing succeeds against a Samba server that requires guest creds.
- [ ] Browse a share with `mm_network_share_user_guid = NULL` — handler still uses `-N`, listing succeeds against an open share.
- [ ] Open `/admin/library` with at least one share that has no auth user assigned — dropdown shows "Anonymous" selected.
- [ ] Open `/admin/library` with a share that has an auth user assigned — dropdown shows that user selected, "Anonymous" present but unselected.

Note: the auth user `<select>` still does not persist changes (no `name`/`onchange`/form). That's a separate follow-up.

https://claude.ai/code/session_019tkYQTWCFitfPzV7HJBctt

---
_Generated by [Claude Code](https://claude.ai/code/session_019tkYQTWCFitfPzV7HJBctt)_