### PR TITLE
Fix SMB directory listing parsing for column-formatted output

### DIFF
--- a/docker/core/mkwebaxum/src/admin/bp_library.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_library.rs
@@ -111,6 +111,29 @@ fn classify_smbclient_browse_error(
     (StatusCode::BAD_GATEWAY, "Failed to list share directories")
 }
 
+// Matches the 24-byte ASCII output of samba's `time_to_asc()` /
+// `asctime`-style format: "Day Mon DD HH:MM:SS YYYY".
+fn is_smb_ls_date(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    if bytes.len() != 24 {
+        return false;
+    }
+    bytes[3] == b' '
+        && bytes[7] == b' '
+        && bytes[10] == b' '
+        && bytes[13] == b':'
+        && bytes[16] == b':'
+        && bytes[19] == b' '
+        && bytes[0..3].iter().all(|c| c.is_ascii_alphabetic())
+        && bytes[4..7].iter().all(|c| c.is_ascii_alphabetic())
+        && (bytes[8] == b' ' || bytes[8].is_ascii_digit())
+        && bytes[9].is_ascii_digit()
+        && bytes[11..13].iter().all(|c| c.is_ascii_digit())
+        && bytes[14..16].iter().all(|c| c.is_ascii_digit())
+        && bytes[17..19].iter().all(|c| c.is_ascii_digit())
+        && bytes[20..24].iter().all(|c| c.is_ascii_digit())
+}
+
 pub async fn admin_library(
     State(state): State<AppState>,
     method: Method,
@@ -522,7 +545,7 @@ pub async fn admin_library_share_directories(
         "message": "smbclient directory listing succeeded",
         "module": module_path!(),
         "function": "admin_library_share_directories",
-        "payload": {"stdout_len": stdout_data.len(), "stdout": &stdout_data},
+        "payload": {"stdout_len": stdout_data.len()},
     }))
     .await
     {
@@ -531,12 +554,15 @@ pub async fn admin_library_share_directories(
     let mut directories = Vec::new();
     for line in stdout_data.lines() {
         // smbclient's `ls` is column-formatted regardless of `-g` (the grepable
-        // flag only changes `-L` share-list output, not file listings):
-        //   "  <name>  <attrs>  <size>  <Day Mon DD HH:MM:SS YYYY>"
-        // The trailing 5 whitespace tokens are the date, the next is size, the
-        // next is the attrs ([DAHSRNV]), and everything before that is the
-        // filename. Some smbclient builds also emit pipe-separated rows
-        // (`<type>|<name>|<size>|<date>`); accept both shapes.
+        // flag only changes `-L` share-list output, not file listings). The
+        // emitting format string in samba's display_finfo() is:
+        //   "  %-30s%7.7s %8.0f  %s"
+        //  = 2 spaces, name padded to >=30 cols, 7-col attrs, " ",
+        //    8-col size, "  ", 24-col date "Day Mon DD HH:MM:SS YYYY".
+        // Some smbclient builds also emit pipe-separated rows
+        // (`<type>|<name>|<size>|<date>`); accept both shapes. Parse the
+        // column form by trimming fixed-width fields off the right so internal
+        // whitespace inside directory names is preserved verbatim.
         if let Some((type_field, rest)) = line.split_once('|') {
             if type_field == "D" {
                 let name = rest.split('|').next().unwrap_or_default();
@@ -546,19 +572,36 @@ pub async fn admin_library_share_directories(
                 }
             }
         }
-        let trimmed = line.trim_end();
-        if trimmed.is_empty() {
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        // 2 + 30 + 7 + 1 + 8 + 2 + 24 = 74 minimum bytes.
+        if trimmed.len() < 74 {
             continue;
         }
-        let tokens: Vec<&str> = trimmed.split_whitespace().collect();
-        if tokens.len() < 8 {
+        let date_start = trimmed.len() - 24;
+        if !is_smb_ls_date(&trimmed[date_start..]) {
             continue;
         }
-        let n = tokens.len();
-        if tokens[n - 6].parse::<u64>().is_err() {
+        let head = &trimmed[..date_start];
+        let head = match head.strip_suffix("  ") {
+            Some(rest) => rest,
+            None => continue,
+        };
+        if head.len() < 8 {
             continue;
         }
-        let attrs = tokens[n - 7];
+        let (head, size_field) = head.split_at(head.len() - 8);
+        if size_field.trim_start().parse::<u64>().is_err() {
+            continue;
+        }
+        let head = match head.strip_suffix(' ') {
+            Some(rest) => rest,
+            None => continue,
+        };
+        if head.len() < 7 {
+            continue;
+        }
+        let (head, attrs_field) = head.split_at(head.len() - 7);
+        let attrs = attrs_field.trim_start();
         if attrs.is_empty()
             || !attrs
                 .chars()
@@ -569,11 +612,19 @@ pub async fn admin_library_share_directories(
         if !attrs.contains('D') {
             continue;
         }
-        let filename = tokens[..n - 7].join(" ");
-        if filename == "." || filename == ".." {
+        let name_padded = match head.strip_prefix("  ") {
+            Some(rest) => rest,
+            None => continue,
+        };
+        // %-30s right-pads the name with spaces to fill its field; SMB names
+        // effectively cannot have trailing spaces (Windows strips them), so
+        // dropping trailing ASCII spaces recovers the real name without
+        // collapsing any internal whitespace.
+        let filename = name_padded.trim_end_matches(' ');
+        if filename.is_empty() || filename == "." || filename == ".." {
             continue;
         }
-        directories.push(filename);
+        directories.push(filename.to_string());
     }
     directories.sort_unstable();
     directories.dedup();

--- a/docker/core/mkwebaxum/src/admin/bp_library.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_library.rs
@@ -516,25 +516,67 @@ pub async fn admin_library_share_directories(
         );
     }
 
-    let stdout_data = String::from_utf8_lossy(&smb_output.stdout);
+    let stdout_data = String::from_utf8_lossy(&smb_output.stdout).to_string();
+    if let Err(error) = mk_lib_logging::mk_lib_logging_loki::mk_logging_loki_push(json!({
+        "level": "info",
+        "message": "smbclient directory listing succeeded",
+        "module": module_path!(),
+        "function": "admin_library_share_directories",
+        "payload": {"stdout_len": stdout_data.len(), "stdout": &stdout_data},
+    }))
+    .await
+    {
+        eprintln!("loki push error: {error}");
+    }
     let mut directories = Vec::new();
     for line in stdout_data.lines() {
-        // With `-g`, smbclient emits pipe-separated rows: `<type>|<name>|<size>|<date>`
-        // where <type> is `D` for directories and `F`/`H` for files.
-        let parts: Vec<&str> = line.split('|').collect();
-        if parts.len() < 2 {
+        // smbclient's `ls` is column-formatted regardless of `-g` (the grepable
+        // flag only changes `-L` share-list output, not file listings):
+        //   "  <name>  <attrs>  <size>  <Day Mon DD HH:MM:SS YYYY>"
+        // The trailing 5 whitespace tokens are the date, the next is size, the
+        // next is the attrs ([DAHSRNV]), and everything before that is the
+        // filename. Some smbclient builds also emit pipe-separated rows
+        // (`<type>|<name>|<size>|<date>`); accept both shapes.
+        if let Some((type_field, rest)) = line.split_once('|') {
+            if type_field == "D" {
+                let name = rest.split('|').next().unwrap_or_default();
+                if !name.is_empty() && name != "." && name != ".." {
+                    directories.push(name.to_string());
+                    continue;
+                }
+            }
+        }
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
             continue;
         }
-        if parts[0] != "D" {
+        let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+        if tokens.len() < 8 {
             continue;
         }
-        let filename = parts[1];
-        if filename.is_empty() || filename == "." || filename == ".." {
+        let n = tokens.len();
+        if tokens[n - 6].parse::<u64>().is_err() {
             continue;
         }
-        directories.push(filename.to_string());
+        let attrs = tokens[n - 7];
+        if attrs.is_empty()
+            || !attrs
+                .chars()
+                .all(|c| matches!(c, 'D' | 'A' | 'H' | 'S' | 'R' | 'N' | 'V'))
+        {
+            continue;
+        }
+        if !attrs.contains('D') {
+            continue;
+        }
+        let filename = tokens[..n - 7].join(" ");
+        if filename == "." || filename == ".." {
+            continue;
+        }
+        directories.push(filename);
     }
     directories.sort_unstable();
+    directories.dedup();
 
     let parent_path = cleaned_path
         .rsplit_once('/')


### PR DESCRIPTION
## Summary
Updated the SMB directory listing parser in `admin_library_share_directories` to correctly handle both pipe-separated and column-formatted output from smbclient, while adding logging and deduplication of results.

## Key Changes
- **Improved output parsing**: Replaced simple pipe-separated parsing with logic that handles both pipe-separated (`<type>|<name>|<size>|<date>`) and column-formatted output (the default smbclient format)
- **Column format support**: Added whitespace-tokenized parsing that validates file attributes and extracts filenames from the column-formatted output, accounting for multi-word filenames
- **Added logging**: Integrated Loki logging to track successful smbclient directory listing operations with output metadata
- **Result deduplication**: Added `dedup()` call to remove duplicate directory entries
- **Validation improvements**: Enhanced validation of file attributes (checking for valid characters: D, A, H, S, R, N, V) and proper token count before parsing

## Implementation Details
- The parser now attempts pipe-separated parsing first (for compatibility with some smbclient builds), then falls back to column-formatted parsing
- For column format, the code validates that the 6th token from the end is a valid size (u64) and the 7th token from the end contains only valid attribute characters
- Filenames are reconstructed by joining all tokens before the attributes field, supporting multi-word directory names
- Logging includes the stdout length and content for debugging purposes

https://claude.ai/code/session_01SfVwd49r5qmY5hueboKjXF