### PR TITLE
Handle IP-prefixed paths in network share name parsing

### DIFF
--- a/src/mk_lib_database/src/mk_lib_database_network_share.rs
+++ b/src/mk_lib_database/src/mk_lib_database_network_share.rs
@@ -19,6 +19,10 @@ fn share_auth_key() -> String {
 /// `mm_network_share_ip` — and any deeper subpath is dropped, so only the
 /// share name itself is returned. A bare `share` with no UNC prefix is also
 /// accepted and returned unchanged.
+///
+/// IP-address-shaped values are rejected: when smb-enum-shares cannot
+/// enumerate anonymously it can surface a host-keyed entry, which would
+/// otherwise produce a `//host/host` URI when browsing.
 pub fn parse_share_name(network_share_path: &str) -> Option<String> {
     let normalized = network_share_path.replace('\\', "/");
     let had_unc_prefix = normalized.starts_with("//");
@@ -26,7 +30,11 @@ pub fn parse_share_name(network_share_path: &str) -> Option<String> {
     if had_unc_prefix {
         segments.next()?;
     }
-    segments.next().map(str::to_owned)
+    let candidate = segments.next()?.to_owned();
+    if candidate.parse::<std::net::IpAddr>().is_ok() {
+        return None;
+    }
+    Some(candidate)
 }
 
 pub async fn mk_lib_database_network_share_exists(
@@ -244,5 +252,12 @@ mod tests {
     fn unc_without_share_segment_returns_none() {
         assert!(parse_share_name(r"\\host").is_none());
         assert!(parse_share_name("//host").is_none());
+    }
+
+    #[test]
+    fn bare_ip_is_rejected() {
+        assert!(parse_share_name("192.168.1.122").is_none());
+        assert!(parse_share_name("10.0.0.1").is_none());
+        assert!(parse_share_name("::1").is_none());
     }
 }

--- a/src/mk_lib_database/src/mk_lib_database_network_share.rs
+++ b/src/mk_lib_database/src/mk_lib_database_network_share.rs
@@ -20,15 +20,20 @@ fn share_auth_key() -> String {
 /// share name itself is returned. A bare `share` with no UNC prefix is also
 /// accepted and returned unchanged.
 ///
-/// IP-address-shaped values are rejected: when smb-enum-shares cannot
-/// enumerate anonymously it can surface a host-keyed entry, which would
-/// otherwise produce a `//host/host` URI when browsing.
+/// Paths missing the UNC prefix but starting with an IP (e.g.
+/// `192.168.1.122\testshare`) are also handled by stripping the leading
+/// IP segment; otherwise the browse handler ends up with a `//host/host`
+/// URI. Bare IP values with no share segment are rejected.
 pub fn parse_share_name(network_share_path: &str) -> Option<String> {
     let normalized = network_share_path.replace('\\', "/");
     let had_unc_prefix = normalized.starts_with("//");
-    let mut segments = normalized.split('/').filter(|s| !s.is_empty());
+    let mut segments = normalized.split('/').filter(|s| !s.is_empty()).peekable();
     if had_unc_prefix {
         segments.next()?;
+    } else if let Some(first) = segments.peek() {
+        if first.parse::<std::net::IpAddr>().is_ok() {
+            segments.next();
+        }
     }
     let candidate = segments.next()?.to_owned();
     if candidate.parse::<std::net::IpAddr>().is_ok() {
@@ -259,5 +264,21 @@ mod tests {
         assert!(parse_share_name("192.168.1.122").is_none());
         assert!(parse_share_name("10.0.0.1").is_none());
         assert!(parse_share_name("::1").is_none());
+    }
+
+    #[test]
+    fn ip_prefixed_path_without_unc_strips_host() {
+        assert_eq!(
+            parse_share_name(r"192.168.1.122\testshare").as_deref(),
+            Some("testshare"),
+        );
+        assert_eq!(
+            parse_share_name("192.168.1.122/testshare").as_deref(),
+            Some("testshare"),
+        );
+        assert_eq!(
+            parse_share_name(r"192.168.1.122\testshare\sub").as_deref(),
+            Some("testshare"),
+        );
     }
 }


### PR DESCRIPTION
## Summary
Enhanced the `parse_share_name` function to properly handle network share paths that are prefixed with an IP address but lack the UNC (`//`) prefix. This prevents malformed URIs with duplicate host segments from being passed to the browse handler.

## Key Changes
- Modified `parse_share_name` to detect and strip leading IP address segments from non-UNC paths (e.g., `192.168.1.122\testshare` → `testshare`)
- Added validation to reject bare IP addresses with no share segment (e.g., `192.168.1.122` returns `None`)
- Converted segment iterator to peekable to allow lookahead without consuming elements
- Updated logic to explicitly validate that the extracted share name is not itself an IP address

## Implementation Details
- Uses `std::net::IpAddr::parse()` to detect IP addresses in path segments
- Handles both IPv4 and IPv6 address formats
- Maintains backward compatibility with existing UNC path handling and bare share names
- Added comprehensive test coverage for IP-prefixed paths and bare IP rejection

https://claude.ai/code/session_0117jHgcMqMWEjQPsf5tpdvm