### PR TITLE
Fix smbclient recurse toggle breaking directory listing

### DIFF
--- a/docker/core/mkwebaxum/src/admin/bp_library.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_library.rs
@@ -456,8 +456,13 @@ pub async fn admin_library_share_directories(
     // directory at the share root and returning the same top-level listing
     // regardless of the requested subdirectory. `cd "path"` inside `-c`
     // matches the working pattern in mk_lib_smb::mk_file_smb_client_tree_smbclient.
-    let mut smb_commands: Vec<String> =
-        vec![String::from("recurse OFF"), String::from("prompt OFF")];
+    //
+    // Do NOT prepend `recurse OFF` / `prompt OFF`: in many smbclient builds
+    // `recurse` is a no-arg toggle that ignores trailing tokens, so
+    // `recurse OFF` actually flips recursion from OFF (the default) to ON.
+    // That makes `ls` enumerate every subdirectory in the share and surface
+    // them all in the picker regardless of the requested cwd.
+    let mut smb_commands: Vec<String> = Vec::new();
     if cleaned_path.is_empty() == false {
         smb_commands.push(format!("cd \"{}\"", cleaned_path));
     }


### PR DESCRIPTION
## Summary
Fixed a bug in the SMB library share directory listing where incorrect smbclient command initialization was causing recursive enumeration of all subdirectories instead of respecting the requested working directory.

## Key Changes
- Removed initialization of `recurse OFF` and `prompt OFF` commands from the smbclient command vector
- Added detailed comment explaining why these commands were problematic: in many smbclient builds, `recurse` is a no-arg toggle that ignores trailing tokens, so `recurse OFF` actually enables recursion instead of disabling it
- Changed `smb_commands` initialization from a pre-populated vector to an empty `Vec::new()`

## Implementation Details
The issue occurred because `recurse` in smbclient behaves as a toggle command that ignores arguments. When `recurse OFF` was passed, it toggled recursion from its default OFF state to ON, causing the `ls` command to enumerate every subdirectory in the share. This made all nested directories appear in the picker regardless of the requested current working directory (`cd` path).

By removing these problematic initialization commands and only adding the `cd` command when needed, the directory listing now correctly respects the requested subdirectory path.

https://claude.ai/code/session_01N4HL53iki2QdzUi7D3P5sM