### PR TITLE
Migrate mk_lib_file to mk_lib_share and refactor async I/O

### DIFF
--- a/docker/core/mkmediascanner/Cargo.toml
+++ b/docker/core/mkmediascanner/Cargo.toml
@@ -18,7 +18,6 @@ codegen-units = 1
 [dependencies]
 mk_lib_common = { version = "0.0.213", registry = "kellnr" }
 mk_lib_database = { version = "0.0.245", registry = "kellnr" }
-mk_lib_file = { version = "0.0.222", registry = "kellnr" }
 mk_lib_logging = { version = "0.0.214", registry = "kellnr" }
 mk_lib_rabbitmq = { version = "0.0.217", registry = "kellnr" }
 mk_lib_share = { version = "0.0.222", registry = "kellnr" }

--- a/docker/core/mkmediascanner/src/main.rs
+++ b/docker/core/mkmediascanner/src/main.rs
@@ -15,7 +15,7 @@ use mk_lib_common::mk_lib_common_media_extension::{
     GAME_EXTENSION, MEDIA_EXTENSION, MEDIA_EXTENSION_SKIP_FFMPEG, SUBTITLE_EXTENSION,
 };
 use mk_lib_database::mk_lib_database_network_share::{DBShareList, parse_share_name};
-use mk_lib_file::mk_lib_smb::File_Metadata;
+use mk_lib_share::mk_lib_smb::FileMetadata;
 use mk_lib_logging::mk_lib_logging_loki::mk_logging_loki_push;
 
 lazy_static! {
@@ -51,7 +51,7 @@ fn mk_nfs_uri(share_info: &DBShareList, uri: &str) -> String {
 async fn mk_nfs_tree(
     share_info: &DBShareList,
     uri: &str,
-) -> Result<Vec<File_Metadata>, Box<dyn Error>> {
+) -> Result<Vec<FileMetadata>, Box<dyn Error>> {
     let output = Command::new("nfs-ls")
         .arg("-R")
         .arg(mk_nfs_uri(share_info, uri))
@@ -84,7 +84,7 @@ async fn mk_nfs_tree(
         }
         let is_dir = relative.ends_with('/');
         let normalized = relative.trim_end_matches('/');
-        file_list.push(File_Metadata {
+        file_list.push(FileMetadata {
             name: format!("/{normalized}"),
             directory: is_dir,
         });
@@ -169,7 +169,7 @@ async fn mk_smb_probe(share_info: &DBShareList, path_on_share: &str) -> bool {
 async fn mk_smb_tree(
     share_info: &DBShareList,
     path_on_share: &str,
-) -> Result<Vec<File_Metadata>, Box<dyn Error>> {
+) -> Result<Vec<FileMetadata>, Box<dyn Error>> {
     let share_uri = mk_smb_share_uri(share_info)
         .ok_or_else(|| Box::<dyn Error>::from("invalid SMB share path"))?;
     let cleaned = path_on_share.trim_start_matches('/');
@@ -190,7 +190,7 @@ async fn mk_smb_tree(
     // error if we got nothing — otherwise a single permission glitch would
     // discard every discovery for the share.
     let stdout_data = String::from_utf8(output.stdout)?;
-    let mut file_list: Vec<File_Metadata> = vec![];
+    let mut file_list: Vec<FileMetadata> = vec![];
     for line in stdout_data.lines() {
         let parts: Vec<&str> = line.split('|').collect();
         if parts.len() < 2 {
@@ -209,7 +209,7 @@ async fn mk_smb_tree(
         } else {
             format!("{}/{}", path_on_share, parts[1])
         };
-        file_list.push(File_Metadata {
+        file_list.push(FileMetadata {
             name: path_value,
             directory: parts[0] == "D",
         });
@@ -520,7 +520,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             // recursive smbclient subprocess (matching mkwebaxum's working
             // share-browse pattern). If the SMB probe failed we use
             // `nfs-ls -R` instead.
-            let files: Vec<File_Metadata> = if smb_reachable {
+            let files: Vec<FileMetadata> = if smb_reachable {
                 match mk_smb_tree(&share_info, &path_on_share).await {
                     Ok(entries) => entries,
                     Err(cli_error) => {

--- a/docker/core/mkwebaxum/Cargo.toml
+++ b/docker/core/mkwebaxum/Cargo.toml
@@ -18,7 +18,6 @@ codegen-units = 1
 [dependencies]
 mk_lib_common = { version = "0.0.213", registry = "kellnr" }
 mk_lib_database = { version = "0.0.245", registry = "kellnr" }
-mk_lib_file = { version = "0.0.222", registry = "kellnr" }
 mk_lib_logging = { version = "0.0.214", registry = "kellnr" }
 mk_lib_metadata = { version = "0.0.225", registry = "kellnr" }
 mk_lib_network = { version = "0.0.215", registry = "kellnr" }

--- a/docker/core/mkwebaxum/src/admin/bp_library.rs
+++ b/docker/core/mkwebaxum/src/admin/bp_library.rs
@@ -1,6 +1,6 @@
 use crate::AppState;
 use crate::mk_lib_database;
-use mk_lib_file;
+use mk_lib_share::mk_lib_file_smb::{classify_smbclient_browse_error, is_smb_ls_date};
 use askama::Template;
 use axum::extract::{Form, State};
 use axum::{
@@ -462,8 +462,10 @@ pub async fn admin_library_share_directories(
         } else {
             stderr_output.clone()
         };
-        let (status_code, error_message) =
+        let (status_u16, error_message) =
             classify_smbclient_browse_error(&stdout_output, &stderr_output);
+        let status_code =
+            StatusCode::from_u16(status_u16).unwrap_or(StatusCode::BAD_GATEWAY);
         if let Err(loki_error) =
             mk_lib_logging::mk_lib_logging_loki::mk_logging_loki_push(json!({
                 "level": "error",
@@ -472,7 +474,7 @@ pub async fn admin_library_share_directories(
                 "function": "admin_library_share_directories",
                 "payload": {
                     "status_code": smb_output.status.code(),
-                    "classified_status": status_code.as_u16(),
+                    "classified_status": status_u16,
                     "classified_message": error_message,
                     "stdout": stdout_output,
                     "stderr": stderr_output,

--- a/src/mk_lib_share/Cargo.toml
+++ b/src/mk_lib_share/Cargo.toml
@@ -10,17 +10,11 @@ codegen-units = 1
 
 [dependencies]
 mk_lib_database = { version = "0.0.245", registry = "kellnr" }
-mk_lib_logging = { version = "0.0.214", registry = "kellnr" }
 
 libnfs = { version = "0.1.1" }
-nix = {version = "0.31.2" }
 pavao = { version = "0.2.16" }
-reqwest = { version = "0.13.3", default-features = false, features = ["json", "native-tls"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-tokio = { version = "1.52.3", features = ["full"] }
+tokio = { version = "1.52.3", features = ["fs", "process"] }
 uuid = { version = "1.23.1", features = ["serde", "v4"] }
-walkdir = "2.5.0"
 
 [dev-dependencies]
 tokio-test = "*"

--- a/src/mk_lib_share/src/mk_lib_file_share.rs
+++ b/src/mk_lib_share/src/mk_lib_file_share.rs
@@ -1,7 +1,8 @@
 use mk_lib_database;
 use std::error::Error;
-use std::fs;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
+use tokio::fs;
+use tokio::process::Command;
 
 fn validate_mount_option_value(value: &str, field: &str) -> Result<(), Box<dyn Error>> {
     // `-o key=value,key=value,...` is comma-separated, so a value containing
@@ -26,7 +27,7 @@ pub async fn mk_file_share_mount(
     // Example target: mount -t cifs -o rw,guest,vers=1.0 //host/share /mnt
     let source = format!("//{}/{}", host_ip, host_path.replace('\\', "/"));
     let target = format!("/mediakraken/mnt/{share_guid}");
-    fs::create_dir_all(&target)?;
+    fs::create_dir_all(&target).await?;
 
     let mut options: Vec<String> = Vec::new();
     if share_version_old {
@@ -49,7 +50,11 @@ pub async fn mk_file_share_mount(
     }
     cmd.arg(&source).arg(&target);
 
-    let output = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).output()?;
+    let output = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
     if !output.status.success() {
         return Err(format!(
             "mount {source} -> {target} failed: status={:?} stderr={}",

--- a/src/mk_lib_share/src/mk_lib_file_smb.rs
+++ b/src/mk_lib_share/src/mk_lib_file_smb.rs
@@ -1,5 +1,5 @@
 
-fn classify_smbclient_browse_error(
+pub fn classify_smbclient_browse_error(
     stdout_output: &str,
     stderr_output: &str,
 ) -> (u16, &'static str) {
@@ -49,7 +49,7 @@ fn classify_smbclient_browse_error(
 
 // Matches the 24-byte ASCII output of samba's `time_to_asc()` /
 // `asctime`-style format: "Day Mon DD HH:MM:SS YYYY".
-fn is_smb_ls_date(s: &str) -> bool {
+pub fn is_smb_ls_date(s: &str) -> bool {
     let bytes = s.as_bytes();
     if bytes.len() != 24 {
         return false;

--- a/src/mk_lib_share/src/mk_lib_nfs.rs
+++ b/src/mk_lib_share/src/mk_lib_nfs.rs
@@ -1,6 +1,3 @@
-use libnfs::*;
-use std::error::Error;
-
 // Stub for future NFS share mounting.
 //
 // The previous implementation ignored `share_to_mount` entirely and always

--- a/testing_rust/test_share_read_db/Cargo.toml
+++ b/testing_rust/test_share_read_db/Cargo.toml
@@ -15,8 +15,8 @@ chrono = { version = "0.4.31", features = ["serde"] }
 env_logger = "^0.10"
 mk_lib_common = { path = "../../src/mk_lib_common" }
 mk_lib_database = { path = "../../src/mk_lib_database" }
-mk_lib_file = { path = "../../src/mk_lib_file", features = ["smb"] }
 mk_lib_network = { path = "../../src/mk_lib_network" }
+mk_lib_share = { path = "../../src/mk_lib_share" }
 pavao = "0.2.3"
 reqwest = { version = "0.11.23", default-features = false, features = [
     "json",

--- a/testing_rust/test_share_read_db/src/main.rs
+++ b/testing_rust/test_share_read_db/src/main.rs
@@ -2,7 +2,7 @@ use chrono::prelude::*;
 use chrono::DateTime;
 use mk_lib_common;
 use mk_lib_database;
-use mk_lib_file;
+use mk_lib_share;
 use pavao::{SmbClient, SmbCredentials, SmbDirent, SmbDirentType, SmbOptions, SmbStat};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -32,7 +32,7 @@ async fn main() {
             .await
             .unwrap();
         println!("share: {:?}", share_info);
-        let smb_client = mk_lib_file::mk_lib_smb::mk_file_smb_client_connect(share_info);
+        let smb_client = mk_lib_share::mk_lib_smb::mk_file_smb_client_connect(share_info);
         match smb_client {
             Ok(smb_client) => {
                 // make sure the path still exists
@@ -50,7 +50,7 @@ async fn main() {
                         );
                         if last_modified > row_data.mm_media_dir_last_scanned {
                             // grab initial file/dir list
-                            let files_to_process = mk_lib_file::mk_lib_smb::mk_file_smb_client_tree(
+                            let files_to_process = mk_lib_share::mk_lib_smb::mk_file_smb_client_tree(
                                 &smb_client,
                                 format!("/{}", row_data.mm_media_dir_path).as_str(),
                             )
@@ -73,7 +73,7 @@ async fn main() {
 
 fn mediascan_file_process(
     smb_client: &SmbClient,
-    files_to_process: Vec<mk_lib_file::mk_lib_smb::File_Metadata>,
+    files_to_process: Vec<mk_lib_share::mk_lib_smb::FileMetadata>,
     dir_last_scanned: DateTime<Utc>,
 ) {
     let epoch: DateTime<Utc> = DateTime::<Utc>::from(UNIX_EPOCH);


### PR DESCRIPTION
## Summary
This PR consolidates file share functionality by migrating code from `mk_lib_file` to `mk_lib_share`, and refactors synchronous I/O operations to use async/await patterns with tokio.

## Key Changes

- **Module Migration**: Moved SMB-related functionality from `mk_lib_file::mk_lib_smb` to `mk_lib_share::mk_lib_smb`, consolidating share-related operations into a single library
- **Type Rename**: Renamed `File_Metadata` to `FileMetadata` for consistency with Rust naming conventions
- **Async I/O Refactoring**: 
  - Converted `std::fs` operations to `tokio::fs` in `mk_lib_file_share.rs`
  - Converted `std::process::Command` to `tokio::process::Command` for non-blocking subprocess execution
  - Updated all `.await?` calls for async operations
- **API Visibility**: Made `classify_smbclient_browse_error()` and `is_smb_ls_date()` public in `mk_lib_file_smb.rs` to support external usage
- **Error Handling**: Updated `bp_library.rs` to properly convert the returned `u16` status code to `StatusCode` enum using `from_u16()`
- **Dependency Cleanup**: 
  - Removed unused dependencies from `mk_lib_share` (mk_lib_logging, nix, reqwest, serde, walkdir)
  - Reduced tokio features to only "fs" and "process" as needed
  - Updated all crate references to use `mk_lib_share` instead of `mk_lib_file`

## Notable Implementation Details

- The async refactoring in `mk_file_share_mount()` ensures mount operations don't block the async runtime
- All imports updated across mkmediascanner, mkwebaxum, and test utilities to reference the new module locations
- The NFS stub in `mk_lib_nfs.rs` was cleaned up by removing unused imports

https://claude.ai/code/session_01EpMnacnEL3FiJqzkaYRwf5