### PR TITLE
Refactor SMB directory parsing to use pipe-separated format

### DIFF
--- a/docker/core/mkwebaxum/src/admin/bp_library.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_library.rs
@@ -519,38 +519,20 @@ pub async fn admin_library_share_directories(
     let stdout_data = String::from_utf8_lossy(&smb_output.stdout);
     let mut directories = Vec::new();
     for line in stdout_data.lines() {
-        let trimmed = line.trim_end();
-        if trimmed.is_empty() {
+        // With `-g`, smbclient emits pipe-separated rows: `<type>|<name>|<size>|<date>`
+        // where <type> is `D` for directories and `F`/`H` for files.
+        let parts: Vec<&str> = line.split('|').collect();
+        if parts.len() < 2 {
             continue;
         }
-        // smbclient `ls` is column-formatted, not pipe-separated:
-        //   "  <name>  <attrs>  <size>  <Day Mon DD HH:MM:SS YYYY>"
-        // Date is exactly 5 whitespace tokens; size is 1 numeric token;
-        // attrs is 1 token of [DAHSRNV]; everything before that is the filename.
-        let tokens: Vec<&str> = trimmed.split_whitespace().collect();
-        if tokens.len() < 8 {
+        if parts[0] != "D" {
             continue;
         }
-        let n = tokens.len();
-        if tokens[n - 6].parse::<u64>().is_err() {
+        let filename = parts[1];
+        if filename.is_empty() || filename == "." || filename == ".." {
             continue;
         }
-        let attrs = tokens[n - 7];
-        if attrs.is_empty()
-            || !attrs
-                .chars()
-                .all(|c| matches!(c, 'D' | 'A' | 'H' | 'S' | 'R' | 'N' | 'V'))
-        {
-            continue;
-        }
-        if !attrs.contains('D') {
-            continue;
-        }
-        let filename = tokens[..n - 7].join(" ");
-        if filename == "." || filename == ".." {
-            continue;
-        }
-        directories.push(filename);
+        directories.push(filename.to_string());
     }
     directories.sort_unstable();
 


### PR DESCRIPTION
## Summary
Updated the SMB directory listing parser in `admin_library_share_directories` to use the pipe-separated output format from `smbclient -g` instead of parsing whitespace-delimited column output.

## Key Changes
- Changed from parsing whitespace-delimited columns to pipe-separated values (`|`)
- Simplified directory detection by checking for `D` type marker in the first field instead of parsing attributes
- Removed complex token-based parsing logic that was fragile with filenames containing spaces
- Reduced validation complexity by relying on the structured format provided by `smbclient -g`
- Improved robustness by filtering out empty filenames and special directory entries (`.` and `..`)

## Implementation Details
- The new format uses `smbclient -g` which emits rows as: `<type>|<name>|<size>|<date>`
- Type field contains `D` for directories, `F`/`H` for files
- Validation now checks:
  - Minimum 2 pipe-separated parts exist
  - First part equals `"D"` (directory type)
  - Filename is not empty and not `.` or `..`
- This approach is more maintainable and handles edge cases (like spaces in filenames) more gracefully

https://claude.ai/code/session_01DSvGSKuYYyh3dBAQqgnjxa