### PR TITLE
Fix SMB directory parsing to handle whitespace in filenames

### DIFF
--- a/docker/core/mkwebaxum/src/admin/bp_library.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_library.rs
@@ -519,14 +519,38 @@ pub async fn admin_library_share_directories(
     let stdout_data = String::from_utf8_lossy(&smb_output.stdout);
     let mut directories = Vec::new();
     for line in stdout_data.lines() {
-        let parts: Vec<&str> = line.split('|').collect();
-        if parts.len() < 2 || parts[0] != "D" {
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
             continue;
         }
-        if parts[1] == "." || parts[1] == ".." {
+        // smbclient `ls` is column-formatted, not pipe-separated:
+        //   "  <name>  <attrs>  <size>  <Day Mon DD HH:MM:SS YYYY>"
+        // Date is exactly 5 whitespace tokens; size is 1 numeric token;
+        // attrs is 1 token of [DAHSRNV]; everything before that is the filename.
+        let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+        if tokens.len() < 8 {
             continue;
         }
-        directories.push(parts[1].to_string());
+        let n = tokens.len();
+        if tokens[n - 6].parse::<u64>().is_err() {
+            continue;
+        }
+        let attrs = tokens[n - 7];
+        if attrs.is_empty()
+            || !attrs
+                .chars()
+                .all(|c| matches!(c, 'D' | 'A' | 'H' | 'S' | 'R' | 'N' | 'V'))
+        {
+            continue;
+        }
+        if !attrs.contains('D') {
+            continue;
+        }
+        let filename = tokens[..n - 7].join(" ");
+        if filename == "." || filename == ".." {
+            continue;
+        }
+        directories.push(filename);
     }
     directories.sort_unstable();
 


### PR DESCRIPTION
## Summary
Updated the SMB directory listing parser to correctly handle the column-formatted output from `smbclient ls` instead of treating it as pipe-separated values. This fixes parsing failures when directory names contain spaces.

## Key Changes
- Changed parsing logic from pipe-delimited (`|`) to whitespace-delimited tokens
- Implemented proper column-format parsing by identifying fixed-position fields:
  - Size field (numeric, 6 tokens from end)
  - Attributes field (1 token from end, containing D/A/H/S/R/N/V characters)
  - Date field (exactly 5 whitespace tokens at the end)
  - Filename (all remaining tokens before the attributes field)
- Added validation to skip empty lines
- Added validation to ensure parsed size is a valid u64
- Added validation to ensure attributes field contains only valid characters
- Added validation to ensure only directories (with 'D' attribute) are included
- Properly reconstructs filenames with spaces by joining tokens

## Implementation Details
The parser now correctly identifies the structure of `smbclient ls` output:
```
  <name>  <attrs>  <size>  <Day Mon DD HH:MM:SS YYYY>
```
By working backwards from the end of each line, it reliably extracts the filename regardless of internal spaces, while validating that intermediate fields match expected formats.

https://claude.ai/code/session_015LaPNU8VrwEzfH3HctS57q